### PR TITLE
fix: restore missing lucide-react icon imports

### DIFF
--- a/src/components/screens/WebShowcase.tsx
+++ b/src/components/screens/WebShowcase.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Download, ArrowRight, Sparkles, Shield, Terminal } from "lucide-react";
+import { Download, ArrowRight, Sparkles, Shield, Terminal, Monitor, Layers, Play } from "lucide-react";
 
 export const WebShowcase: React.FC = () => {
   return (


### PR DESCRIPTION
## What does this PR do?

<!-- Describe the changes in this PR -->

## Related issue

Closes #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Testing done

- [ ] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux
- [ ] Added/updated tests
- [ ] All existing tests pass

## Checklist

- [ ] My code follows the project's code style
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if UI change)

<!-- Add screenshots or screen recordings here -->

## Additional notes

<!-- Any additional information that reviewers should know -->
