### PR TITLE
docs: update installation instructions across releases and workflows

### DIFF
--- a/.github/RELEASE_NOTES_TEMPLATE.md
+++ b/.github/RELEASE_NOTES_TEMPLATE.md
@@ -51,27 +51,28 @@ This is an **alpha release** - expect rough edges:
 
 ## Installation
 
-### macOS
+### macOS (Apple Silicon & Intel)
 
-Download `Clypra_0.1.0-alpha.1_universal.dmg` and drag to Applications folder.
+The recommended way to install Clypra on macOS is via **Homebrew Cask** to automatically bypass the Gatekeeper security warnings:
+
+```bash
+# Add the custom tap and install the cask
+brew install AIEraDev/tap/clypra
+```
+
+Alternatively, download `Clypra_<version>_universal.dmg`, drag Clypra to your `/Applications` folder, then Right-click (Control-click) the application icon and select **Open** to authorize execution.
 
 ### Windows
 
-Download `Clypra_0.1.0-alpha.1_x64_en-US.msi` and run the installer.
+Download the `.msi` setup file and run it. If Windows SmartScreen blocks execution, click **More Info** and select **Run Anyway**.
 
 ### Linux
 
-Download `clypra_0.1.0-alpha.1_amd64.AppImage` and make it executable:
+Download the `.AppImage` file and make it executable:
 
 ```bash
-chmod +x clypra_0.1.0-alpha.1_amd64.AppImage
-./clypra_0.1.0-alpha.1_amd64.AppImage
-```
-
-Or install the `.deb` package:
-
-```bash
-sudo dpkg -i clypra_0.1.0-alpha.1_amd64.deb
+chmod +x Clypra*.AppImage
+./Clypra*.AppImage
 ```
 
 ### Build from Source

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,18 +60,21 @@ jobs:
 
             ## Installation
 
-            ### macOS
-            1. Download the `.dmg` file
-            2. Open it and drag Clypra to Applications
-            3. First time: Right-click → Open (to bypass Gatekeeper)
+            ### macOS (Apple Silicon & Intel)
+            The recommended way to install Clypra on macOS is via **Homebrew Cask** to automatically bypass the Gatekeeper security warnings:
+            ```bash
+            # Tap the repository and install the cask
+            brew install AIEraDev/tap/clypra
+            ```
+            Alternatively, download the `.dmg` file below, drag Clypra to your `/Applications` folder, then Right-click (Control-click) the application icon and select **Open** to authorize execution.
 
             ### Windows
-            1. Download the `.msi` file
+            1. Download the `.msi` file below
             2. Run the installer
-            3. If SmartScreen appears, click "More info" → "Run anyway"
+            3. If Windows SmartScreen blocks execution, click **More Info** and select **Run Anyway**
 
             ### Linux
-            1. Download the `.AppImage` file
+            1. Download the `.AppImage` file below
             2. Make it executable: `chmod +x Clypra*.AppImage`
             3. Run it: `./Clypra*.AppImage`
           draft: true


### PR DESCRIPTION
## Summary
Updates the automated release notes templates and release workflows to feature Homebrew Cask installation instructions for macOS, and provide clean/consistent instructions for Windows SmartScreen and Linux AppImage.