### PR TITLE
feat: add Homebrew Cask installation and update download docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,15 +29,27 @@ A modern, open-source video editor built with Tauri, React, and TypeScript featu
 - 🎨 **Modern UI** - Clean, intuitive interface with dark mode
 - 🔄 **Cross-Platform** - Works on macOS, Windows, and Linux
 
-## Download
+## Download & Installation
 
-| Platform                      | Download         |
-| ----------------------------- | ---------------- |
-| macOS (Apple Silicon + Intel) | [Coming Soon](#) |
-| Windows 10/11                 | [Coming Soon](#) |
-| Linux (AppImage)              | [Coming Soon](#) |
+### macOS (Apple Silicon & Intel)
+The recommended way to install Clypra on macOS is via **Homebrew Cask** to automatically bypass the Gatekeeper security warnings:
 
-**Current Status:** v0.1.0 in development. [See milestone →](https://github.com/AIEraDev/Clypra/milestone/1)
+```bash
+# Add the custom tap and install the cask
+brew install AIEraDev/tap/clypra
+```
+
+Alternatively, download the direct installer from the [Latest Releases](https://github.com/AIEraDev/Clypra/releases/latest):
+* **macOS Universal DMG**
+  *(If using the DMG, drag Clypra to your `/Applications` folder, then Right-click/Control-click the icon and select **Open** to authorize execution).*
+
+### Windows
+* **Windows x64 MSI Installer**: Download from the [Latest Releases](https://github.com/AIEraDev/Clypra/releases/latest)
+  *(If SmartScreen blocks execution, click **More Info** and select **Run Anyway**).*
+
+### Linux
+* **Linux x64 AppImage**: Download from the [Latest Releases](https://github.com/AIEraDev/Clypra/releases/latest)
+  *(Make the file executable using `chmod +x Clypra*.AppImage`, then run).*
 
 ## Project Structure
 

--- a/src/components/screens/WebShowcase.tsx
+++ b/src/components/screens/WebShowcase.tsx
@@ -94,20 +94,26 @@ export const WebShowcase: React.FC = () => {
                   <span className="text-accent font-bold">✓</span> Supports both Apple Silicon & Intel processors.
                 </li>
                 <li className="flex gap-2">
-                  <span className="text-accent font-bold">✓</span> Direct DMG installer with Application drag-and-drop.
+                  <span className="text-accent font-bold">✓</span> Bypasses Gatekeeper via Homebrew Cask.
                 </li>
               </ul>
 
-              <div className="mt-auto pt-4 border-t border-white/[0.04]">
+              <div className="mt-auto pt-4 border-t border-white/[0.04] flex flex-col gap-2">
                 <a
-                  href="https://github.com/AIEraDev/clypra/releases/latest"
+                  href="https://github.com/AIEraDev/Clypra/releases/latest"
                   target="_blank"
                   rel="noopener noreferrer"
                   className="w-full h-11 rounded-xl bg-white/[0.06] border border-white/[0.08] hover:bg-white/[0.1] text-xs font-semibold text-white flex items-center justify-center gap-2 transition-all hover:scale-[1.01]"
                 >
                   <Download className="w-3.5 h-3.5" />
-                  Download for macOS
+                  Download DMG
                 </a>
+                <div className="p-2 rounded-lg bg-[#121214] border border-white/[0.04] flex flex-col gap-1 text-[10px] text-left">
+                  <span className="font-mono text-neutral-400 font-medium">Or install via Homebrew:</span>
+                  <code className="text-accent font-mono select-all break-all bg-white/5 p-1 rounded">
+                    brew install AIEraDev/tap/clypra
+                  </code>
+                </div>
               </div>
             </div>
 
@@ -191,9 +197,13 @@ export const WebShowcase: React.FC = () => {
           <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
             <div className="flex flex-col gap-2 text-left">
               <span className="text-[10px] font-semibold text-accent font-mono">01 / MACOS USER INSTALLATION</span>
-              <h5 className="font-bold text-white text-sm">Open with Control-Click</h5>
+              <h5 className="font-bold text-white text-sm">Homebrew or Control-Click</h5>
               <p className="text-xs text-text-muted leading-relaxed">
-                If macOS reports that the app is from an unidentified developer, simply drag Clypra to your **Applications** folder. Right-click (or Control-click) the Clypra icon, and select **Open** from the context menu. Click **Open** again in the warning dialog to authorize execution.
+                To bypass the Gatekeeper warning completely, install via our Homebrew Tap:
+                <code className="block my-1.5 p-1.5 bg-[#121214] border border-white/[0.04] rounded text-accent text-[10px] font-mono select-all">
+                  brew install AIEraDev/tap/clypra
+                </code>
+                Alternatively, drag the downloaded DMG to your **Applications** folder, Right-click (Control-click) the Clypra icon, and select **Open** to authorize execution.
               </p>
             </div>
 


### PR DESCRIPTION
## Summary

- **Homebrew Cask Tap**: Added `brew install AIEraDev/tap/clypra` as the recommended macOS installation method, which automatically strips the Gatekeeper quarantine attribute via a `postflight` block.
- **WebShowcase**: Updated the macOS download card with a Homebrew Cask command snippet and updated installation bypass instructions.
- **README.md**: Replaced the placeholder download table with detailed installation instructions for all 3 platforms, featuring Homebrew as the primary macOS method.

## Verification
- `npm run build` ✅ (zero TypeScript errors)
- `npm test` ✅ (538/538 tests passed)
- `brew audit --cask aieradev/tap/clypra` ✅ (zero audit problems)
- Local `brew install --cask aieradev/tap/clypra` ✅ (app installs and launches without Gatekeeper block)