### PR TITLE
docs: add Clypra showcase image banner to README header

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 <div align="center">
 
+![Clypra Showcase Banner](public/clypra.jpg)
+
 ![Clypra Logo](https://img.shields.io/badge/Clypra-Video%20Editor-blue?style=for-the-badge)
 
 A modern, open-source video editor built with Tauri, React, and TypeScript featuring a professional timeline interface.


### PR DESCRIPTION
Adds the `public/clypra.jpg` showcase screenshot banner to the top of the README file.