### PR TITLE
feat: architecture refactor — platform capability, rendering consistency, evaluateScene rename

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
-        "@clypra/engine": "file:../clypra-studio/packages/clypra-engine",
+        "@clypra/engine": "1.1.0",
         "@fontsource-variable/dancing-script": "^5.2.8",
         "@fontsource-variable/geist": "^5.2.9",
         "@fontsource-variable/inter": "^5.2.8",
@@ -68,26 +68,6 @@
         "typescript": "~5.8.3",
         "vite": "^7.0.4",
         "vitest": "^4.1.4"
-      }
-    },
-    "../clypra-studio/packages/clypra-engine": {
-      "name": "@clypra/engine",
-      "version": "1.0.2",
-      "dependencies": {
-        "jszip": "^3.10.1",
-        "lottie-web": "^5.13.0"
-      },
-      "devDependencies": {
-        "@napi-rs/canvas": "^0.1.70",
-        "@semantic-release/changelog": "^6.0.3",
-        "@semantic-release/commit-analyzer": "^11.1.0",
-        "@semantic-release/git": "^10.0.1",
-        "@semantic-release/github": "^9.2.6",
-        "@semantic-release/npm": "^11.0.2",
-        "@semantic-release/release-notes-generator": "^12.1.0",
-        "semantic-release": "^23.0.0",
-        "tsup": "^8.0.0",
-        "typescript": "~5.8.2"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -608,8 +588,13 @@
       }
     },
     "node_modules/@clypra/engine": {
-      "resolved": "../clypra-studio/packages/clypra-engine",
-      "link": true
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@clypra/engine/-/engine-1.1.0.tgz",
+      "integrity": "sha512-yWD5E7ytFLfVl7u/2nG4P7INb9bkOp6KLgz3jp2L287xUuaJOL/JDQQOSlcoNPieJZRmuOdMQlN114QlnG+YUg==",
+      "dependencies": {
+        "jszip": "^3.10.1",
+        "lottie-web": "^5.13.0"
+      }
     },
     "node_modules/@csstools/color-helpers": {
       "version": "6.0.2",
@@ -5308,6 +5293,12 @@
         "node": ">=6.6.0"
       }
     },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "license": "MIT"
+    },
     "node_modules/cors": {
       "version": "2.8.6",
       "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
@@ -6582,6 +6573,12 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "license": "MIT"
+    },
     "node_modules/import-fresh": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -6834,6 +6831,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "license": "MIT"
+    },
     "node_modules/isexe": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.5.tgz",
@@ -6985,6 +6988,48 @@
         "graceful-fs": "^4.1.6"
       }
     },
+    "node_modules/jszip": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+      "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+      "license": "(MIT OR GPL-3.0-or-later)",
+      "dependencies": {
+        "lie": "~3.3.0",
+        "pako": "~1.0.2",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "^1.0.5"
+      }
+    },
+    "node_modules/jszip/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/jszip/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
+    "node_modules/jszip/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
     "node_modules/kleur": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
@@ -6992,6 +7037,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "immediate": "~3.0.5"
       }
     },
     "node_modules/lightningcss": {
@@ -7852,6 +7906,12 @@
       "integrity": "sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==",
       "license": "MIT"
     },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "license": "(MIT AND Zlib)"
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -8081,6 +8141,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "license": "MIT"
     },
     "node_modules/prompts": {
       "version": "2.4.2",
@@ -8773,6 +8839,12 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-3.1.0.tgz",
       "integrity": "sha512-kjnC1DXBHcxaOaOXBHBeRtltsDG2nUiUni+jP92M9gYdW12rsmx92UsfpH7o5tDRs7I1ZZPSQJQGv3UaRfCiuw==",
+      "license": "MIT"
+    },
+    "node_modules/setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
       "license": "MIT"
     },
     "node_modules/setprototypeof": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
-        "@clypra/engine": "1.0.0",
+        "@clypra/engine": "file:../clypra-studio/packages/clypra-engine",
         "@fontsource-variable/dancing-script": "^5.2.8",
         "@fontsource-variable/geist": "^5.2.9",
         "@fontsource-variable/inter": "^5.2.8",
@@ -68,6 +68,26 @@
         "typescript": "~5.8.3",
         "vite": "^7.0.4",
         "vitest": "^4.1.4"
+      }
+    },
+    "../clypra-studio/packages/clypra-engine": {
+      "name": "@clypra/engine",
+      "version": "1.0.2",
+      "dependencies": {
+        "jszip": "^3.10.1",
+        "lottie-web": "^5.13.0"
+      },
+      "devDependencies": {
+        "@napi-rs/canvas": "^0.1.70",
+        "@semantic-release/changelog": "^6.0.3",
+        "@semantic-release/commit-analyzer": "^11.1.0",
+        "@semantic-release/git": "^10.0.1",
+        "@semantic-release/github": "^9.2.6",
+        "@semantic-release/npm": "^11.0.2",
+        "@semantic-release/release-notes-generator": "^12.1.0",
+        "semantic-release": "^23.0.0",
+        "tsup": "^8.0.0",
+        "typescript": "~5.8.2"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -588,13 +608,8 @@
       }
     },
     "node_modules/@clypra/engine": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@clypra/engine/-/engine-1.0.0.tgz",
-      "integrity": "sha512-yjASgAm7fXEig/pk18KUO577WXCekbTHLHm/hFUfihdBbS3/hGeR7HfTN7ceGNphsvEFMJvGNXTTy4E+dlr8UA==",
-      "dependencies": {
-        "jszip": "^3.10.1",
-        "lottie-web": "^5.13.0"
-      }
+      "resolved": "../clypra-studio/packages/clypra-engine",
+      "link": true
     },
     "node_modules/@csstools/color-helpers": {
       "version": "6.0.2",
@@ -5293,12 +5308,6 @@
         "node": ">=6.6.0"
       }
     },
-    "node_modules/core-util-is": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
-      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
-      "license": "MIT"
-    },
     "node_modules/cors": {
       "version": "2.8.6",
       "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
@@ -6573,12 +6582,6 @@
         "node": ">= 4"
       }
     },
-    "node_modules/immediate": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
-      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
-      "license": "MIT"
-    },
     "node_modules/import-fresh": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -6831,12 +6834,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/isarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
-      "license": "MIT"
-    },
     "node_modules/isexe": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.5.tgz",
@@ -6988,48 +6985,6 @@
         "graceful-fs": "^4.1.6"
       }
     },
-    "node_modules/jszip": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
-      "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
-      "license": "(MIT OR GPL-3.0-or-later)",
-      "dependencies": {
-        "lie": "~3.3.0",
-        "pako": "~1.0.2",
-        "readable-stream": "~2.3.6",
-        "setimmediate": "^1.0.5"
-      }
-    },
-    "node_modules/jszip/node_modules/readable-stream": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
-      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
-      "license": "MIT",
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      }
-    },
-    "node_modules/jszip/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "license": "MIT"
-    },
-    "node_modules/jszip/node_modules/string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "~5.1.0"
-      }
-    },
     "node_modules/kleur": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
@@ -7037,15 +6992,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/lie": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
-      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
-      "license": "MIT",
-      "dependencies": {
-        "immediate": "~3.0.5"
       }
     },
     "node_modules/lightningcss": {
@@ -7906,12 +7852,6 @@
       "integrity": "sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==",
       "license": "MIT"
     },
-    "node_modules/pako": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
-      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
-      "license": "(MIT AND Zlib)"
-    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -8141,12 +8081,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/process-nextick-args": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-      "license": "MIT"
     },
     "node_modules/prompts": {
       "version": "2.4.2",
@@ -8839,12 +8773,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-3.1.0.tgz",
       "integrity": "sha512-kjnC1DXBHcxaOaOXBHBeRtltsDG2nUiUni+jP92M9gYdW12rsmx92UsfpH7o5tDRs7I1ZZPSQJQGv3UaRfCiuw==",
-      "license": "MIT"
-    },
-    "node_modules/setimmediate": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
       "license": "MIT"
     },
     "node_modules/setprototypeof": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "test:ui": "vitest --ui"
   },
   "dependencies": {
-    "@clypra/engine": "1.0.2",
+    "@clypra/engine": "1.1.0",
     "@fontsource-variable/dancing-script": "^5.2.8",
     "@fontsource-variable/geist": "^5.2.9",
     "@fontsource-variable/inter": "^5.2.8",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "test:ui": "vitest --ui"
   },
   "dependencies": {
-    "@clypra/engine": "1.0.0",
+    "@clypra/engine": "1.0.2",
     "@fontsource-variable/dancing-script": "^5.2.8",
     "@fontsource-variable/geist": "^5.2.9",
     "@fontsource-variable/inter": "^5.2.8",

--- a/src/components/editor/preview/ProgramPreview.tsx
+++ b/src/components/editor/preview/ProgramPreview.tsx
@@ -5,7 +5,7 @@ import { useProjectStore } from "@/store/projectStore";
 import { useTimelineStore } from "@/store/timelineStore";
 import { useUIStore } from "@/store/uiStore";
 import { useSettingsStore } from "@/store/settingsStore";
-import { evaluateSceneCached } from "@/core/evaluation/evaluator";
+import { evaluateTimelineSceneCached } from "@/core/evaluation/evaluator";
 import { getFrameScheduler } from "@/core/scheduler/FrameScheduler";
 import { getActiveSessionOrNull, subscribeToSessionChanges } from "@/core/runtime/ProjectSession";
 import { PreviewTransport } from "./PreviewTransport";
@@ -157,7 +157,7 @@ export const ProgramPreview: React.FC = () => {
   renderStateRef.current.canvasHeight = canvasHeight;
 
   const scene = useMemo(() => {
-    return evaluateSceneCached(clockState.time, clips, tracks, mediaAssets, project ?? null, epoch);
+    return evaluateTimelineSceneCached(clockState.time, clips, tracks, mediaAssets, project ?? null, epoch);
   }, [tracks, clips, mediaAssets, clockState.time, project, epoch]);
 
   // =========================================================================
@@ -495,46 +495,18 @@ export const ProgramPreview: React.FC = () => {
       <div className="flex items-center px-4 h-10 shrink-0 gap-2">
         <span className="text-[13px] font-semibold text-text-primary tracking-tight">Program Preview</span>
         <span className="text-[13px] text-text-muted">— Timeline</span>
-        <button
-          onClick={() => setShowSafeOverlay((s) => !s)}
-          className={cn(
-            "ml-auto px-2 h-6 rounded text-[10px] font-medium transition-colors cursor-pointer",
-            showSafeOverlay ? "bg-accent/20 text-accent" : "text-text-muted hover:text-text-primary hover:bg-white/6"
-          )}
-          title="Toggle Title/Action Safe Zones"
-          aria-label="Toggle Title/Action Safe Zones"
-        >
+        <button onClick={() => setShowSafeOverlay((s) => !s)} className={cn("ml-auto px-2 h-6 rounded text-[10px] font-medium transition-colors cursor-pointer", showSafeOverlay ? "bg-accent/20 text-accent" : "text-text-muted hover:text-text-primary hover:bg-white/6")} title="Toggle Title/Action Safe Zones" aria-label="Toggle Title/Action Safe Zones">
           Safe Zones
         </button>
-        <button
-          onClick={() => setShowTelemetry((s) => !s)}
-          className={cn(
-            "px-2 h-6 rounded text-[10px] font-medium transition-colors cursor-pointer",
-            showTelemetry ? "bg-accent/20 text-accent" : "text-text-muted hover:text-text-primary hover:bg-white/6"
-          )}
-          title="Toggle render telemetry"
-          aria-label="Toggle render telemetry"
-        >
+        <button onClick={() => setShowTelemetry((s) => !s)} className={cn("px-2 h-6 rounded text-[10px] font-medium transition-colors cursor-pointer", showTelemetry ? "bg-accent/20 text-accent" : "text-text-muted hover:text-text-primary hover:bg-white/6")} title="Toggle render telemetry" aria-label="Toggle render telemetry">
           Stats
         </button>
       </div>
 
       {/* ── Video Area ─────────────────────────────────────────────── */}
       <div className="flex-1 flex items-center justify-center overflow-hidden bg-[#06080a] relative">
-        <div
-          ref={containerRef}
-          onPointerDownCapture={handlePreviewPointerDownCapture}
-          className={cn(
-            "w-full h-full flex items-center justify-center relative z-10 overflow-hidden",
-            isPanning && "cursor-grabbing",
-            spacePressed && !isPanning && "cursor-grab"
-          )}
-        >
-          <div
-            data-testid="program-preview-viewport"
-            className="relative flex shrink-0 items-center justify-center overflow-hidden shadow-[0_0_40px_rgba(0,0,0,0.36)]"
-            style={{ width: displayWidth, height: displayHeight }}
-          >
+        <div ref={containerRef} onPointerDownCapture={handlePreviewPointerDownCapture} className={cn("w-full h-full flex items-center justify-center relative z-10 overflow-hidden", isPanning && "cursor-grabbing", spacePressed && !isPanning && "cursor-grab")}>
+          <div data-testid="program-preview-viewport" className="relative flex shrink-0 items-center justify-center overflow-hidden shadow-[0_0_40px_rgba(0,0,0,0.36)]" style={{ width: displayWidth, height: displayHeight }}>
             <>
               {/* Canvas-based preview (matches export rendering) */}
               <canvas
@@ -549,34 +521,17 @@ export const ProgramPreview: React.FC = () => {
               />
 
               {/* Transform overlay for selected clips */}
-              <TransformOverlay
-                canvasWidth={canvasWidth}
-                canvasHeight={canvasHeight}
-                scale={scale}
-                viewport={previewViewport}
-                displayOffset={{ x: offsetX, y: offsetY }}
-                displayWidth={displayWidth}
-                displayHeight={displayHeight}
-                currentTime={currentTime}
-              />
+              <TransformOverlay canvasWidth={canvasWidth} canvasHeight={canvasHeight} scale={scale} viewport={previewViewport} displayOffset={{ x: offsetX, y: offsetY }} displayWidth={displayWidth} displayHeight={displayHeight} currentTime={currentTime} />
 
               {/* Title & Action Safe Areas Overlay */}
-              <SafeOverlay
-                visible={showSafeOverlay}
-                displayWidth={displayWidth}
-                displayHeight={displayHeight}
-                displayOffset={{ x: offsetX, y: offsetY }}
-              />
+              <SafeOverlay visible={showSafeOverlay} displayWidth={displayWidth} displayHeight={displayHeight} displayOffset={{ x: offsetX, y: offsetY }} />
             </>
           </div>
         </div>
 
         {/* Professional empty state */}
         {clips.length === 0 && (
-          <div
-            className="absolute inset-0 flex items-center justify-center z-20 pointer-events-none mx-auto"
-            style={{ width: displayWidth, height: displayHeight }}
-          >
+          <div className="absolute inset-0 flex items-center justify-center z-20 pointer-events-none mx-auto" style={{ width: displayWidth, height: displayHeight }}>
             <div className="text-center space-y-3">
               <div className="text-sm font-medium text-text-muted">No clips in sequence</div>
               <div className="text-xs text-text-muted/80 space-y-1 font-mono">
@@ -621,24 +576,14 @@ export const ProgramPreview: React.FC = () => {
           <div className="flex items-center gap-1">
             {/* Speed selection */}
             <div className="relative" ref={speedMenuRef}>
-              <PlaybackSpeedSelector
-                playbackSpeed={playbackSpeed}
-                speedMenuOpen={speedMenuOpen}
-                setSpeedMenuOpen={setSpeedMenuOpen}
-                setSpeed={setSpeed}
-              />
+              <PlaybackSpeedSelector playbackSpeed={playbackSpeed} speedMenuOpen={speedMenuOpen} setSpeedMenuOpen={setSpeedMenuOpen} setSpeed={setSpeed} />
             </div>
 
             <div className="w-px h-3 bg-white/10 mx-0.5" />
 
             {/* Playback Quality selection */}
             <div className="relative" ref={qualityMenuRef}>
-              <PlaybackQualitySelector
-                previewQuality={previewQuality}
-                qualityMenuOpen={qualityMenuOpen}
-                setQualityMenuOpen={setQualityMenuOpen}
-                setPreviewQuality={setPreviewQuality}
-              />
+              <PlaybackQualitySelector previewQuality={previewQuality} qualityMenuOpen={qualityMenuOpen} setQualityMenuOpen={setQualityMenuOpen} setPreviewQuality={setPreviewQuality} />
             </div>
           </div>
         }
@@ -646,37 +591,16 @@ export const ProgramPreview: React.FC = () => {
           <>
             {/* Aspect menu */}
             <div className="relative shrink-0" ref={aspectMenuRef}>
-              <AspectSelector
-                aspectMenuOpen={aspectMenuOpen}
-                setAspectMenuOpen={setAspectMenuOpen}
-                previewAspectPreset={previewAspectPreset}
-                selectAspectPreset={selectAspectPreset}
-                canvasWidth={canvasWidth}
-                canvasHeight={canvasHeight}
-              />
+              <AspectSelector aspectMenuOpen={aspectMenuOpen} setAspectMenuOpen={setAspectMenuOpen} previewAspectPreset={previewAspectPreset} selectAspectPreset={selectAspectPreset} canvasWidth={canvasWidth} canvasHeight={canvasHeight} />
             </div>
 
-            <button
-              onClick={() => setPreviewScaleMode((m) => (m === "fit" ? "fill" : "fit"))}
-              className="w-6 h-6 flex items-center justify-center rounded text-text-muted hover:text-text-primary hover:bg-white/6 transition-colors cursor-pointer"
-              title={
-                previewScaleMode === "fit"
-                  ? "Fill preview — scale to cover (crop edges)"
-                  : "Fit preview — show entire frame (letterbox)"
-              }
-              aria-label={previewScaleMode === "fit" ? "Fill preview" : "Fit preview"}
-            >
+            <button onClick={() => setPreviewScaleMode((m) => (m === "fit" ? "fill" : "fit"))} className="w-6 h-6 flex items-center justify-center rounded text-text-muted hover:text-text-primary hover:bg-white/6 transition-colors cursor-pointer" title={previewScaleMode === "fit" ? "Fill preview — scale to cover (crop edges)" : "Fit preview — show entire frame (letterbox)"} aria-label={previewScaleMode === "fit" ? "Fill preview" : "Fit preview"}>
               {previewScaleMode === "fit" ? <Expand className="w-3.5 h-3.5" /> : <Shrink className="w-3.5 h-3.5" />}
             </button>
 
             <div className="w-px h-4 bg-white/10 mx-1" />
 
-            <VolumeControl
-              isMuted={isMuted}
-              setIsMuted={setIsMuted}
-              volume={volume}
-              setVolume={setVolume}
-            />
+            <VolumeControl isMuted={isMuted} setIsMuted={setIsMuted} volume={volume} setVolume={setVolume} />
           </>
         }
       />

--- a/src/components/editor/preview/TextSourcePreview.tsx
+++ b/src/components/editor/preview/TextSourcePreview.tsx
@@ -1,40 +1,148 @@
-import { useState, useCallback, useEffect } from "react";
+import React, { useRef, useEffect, useCallback } from "react";
 import { LottiePlayer } from "@/features/text-templates/LottiePlayer";
-import { renderTextEffectAsync } from "@/features/text-effects/renderer";
+import { renderTextEffectToContext } from "@/features/text-effects/renderer";
+import { getFontLoader } from "@/core/fonts/FontLoader";
+import type { EffectFullDefinition } from "@/features/text-effects/types/types";
 
-export const TextSourcePreview: React.FC<{ preset: any }> = ({ preset }) => {
-  const [canvas, setCanvas] = useState<HTMLCanvasElement | null>(null);
-  const canvasRef = useCallback((node: HTMLCanvasElement | null) => {
-    setCanvas(node);
-  }, []);
+// Effects are designed for this banner canvas size (800×200).
+// Using the engine's canonical defaults keeps preview ↔ export consistent.
+const PREVIEW_CANVAS_W = 800;
+const PREVIEW_CANVAS_H = 200;
 
-  const previewText = preset?.text || "CLYPRA";
-  const isTemplate = preset?.presetType === "template" || !!preset?.lottieData;
+interface TextSourcePreviewProps {
+  preset: (EffectFullDefinition & { presetType?: "effect" | "template" }) | null;
+}
 
-  // The preset IS the full effect definition (fetched from API). Use it directly —
-  // allTextEffects is empty since definitions are no longer bundled locally.
+/**
+ * Source-mode preview for text effects and Lottie templates.
+ *
+ * Effect rendering:
+ *  - Uses renderTextEffectToContext (full @clypra/engine pipeline)
+ *  - Drives a rAF animation loop for animated effects
+ *  - Cancels the loop cleanly on unmount or preset change
+ *  - Pre-loads the effect's font before the first draw
+ *  - Canvas is sized to the effect's native dimensions (800×200 default)
+ *
+ * Template rendering:
+ *  - Delegates to LottiePlayer
+ */
+export const TextSourcePreview: React.FC<TextSourcePreviewProps> = ({ preset }) => {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const rafRef = useRef<number>(0);
+  const mountedRef = useRef(true);
+
+  // Keep a ref to the latest preset so the rAF closure always sees it
+  // without needing to be recreated on every render.
+  const presetRef = useRef(preset);
+  presetRef.current = preset;
+
+  const isTemplate = preset?.presetType === "template" || !!(preset as any)?.lottieData;
   const effectDefinition = !isTemplate && preset?.font ? preset : null;
 
+  // Stable canvas ref callback
+  const setCanvasRef = useCallback((node: HTMLCanvasElement | null) => {
+    // React 19 refs are mutable by default — assign directly
+    (canvasRef as { current: HTMLCanvasElement | null }).current = node;
+    if (node) {
+      node.width = PREVIEW_CANVAS_W;
+      node.height = PREVIEW_CANVAS_H;
+    }
+  }, []);
+
   useEffect(() => {
-    if (!canvas || !effectDefinition || isTemplate) return;
-    // renderTextEffectAsync: sets canvas size, injects + awaits the font,
-    // then calls evaluateScene (full engine pipeline incl. ctx.filter for blur).
-    renderTextEffectAsync(canvas, previewText, effectDefinition, 44);
-  }, [canvas, previewText, effectDefinition, isTemplate]);
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas || !effectDefinition) return;
+
+    // Cancel any previous animation loop
+    cancelAnimationFrame(rafRef.current);
+
+    let aborted = false;
+
+    const effectDef = effectDefinition;
+    const previewText = (preset as any)?.text || (preset as any)?.defaultText || preset?.name || "CLYPRA";
+    const fontSize = 80; // matches DEFAULT_FONT_SIZE — fills 800×200 correctly
+
+    const durationSec = (effectDef.durationMs ?? 2000) / 1000;
+    const hasAnimation = !!effectDef.animation && effectDef.animation.type !== "none";
+
+    async function start() {
+      // 1. Pre-load the effect's font so the first frame is correct
+      if (effectDef.font?.family) {
+        try {
+          await getFontLoader().ensureFont({
+            family: effectDef.font.family,
+            weight: effectDef.font.weight,
+            style: effectDef.font.style,
+          });
+        } catch {
+          // Font failed — proceed with fallback; still render rather than blank
+        }
+      }
+
+      if (typeof document !== "undefined" && document.fonts) {
+        await document.fonts.ready;
+      }
+
+      if (aborted || !mountedRef.current) return;
+
+      const ctx = canvas!.getContext("2d");
+      if (!ctx) return;
+
+      if (hasAnimation) {
+        // ── Animated: rAF loop ──────────────────────────────────────
+        const startTime = performance.now();
+
+        const loop = (now: number) => {
+          if (aborted || !mountedRef.current) return;
+
+          const elapsed = (now - startTime) / 1000;
+          const loopTime = durationSec > 0 ? elapsed % durationSec : elapsed;
+
+          ctx.clearRect(0, 0, PREVIEW_CANVAS_W, PREVIEW_CANVAS_H);
+          renderTextEffectToContext(ctx, previewText, effectDef, fontSize, PREVIEW_CANVAS_W / 2, PREVIEW_CANVAS_H / 2, PREVIEW_CANVAS_W, PREVIEW_CANVAS_H, loopTime, 0, durationSec);
+
+          rafRef.current = requestAnimationFrame(loop);
+        };
+
+        rafRef.current = requestAnimationFrame(loop);
+      } else {
+        // ── Static: single draw ─────────────────────────────────────
+        ctx.clearRect(0, 0, PREVIEW_CANVAS_W, PREVIEW_CANVAS_H);
+        renderTextEffectToContext(ctx, previewText, effectDef, fontSize, PREVIEW_CANVAS_W / 2, PREVIEW_CANVAS_H / 2, PREVIEW_CANVAS_W, PREVIEW_CANVAS_H);
+      }
+    }
+
+    start();
+
+    return () => {
+      aborted = true;
+      cancelAnimationFrame(rafRef.current);
+    };
+  }, [effectDefinition, (preset as any)?.text, preset?.name]);
 
   if (!preset) return null;
 
+  // ── Lottie template ──────────────────────────────────────────────────────
   if (isTemplate) {
     return (
       <div className="w-full aspect-video bg-black flex items-center justify-center relative p-8 shadow-[0_0_40px_rgba(0,0,0,0.8)] border border-white/5 overflow-hidden">
-        <LottiePlayer lottieData={preset.injectedData || preset.lottieData} autoplay={true} loop={true} className="w-full h-full object-contain" />
+        <LottiePlayer lottieData={(preset as any).injectedData || (preset as any).lottieData} autoplay={true} loop={true} className="w-full h-full object-contain" />
       </div>
     );
   }
 
+  // ── Canvas effect ────────────────────────────────────────────────────────
+  // Aspect ratio matches the canvas: 800×200 = 4:1
   return (
-    <div className="w-full aspect-video flex items-center justify-center relative border-white/5 overflow-hidden">
-      <canvas ref={canvasRef} className="max-w-full max-h-full block select-none pointer-events-none" />
+    <div className="w-full flex items-center justify-center relative overflow-hidden checkerboard" style={{ aspectRatio: `${PREVIEW_CANVAS_W} / ${PREVIEW_CANVAS_H}` }}>
+      <canvas ref={setCanvasRef} width={PREVIEW_CANVAS_W} height={PREVIEW_CANVAS_H} className="w-full h-full block select-none pointer-events-none" />
     </div>
   );
 };

--- a/src/core/evaluation/__tests__/textEvaluation.test.ts
+++ b/src/core/evaluation/__tests__/textEvaluation.test.ts
@@ -5,7 +5,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { evaluateScene } from "../evaluator";
+import { evaluateTimelineScene as evaluateScene } from "../evaluator";
 import type { TextClip, Track, MediaAsset, Project } from "@/types";
 
 // Mock Tauri API

--- a/src/core/evaluation/evaluator.ts
+++ b/src/core/evaluation/evaluator.ts
@@ -1,14 +1,20 @@
 /**
- * Canonical Scene Evaluator
+ * Canonical Timeline Scene Evaluator
  *
- * This is the SINGLE SOURCE OF TRUTH for timeline evaluation.
+ * This is the SINGLE SOURCE OF TRUTH for NLE timeline evaluation.
  * All rendering paths use this:
  * - Preview
  * - Export
  * - Thumbnails
  * - Proxies
  *
- * Follows the Evaluation Contract (see contract.md)
+ * NOTE: The function is named evaluateTimelineScene (not evaluateScene) to
+ * avoid collision with @clypra/engine's evaluateScene, which takes a
+ * SceneDocument and draws directly to a Canvas 2D context. These two
+ * functions operate at different layers:
+ *
+ *   evaluateTimelineScene  → reads Clips/Tracks/Assets → produces EvaluatedScene
+ *   engine.evaluateScene   → reads SceneDocument       → draws pixels
  */
 
 import type { Clip, Track, MediaAsset, Project, TextClip } from "@/types";
@@ -19,60 +25,44 @@ import { convertFileSrc } from "@tauri-apps/api/core";
 import { getEvaluationCache, computeClipVersion } from "./cache";
 import { evaluateProperty } from "./animation";
 
-
 /**
- * Evaluate the timeline at a specific time.
- * Returns a complete EvaluatedScene ready for rendering.
+ * Evaluate the NLE timeline at a specific time.
+ * Returns a complete EvaluatedScene ready for rasterization.
  *
- * This is the canonical evaluation function.
- * All other evaluation paths should use this.
- *
- * @param time - Timeline time in seconds
- * @param clips - All clips in timeline
- * @param tracks - All tracks
- * @param assets - All media assets
+ * @param time    - Timeline time in seconds
+ * @param clips   - All clips in timeline
+ * @param tracks  - All tracks
+ * @param assets  - All media assets
  * @param project - Project settings
- * @returns Complete evaluated scene
  */
-export function evaluateScene(time: number, clips: Clip[], tracks: Track[], assets: MediaAsset[], project: Project | null): EvaluatedScene {
+export function evaluateTimelineScene(time: number, clips: Clip[], tracks: Track[], assets: MediaAsset[], project: Project | null): EvaluatedScene {
   // Convert to compositor clips (adds roles, priorities)
   const compositorClips = toCompositorClips(clips, tracks);
 
   // Build lookup maps for performance
   const trackMap = new Map(tracks.map((track) => [track.id, track]));
   const assetMap = new Map(assets.map((asset) => [asset.id, asset]));
-  const trackIndexMap = new Map(tracks.map((track, index) => [track.id, index]));
 
   // ─── 1. Active Clip Resolution (Contract §1) ─────────────────────────────
 
   const activeClips = compositorClips.filter((clip) => {
-    // Time bounds check
     const clipEnd = getClipEndTime(clip);
     const isInTimeBounds = clip.startTime <= time && time < clipEnd;
-
-    // Track visibility check
     const track = trackMap.get(clip.trackId);
     const isVisible = track?.visible ?? true;
-
     return isInTimeBounds && isVisible;
   });
 
   // ─── 2. Compositing Order (Contract §2) ───────────────────────────────────
 
   const sortedClips = activeClips.sort((a, b) => {
-    // 1. Role type
     const roleOrder = getRoleOrder(a.role) - getRoleOrder(b.role);
     if (roleOrder !== 0) return roleOrder;
-
-    // 2. Track index (INVERTED: higher index renders below, so top track renders on top)
+    // Higher track index renders below lower index (top track in UI = on top)
     const trackOrder = b.trackIndex - a.trackIndex;
     if (trackOrder !== 0) return trackOrder;
-
-    // 3. Z-index
     const zOrder = a.zIndex - b.zIndex;
     if (zOrder !== 0) return zOrder;
-
-    // 4. Evaluation priority
     return a.evaluationPriority - b.evaluationPriority;
   });
 
@@ -92,20 +82,16 @@ export function evaluateScene(time: number, clips: Clip[], tracks: Track[], asse
     const evalRot = kf.rotation !== undefined ? evaluateProperty(kf.rotation, offset, clip.duration) : clip.rotation;
     const evalOpacity = kf.opacity !== undefined ? evaluateProperty(kf.opacity, offset, clip.duration) : clip.opacity;
 
-    // Check if this is a text clip
     const isTextClip = "text" in clip;
 
     if (isTextClip) {
-      // Evaluate text layer
       const textClip = clip as unknown as TextClip;
-
-      // Evaluate transition state
       const transitionState = evaluateTransitionState(clip, time, sortedClips);
 
-      const evalFontSize = kf.fontSize !== undefined ? evaluateProperty(kf.fontSize, offset, clip.duration) : (textClip.fontSize || 48);
-      const evalColor = kf.color !== undefined ? evaluateProperty(kf.color, offset, clip.duration) : (textClip.color || "#ffffff");
-      const evalLetterSpacing = kf.letterSpacing !== undefined ? evaluateProperty(kf.letterSpacing, offset, clip.duration) : (textClip.letterSpacing || 0);
-      const evalLineHeight = kf.lineHeight !== undefined ? evaluateProperty(kf.lineHeight, offset, clip.duration) : (textClip.lineHeight || 1.2);
+      const evalFontSize = kf.fontSize !== undefined ? evaluateProperty(kf.fontSize, offset, clip.duration) : textClip.fontSize || 48;
+      const evalColor = kf.color !== undefined ? evaluateProperty(kf.color, offset, clip.duration) : textClip.color || "#ffffff";
+      const evalLetterSpacing = kf.letterSpacing !== undefined ? evaluateProperty(kf.letterSpacing, offset, clip.duration) : textClip.letterSpacing || 0;
+      const evalLineHeight = kf.lineHeight !== undefined ? evaluateProperty(kf.lineHeight, offset, clip.duration) : textClip.lineHeight || 1.2;
 
       const textLayer: EvaluatedTextLayer = {
         layerId: `${clip.id}-${time}`,
@@ -116,23 +102,16 @@ export function evaluateScene(time: number, clips: Clip[], tracks: Track[], asse
         time,
         clipStartTime: clip.startTime,
         clipDuration: clip.duration,
-
-        // Transform
         x: evalX,
         y: evalY,
         width: evalW,
         height: evalH,
         rotation: evalRot,
-
         opacity: evalOpacity * (transitionState.opacity ?? 1.0),
-
-        // Transition
         inTransition: transitionState.inTransition,
         transitionType: transitionState.type,
         transitionProgress: transitionState.progress,
         blendMode: (clip as any).blendMode || "normal",
-
-        // Text content
         text: textClip.text || "Text",
         fontFamily: normalizeFontFamily(textClip.fontFamily || "Inter Variable"),
         fontSize: evalFontSize,
@@ -153,48 +132,33 @@ export function evaluateScene(time: number, clips: Clip[], tracks: Track[], asse
       continue;
     }
 
-    // Handle media layers (video/image)
+    // ── Media layers ──────────────────────────────────────────────────────────
     const asset = assetMap.get(clip.mediaId);
+    if (!asset || (asset.type !== "video" && asset.type !== "image")) continue;
 
-    // Skip non-visual clips
-    if (!asset || (asset.type !== "video" && asset.type !== "image")) {
-      continue;
-    }
-
-    // Calculate source time (accounting for trim)
     const sourceTime = clip.trimIn + (time - clip.startTime);
-
-    // Convert file path to Tauri URL
     const sourcePath = asset.path ? convertFileSrc(asset.path) : asset.posterFrame || "";
     if (!sourcePath) continue;
 
-    // Evaluate transition state (Contract §3 - basic implementation)
     const transitionState = evaluateTransitionState(clip, time, sortedClips);
 
-    // Create evaluated media layer
     const mediaLayer: EvaluatedMediaLayer = {
       layerId: `${clip.id}-${time}`,
       clipId: clip.id,
       role: clip.role,
-      zIndex: i, // Actual render order
+      zIndex: i,
       layerType: "media",
-
-      // Source media
       mediaId: clip.mediaId,
       mediaType: asset.type === "video" ? "video" : "image",
       sourcePath,
       posterFrame: asset.posterFrame,
       sourceTime,
-
-      // Transform
       x: evalX,
       y: evalY,
       width: evalW,
       height: evalH,
       rotation: evalRot,
       opacity: evalOpacity * (transitionState.opacity ?? 1.0),
-
-      // Transition
       inTransition: transitionState.inTransition,
       transitionType: transitionState.type,
       transitionProgress: transitionState.progress,
@@ -204,60 +168,45 @@ export function evaluateScene(time: number, clips: Clip[], tracks: Track[], asse
     visualLayers.push(mediaLayer);
   }
 
-  // ─── 4. Evaluate Audio Layers (Contract §6) ───────────────────────────────
+  // ─── 4. Evaluate Audio Layers ─────────────────────────────────────────────
 
   const audioLayers: EvaluatedAudioLayer[] = [];
 
   for (const clip of sortedClips) {
     const asset = assetMap.get(clip.mediaId);
     const track = trackMap.get(clip.trackId);
-
-    // Check if clip has audio
     const hasAudio = clip.role === "audio" || (asset?.type === "video" && clip.role === "primary");
-
     if (!hasAudio || !asset) continue;
+    if (track?.muted ?? false) continue;
 
-    // Check if muted
-    const isMuted = track?.muted ?? false;
-    if (isMuted) continue;
-
-    // Calculate source time
     const sourceTime = clip.trimIn + (time - clip.startTime);
-
-    // Convert file path
     const sourcePath = asset.path ? convertFileSrc(asset.path) : "";
     if (!sourcePath) continue;
 
-    const audioLayer: EvaluatedAudioLayer = {
+    audioLayers.push({
       layerId: `${clip.id}-audio-${time}`,
       clipId: clip.id,
       mediaId: clip.mediaId,
       sourcePath,
       sourceTime,
-      volume: 1.0, // TODO: Per-clip volume
-      pan: 0.0, // TODO: Per-clip pan
-      priority: clip.trackIndex, // Higher tracks have priority
+      volume: 1.0,
+      pan: 0.0,
+      priority: clip.trackIndex,
       muted: false,
-    };
-
-    audioLayers.push(audioLayer);
+    });
   }
 
-  // Sort audio by priority (higher = more important)
   audioLayers.sort((a, b) => b.priority - a.priority);
 
-  // ─── 5. Evaluate Transitions (Contract §3 - placeholder) ──────────────────
-
+  // ─── 5. Transitions (placeholder) ─────────────────────────────────────────
   const transitions: EvaluatedTransition[] = [];
-  // TODO: Detect and evaluate transitions between clips
 
-  // ─── 6. Create Metadata ────────────────────────────────────────────────────
+  // ─── 6. Metadata ──────────────────────────────────────────────────────────
 
-  // Create deterministic hash of active media to trigger lifecycle events
   const activeMediaHash = visualLayers
     .filter((l) => l.layerType === "media")
     .map((l) => l.clipId)
-    .sort() // Sort to prevent ordering bugs
+    .sort()
     .join("|");
 
   const metadata: SceneMetadata = {
@@ -270,19 +219,11 @@ export function evaluateScene(time: number, clips: Clip[], tracks: Track[], asse
     activeMediaHash,
   };
 
-  // ─── 7. Return Evaluated Scene ────────────────────────────────────────────
-
-  return {
-    visualLayers,
-    audioLayers,
-    transitions,
-    metadata,
-  };
+  return { visualLayers, audioLayers, transitions, metadata };
 }
 
-/**
- * Get role order for compositing (Contract §2).
- */
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
 function getRoleOrder(role: string): number {
   const order: Record<string, number> = {
     background: 0,
@@ -290,117 +231,52 @@ function getRoleOrder(role: string): number {
     overlay: 2,
     text: 3,
     effect: 4,
-    audio: -1, // Audio doesn't participate in visual compositing
+    audio: -1,
   };
   return order[role] ?? 1;
 }
 
-/**
- * Evaluate transition state for a clip (Contract §3 - basic implementation).
- *
- * TODO: This is a placeholder. Full transition evaluation needs:
- * - Transition detection at clip boundaries
- * - Configurable transition duration
- * - Multiple transition types
- * - Transition curves (ease in/out)
- */
-function evaluateTransitionState(
-  clip: any,
-  time: number,
-  allClips: any[],
-): {
-  inTransition: boolean;
-  type?: "fade" | "dissolve";
-  progress?: number;
-  opacity?: number;
-} {
-  // Placeholder: No transitions yet
-  return {
-    inTransition: false,
-    opacity: 1.0,
-  };
-
-  // TODO: Implement transition detection
-  // const transitionDuration = 0.5; // seconds
-  // const clipEnd = getClipEndTime(clip);
-  //
-  // // Fade out at end
-  // if (time > clipEnd - transitionDuration && time <= clipEnd) {
-  //   const progress = (time - (clipEnd - transitionDuration)) / transitionDuration;
-  //   return {
-  //     inTransition: true,
-  //     type: "fade",
-  //     progress,
-  //     opacity: 1.0 - progress,
-  //   };
-  // }
-  //
-  // return { inTransition: false, opacity: 1.0 };
+function evaluateTransitionState(clip: any, time: number, allClips: any[]): { inTransition: boolean; type?: "fade" | "dissolve"; progress?: number; opacity?: number } {
+  // Placeholder — full transition detection tracked in issue #transitions
+  return { inTransition: false, opacity: 1.0 };
 }
 
-/**
- * Evaluate scene with caching.
- *
- * This is the recommended entry point for all evaluation.
- * Uses LRU cache with epoch-based invalidation.
- *
- * @param time - Timeline time in seconds
- * @param clips - All clips in timeline
- * @param tracks - All tracks
- * @param assets - All media assets
- * @param project - Project settings
- * @param epoch - Timeline epoch (for cache invalidation)
- * @returns Complete evaluated scene
- */
-export function evaluateSceneCached(time: number, clips: Clip[], tracks: Track[], assets: MediaAsset[], project: Project | null, epoch: number = 0): EvaluatedScene {
-  const cache = getEvaluationCache();
+// ─── Cached variant ───────────────────────────────────────────────────────────
 
-  // Compute cache key
+/**
+ * Evaluate the NLE timeline with LRU caching and epoch-based invalidation.
+ * This is the recommended entry point for all preview/render paths.
+ */
+export function evaluateTimelineSceneCached(time: number, clips: Clip[], tracks: Track[], assets: MediaAsset[], project: Project | null, epoch: number = 0): EvaluatedScene {
+  const cache = getEvaluationCache();
   const clipVersion = computeClipVersion(clips);
   const cacheKey = { time, epoch, clipVersion };
 
-  // Check cache
   const cached = cache.get(cacheKey);
-  if (cached) {
-    return cached;
-  }
+  if (cached) return cached;
 
-  // Cache miss - evaluate
-  const scene = evaluateScene(time, clips, tracks, assets, project);
-
-  // Store in cache
+  const scene = evaluateTimelineScene(time, clips, tracks, assets, project);
   cache.set(cacheKey, scene);
-
   return scene;
 }
 
-/**
- * Get cache statistics (for debugging/monitoring).
- */
 export function getEvaluationCacheStats() {
   return getEvaluationCache().getStats();
 }
 
-/**
- * Clear evaluation cache (for testing or manual invalidation).
- */
 export function clearEvaluationCache() {
   getEvaluationCache().clear();
 }
 
-/**
- * Invalidate cache for specific epoch (called when timeline changes).
- */
 export function invalidateEvaluationCache(epoch: number) {
   getEvaluationCache().invalidateEpoch(epoch);
 }
 
 /**
- * Helper to resolve and normalize font family strings to exact loaded Fontsource font stacks.
+ * Resolve and normalize font family strings to exact loaded Fontsource font stacks.
  */
 export function normalizeFontFamily(family: string): string {
   const f = family.toLowerCase();
-
   if (f === "inter") return "Inter";
   if (f.includes("inter")) return "Inter Variable";
   if (f.includes("montserrat")) return "Montserrat Variable";
@@ -416,6 +292,5 @@ export function normalizeFontFamily(family: string): string {
   if (f.includes("playfair display")) return "Playfair Display Variable";
   if (f.includes("nunito")) return "Nunito Variable";
   if (f.includes("dancing script")) return "Dancing Script Variable";
-
   return family;
 }

--- a/src/core/evaluation/index.ts
+++ b/src/core/evaluation/index.ts
@@ -1,33 +1,26 @@
 /**
- * Evaluation Module - Canonical Timeline Evaluation
- *
- * This is the SINGLE SOURCE OF TRUTH for timeline evaluation.
+ * Evaluation Module - Canonical NLE Timeline Evaluation
  *
  * Architecture:
  *
- *   Timeline State
+ *   Timeline State (Clips / Tracks / Assets)
  *        ↓
- *   Evaluation Contract (contract.md)
+ *   evaluateTimelineScene()  ← entry point for all rendering paths
  *        ↓
- *   Scene Evaluator (evaluator.ts)
+ *   EvaluatedScene           ← universal render currency
  *        ↓
- *   EvaluatedScene (types.ts)
- *        ↓
- *   Render Engine
+ *   rasterizeScene()         ← pixel generation (rasterizer.ts)
  *
- * All rendering paths use this:
- * - Preview rendering
- * - Export rendering
- * - Thumbnail generation
- * - Proxy rendering
- * - Timeline validation
+ * Naming note: the function is called evaluateTimelineScene (not evaluateScene)
+ * to avoid collision with @clypra/engine's evaluateScene, which operates on
+ * a SceneDocument and draws directly to a Canvas 2D context.
  */
 
 // Types
-export type { EvaluatedScene, EvaluatedVisualLayer, EvaluatedAudioLayer, EvaluatedTransition, EvaluatedEffect, EvaluatedMask, SceneMetadata, BlendMode, EvaluationCacheKey, EvaluationResult } from "./types";
+export type { EvaluatedScene, EvaluatedVisualLayer, EvaluatedMediaLayer, EvaluatedTextLayer, EvaluatedAudioLayer, EvaluatedTransition, EvaluatedEffect, EvaluatedMask, SceneMetadata, BlendMode, EvaluationCacheKey, EvaluationResult } from "./types";
 
-// Evaluator
-export { evaluateScene, evaluateSceneCached, getEvaluationCacheStats, clearEvaluationCache, invalidateEvaluationCache } from "./evaluator";
+// Evaluator — primary API
+export { evaluateTimelineScene, evaluateTimelineSceneCached, getEvaluationCacheStats, clearEvaluationCache, invalidateEvaluationCache, normalizeFontFamily } from "./evaluator";
 
 // Cache
 export { getEvaluationCache, resetEvaluationCache, computeClipVersion } from "./cache";

--- a/src/core/render/rasterizer.ts
+++ b/src/core/render/rasterizer.ts
@@ -18,8 +18,17 @@
 import type { EvaluatedScene, EvaluatedMediaLayer, EvaluatedTextLayer } from "../evaluation/types";
 import { getResourceCache } from "../resources/ResourceCache";
 import { _buildConfig } from "../../features/text-effects/registry";
-import { defaultConfig as engineDefaultConfig, evaluateScene, textEffectConfigToScene, type TextEffectConfig } from "@clypra/engine";
+import { defaultConfig as engineDefaultConfig, evaluateScene as engineEvaluateScene, textEffectConfigToScene, supportsCtxFilter, supportsOffscreenCanvas, type TextEffectConfig, WebGLCompositor } from "@clypra/engine";
 import { useEffectsStore } from "../../features/text-effects/store/effectsStore";
+
+// Shared WebGLCompositor for rasterizer — used when ctx.filter is unsupported (WKWebView).
+let _rasterizerCompositor: WebGLCompositor | null = null;
+function getRasterizerCompositor(): WebGLCompositor | null {
+  if (_rasterizerCompositor !== null) return _rasterizerCompositor;
+  if (typeof document === "undefined") return null;
+  _rasterizerCompositor = new WebGLCompositor();
+  return _rasterizerCompositor.isSupported ? _rasterizerCompositor : null;
+}
 
 /**
  * Global pool for OffscreenCanvas to prevent GC stalls during rendering/export.
@@ -351,12 +360,20 @@ function drawLoadingPlaceholder(ctx: CanvasRenderingContext2D | OffscreenCanvasR
 /**
  * Rasterize a text layer.
  *
- * CRITICAL: This is the canonical text rendering.
- * Preview MUST use this same code path.
+ * CRITICAL: This is the canonical text rendering path.
+ * Preview and export MUST use the same code path.
+ *
+ * Styled layers (styleId present) always go through engineEvaluateScene,
+ * which is the authoritative pipeline for stroke-blur, glow, bevel, and
+ * all post-fx. When ctx.filter is unsupported (WKWebView on macOS),
+ * rendering is routed through the WebGLCompositor fallback so visual
+ * output is consistent across platforms.
+ *
+ * Plain text layers (no styleId) use a minimal Canvas 2D path that
+ * respects the same baseline alignment as the engine (fontSize * 0.82).
  */
 function rasterizeTextLayer(ctx: CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D, layer: EvaluatedTextLayer, width: number, height: number, scaleX: number, scaleY: number): void {
-  // If we have a styleId, look up the full effect definition from the effects
-  // store cache (API-fetched definitions live here, allTextEffects is always empty).
+  // ── Styled text: full engine pipeline ────────────────────────────────────
   if (layer.styleId) {
     const effectDef = useEffectsStore.getState().definitions[layer.styleId];
     if (effectDef) {
@@ -364,74 +381,106 @@ function rasterizeTextLayer(ctx: CanvasRenderingContext2D | OffscreenCanvasRende
       const effectPadding = fontSize * 0.5;
       const offW = Math.max(1, Math.ceil(width + effectPadding * 2));
       const offH = Math.max(1, Math.ceil(height + effectPadding * 2));
+
+      const builtCfg = _buildConfig(effectDef, layer.text, fontSize, offW, offH, layer.time, layer.clipStartTime, layer.clipDuration);
+      const engineConfig: TextEffectConfig = {
+        ...engineDefaultConfig,
+        ...builtCfg,
+        // _buildConfig writes width/height (local engine keys).
+        // @clypra/engine uses canvasWidth/canvasHeight for centering.
+        canvasWidth: offW,
+        canvasHeight: offH,
+        fontFamily: layer.fontFamily || effectDef.font?.family,
+      } as TextEffectConfig;
+
+      const sceneDoc = textEffectConfigToScene(engineConfig);
+
+      if (!supportsCtxFilter()) {
+        // WKWebView: ctx.filter is a no-op. Render to offscreen then composite
+        // via WebGLCompositor which applies blur/bloom as WebGL post-fx.
+        const compositor = getRasterizerCompositor();
+        const offscreen = canvasPool.acquire(offW, offH);
+        const offCtx = offscreen.getContext("2d", { alpha: true }) as OffscreenCanvasRenderingContext2D | null;
+        if (offCtx) {
+          offCtx.setTransform(1, 0, 0, 1, 0, 0);
+          offCtx.clearRect(0, 0, offW, offH);
+          engineEvaluateScene(sceneDoc, layer.time ?? 0, offCtx as unknown as CanvasRenderingContext2D, { skipPostFx: true });
+
+          if (compositor) {
+            // WebGL handles blur/bloom pass then blits back to a temp canvas we draw from
+            const blitCanvas = document.createElement("canvas");
+            blitCanvas.width = offW;
+            blitCanvas.height = offH;
+            const blitCtx = blitCanvas.getContext("2d")!;
+            compositor.renderToContext(blitCtx, offscreen, { blur: 0, bloom: 0, bloomThreshold: 0.6 });
+            ctx.drawImage(blitCanvas, 0, 0, offW, offH, -width / 2 - effectPadding, -height / 2 - effectPadding, offW, offH);
+            blitCanvas.width = 0; // release backing store
+          } else {
+            // No WebGL — flat blit, no blur/bloom
+            ctx.drawImage(offscreen, 0, 0, offW, offH, -width / 2 - effectPadding, -height / 2 - effectPadding, offW, offH);
+          }
+        }
+        canvasPool.release(offscreen);
+        return;
+      }
+
+      // ctx.filter supported — evaluate directly onto an offscreen buffer then blit
       const offscreen = canvasPool.acquire(offW, offH);
       const offCtx = offscreen.getContext("2d", { alpha: true }) as OffscreenCanvasRenderingContext2D | null;
       if (offCtx) {
         offCtx.setTransform(1, 0, 0, 1, 0, 0);
         offCtx.clearRect(0, 0, offW, offH);
-
-        // Use evaluateScene — the correct full engine pipeline that applies
-        // ctx.filter for stroke blur, glow compositing, bevel, and all post-fx.
-        const builtCfg = _buildConfig(effectDef, layer.text, fontSize, offW, offH, layer.time, layer.clipStartTime, layer.clipDuration);
-        const engineConfig: TextEffectConfig = {
-          ...engineDefaultConfig,
-          ...builtCfg,
-          // _buildConfig uses width/height — engine expects canvasWidth/canvasHeight.
-          canvasWidth: offW,
-          canvasHeight: offH,
-          fontFamily: layer.fontFamily || effectDef.font?.family,
-        } as TextEffectConfig;
-
-        offCtx.clearRect(0, 0, offW, offH);
-        evaluateScene(textEffectConfigToScene(engineConfig), layer.time ?? 0, offCtx as unknown as CanvasRenderingContext2D);
-
+        engineEvaluateScene(sceneDoc, layer.time ?? 0, offCtx as unknown as CanvasRenderingContext2D);
         ctx.drawImage(offscreen, 0, 0, offW, offH, -width / 2 - effectPadding, -height / 2 - effectPadding, offW, offH);
       }
       canvasPool.release(offscreen);
       return;
     }
+    // styleId present but definition not yet in cache — silent miss, will redraw
+    // once prefetchEffect resolves. Fallthrough to plain text to show something.
   }
 
-  // Build font string
+  // ── Plain text: minimal Canvas 2D path ───────────────────────────────────
+  // Baseline alignment matches the engine: textBaseline = "alphabetic",
+  // startY offset = fontSize * 0.82, which is the engine's convention in
+  // textLayout.ts::layoutWithFontSize.
   const fontWeight = typeof layer.fontWeight === "number" ? layer.fontWeight : layer.fontWeight === "bold" ? "700" : "400";
   const fontStyle = layer.fontStyle === "italic" ? "italic" : "normal";
   const fontSize = layer.fontSize * scaleY;
   const fontFamily = layer.fontFamily;
 
   ctx.font = `${fontStyle} ${fontWeight} ${fontSize}px ${fontFamily}`;
+  ctx.textBaseline = "alphabetic";
 
-  // Apply letter spacing if specified
   if (layer.letterSpacing !== 0) {
-    ctx.letterSpacing = `${layer.letterSpacing * scaleX}px`;
+    (ctx as any).letterSpacing = `${layer.letterSpacing * scaleX}px`;
   }
 
-  // Split text into lines and wrap if needed
   const lines = wrapText(ctx, layer.text, width, fontSize, layer.lineHeight);
   const lineHeight = fontSize * layer.lineHeight;
+  // Total block height: first line baseline to last line baseline + descender allowance
+  const totalHeight = (lines.length - 1) * lineHeight + fontSize;
 
-  // Calculate total text height
-  const totalHeight = lines.length * lineHeight;
-
-  // Calculate vertical alignment offset
-  let startY: number;
+  // Vertical alignment using alphabetic baseline (engine convention: startY = top_of_block + fontSize * 0.82)
+  // 0.82 approximates the cap-height-to-size ratio, matching textLayout.ts::layoutWithFontSize
+  let blockTopY: number;
   switch (layer.verticalAlign) {
     case "top":
-      startY = -height / 2 + lineHeight / 2;
+      blockTopY = -height / 2;
       break;
     case "bottom":
-      startY = height / 2 - totalHeight + lineHeight / 2;
+      blockTopY = height / 2 - totalHeight;
       break;
     case "middle":
     default:
-      startY = -totalHeight / 2 + lineHeight / 2;
+      blockTopY = -totalHeight / 2;
       break;
   }
+  const firstBaselineY = blockTopY + fontSize * 0.82;
 
-  // Set text alignment
   ctx.textAlign = layer.textAlign;
-  ctx.textBaseline = "middle";
+  // textBaseline stays "alphabetic" as set above
 
-  // Calculate horizontal alignment offset
   let textX: number;
   switch (layer.textAlign) {
     case "left":
@@ -446,10 +495,10 @@ function rasterizeTextLayer(ctx: CanvasRenderingContext2D | OffscreenCanvasRende
       break;
   }
 
-  // Setup fillStyle (support multi-color comma-separated gradients)
+  // Gradient fill (comma-separated colors = vertical multi-color gradient)
   if (layer.color.includes(",")) {
     const colors = layer.color.split(",");
-    const gradient = ctx.createLinearGradient(0, startY - lineHeight / 2, 0, startY + totalHeight - lineHeight / 2);
+    const gradient = ctx.createLinearGradient(0, blockTopY, 0, blockTopY + totalHeight);
     colors.forEach((color, idx) => {
       gradient.addColorStop(idx / (colors.length - 1), color.trim());
     });
@@ -458,7 +507,6 @@ function rasterizeTextLayer(ctx: CanvasRenderingContext2D | OffscreenCanvasRende
     ctx.fillStyle = layer.color;
   }
 
-  // Enable clipping to prevent text overflow
   ctx.save();
   ctx.beginPath();
   ctx.rect(-width / 2, -height / 2, width, height);
@@ -486,7 +534,7 @@ function rasterizeTextLayer(ctx: CanvasRenderingContext2D | OffscreenCanvasRende
         break;
     }
 
-    const bgY = startY - lineHeight / 2 - bgPadding;
+    const bgY = blockTopY - bgPadding;
 
     ctx.save();
     ctx.fillStyle = layer.background.color;
@@ -509,7 +557,7 @@ function rasterizeTextLayer(ctx: CanvasRenderingContext2D | OffscreenCanvasRende
   // Draw each line
   for (let i = 0; i < lines.length; i++) {
     const line = lines[i];
-    const y = startY + i * lineHeight;
+    const y = firstBaselineY + i * lineHeight;
 
     // Draw text shadow if specified
     if (layer.shadow) {
@@ -537,7 +585,7 @@ function rasterizeTextLayer(ctx: CanvasRenderingContext2D | OffscreenCanvasRende
 
   // Reset letter spacing
   if (layer.letterSpacing !== 0) {
-    ctx.letterSpacing = "0px";
+    (ctx as any).letterSpacing = "0px";
   }
 }
 

--- a/src/core/scheduler/FrameScheduler.ts
+++ b/src/core/scheduler/FrameScheduler.ts
@@ -16,7 +16,7 @@
 
 import type { FrameRequest, FrameResult, RenderResourceHandle } from "../resources/types";
 import type { Clip, Track, MediaAsset, Project } from "@/types";
-import { evaluateSceneCached } from "../evaluation/evaluator";
+import { evaluateTimelineSceneCached } from "../evaluation/evaluator";
 import { rasterizeScene } from "../render/rasterizer";
 import { getResourceCache } from "../resources/ResourceCache";
 import { getFontLoader } from "../fonts/FontLoader";
@@ -399,7 +399,7 @@ export class FrameScheduler {
       job.progress = 0.3;
       const evalStartTime = Date.now();
 
-      const scene = evaluateSceneCached(job.request.time, this.clips, this.tracks, this.assets, this.project, this.epoch);
+      const scene = evaluateTimelineSceneCached(job.request.time, this.clips, this.tracks, this.assets, this.project, this.epoch);
 
       job.metrics.evaluationTimeMs = Date.now() - evalStartTime;
       this.stats.totalEvaluationTimeMs += job.metrics.evaluationTimeMs;
@@ -544,7 +544,7 @@ export class FrameScheduler {
    */
   private async preloadResources(job: FrameJob): Promise<void> {
     // Evaluate scene to discover required resources
-    const scene = evaluateSceneCached(job.request.time, this.clips, this.tracks, this.assets, this.project, this.epoch);
+    const scene = evaluateTimelineSceneCached(job.request.time, this.clips, this.tracks, this.assets, this.project, this.epoch);
 
     const resourceCache = getResourceCache();
     const loadPromises: Promise<void>[] = [];
@@ -630,7 +630,7 @@ export class FrameScheduler {
    */
   private async preloadFonts(job: FrameJob): Promise<void> {
     // Evaluate scene to discover required fonts
-    const scene = evaluateSceneCached(job.request.time, this.clips, this.tracks, this.assets, this.project, this.epoch);
+    const scene = evaluateTimelineSceneCached(job.request.time, this.clips, this.tracks, this.assets, this.project, this.epoch);
 
     const fontLoader = getFontLoader();
     const fontDescriptors = [];

--- a/src/core/scheduler/__tests__/FrameScheduler.test.ts
+++ b/src/core/scheduler/__tests__/FrameScheduler.test.ts
@@ -10,7 +10,7 @@ import { FrameRequest } from "@/core/resources";
 
 // Mock dependencies
 vi.mock("../../evaluation/evaluator", () => ({
-  evaluateSceneCached: vi.fn(() => ({
+  evaluateTimelineSceneCached: vi.fn(() => ({
     visualLayers: [],
     audioLayers: [],
     transitions: [],

--- a/src/features/text-effects/renderer.ts
+++ b/src/features/text-effects/renderer.ts
@@ -1,71 +1,75 @@
-import { evaluateScene, textEffectConfigToScene, defaultConfig as engineDefaultConfig, WebGLCompositor, type TextEffectConfig } from "@clypra/engine";
+import { evaluateScene as engineEvaluateScene, textEffectConfigToScene, defaultConfig as engineDefaultConfig, supportsCtxFilter, supportsOffscreenCanvas, WebGLCompositor, type TextEffectConfig } from "@clypra/engine";
 import { TextEffectDefinition } from "./types/types";
 import { hasRegisteredEngine, renderRegisteredEffect, _buildConfig } from "./registry";
 import { getFontLoader } from "@/core/fonts/FontLoader";
 
-// ─── ctx.filter support detection ────────────────────────────────────────────
-// Tauri WebView (WKWebView on macOS) does not support ctx.filter, which the
-// engine uses for stroke blur and glow effects. Detect once at module load and
-// use the WebGLCompositor workaround when unsupported.
-let _ctxFilterSupported: boolean | null = null;
-let _compositor: InstanceType<typeof WebGLCompositor> | null = null;
+// ─── Shared WebGLCompositor ───────────────────────────────────────────────────
+// Platform capability detection (supportsCtxFilter) is now provided by
+// @clypra/engine/platform.ts — the single canonical implementation.
+// This module no longer maintains its own detection state.
 
-function isCtxFilterSupported(): boolean {
-  if (_ctxFilterSupported !== null) return _ctxFilterSupported;
-  try {
-    const test = document.createElement("canvas").getContext("2d")!;
-    test.filter = "blur(4px)";
-    _ctxFilterSupported = test.filter !== "none" && test.filter !== "" && test.filter !== "blur(4px)";
-    // Some WebViews accept the assignment silently but don't actually apply it —
-    // check if the filter string round-trips correctly.
-    _ctxFilterSupported = test.filter.includes("blur");
-  } catch {
-    _ctxFilterSupported = false;
-  }
-  return _ctxFilterSupported;
-}
+let _compositor: WebGLCompositor | null = null;
 
-function getCompositor(): InstanceType<typeof WebGLCompositor> | null {
+function getCompositor(): WebGLCompositor | null {
   if (_compositor !== null) return _compositor;
+  if (typeof document === "undefined") return null;
   _compositor = new WebGLCompositor();
   return _compositor.isSupported ? _compositor : null;
 }
 
 /**
- * Draw an evaluated scene to the target canvas.
- * Routes through WebGLCompositor when ctx.filter is unsupported (Tauri WebView).
+ * Draw a SceneDocument to the target canvas context.
+ *
+ * Routes through WebGLCompositor when ctx.filter is unsupported (WKWebView on
+ * macOS Tauri). On standard browsers and Windows WebView2, evaluates directly
+ * onto the target context with no intermediate allocation.
  */
 function drawScene(targetCtx: CanvasRenderingContext2D, cfg: TextEffectConfig, time: number): void {
   const scene = getOrBuildScene(cfg);
   const w = cfg.canvasWidth as number;
   const h = cfg.canvasHeight as number;
 
-  if (!isCtxFilterSupported()) {
-    // ctx.filter unsupported — render to OffscreenCanvas first, then composite
-    // via WebGLCompositor which applies blur/glow as WebGL post-fx.
+  if (!supportsCtxFilter()) {
+    // WKWebView: ctx.filter is a no-op. Render to an intermediate canvas then
+    // composite via WebGLCompositor which applies blur/bloom as WebGL post-fx.
     const compositor = getCompositor();
-    const off = new OffscreenCanvas(w, h);
-    const offCtx = off.getContext("2d") as OffscreenCanvasRenderingContext2D;
+
+    let off: HTMLCanvasElement | OffscreenCanvas;
+    if (supportsOffscreenCanvas()) {
+      off = new OffscreenCanvas(w, h);
+    } else {
+      off = document.createElement("canvas");
+      off.width = w;
+      off.height = h;
+    }
+
+    const offCtx = off.getContext("2d") as CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D;
     offCtx.clearRect(0, 0, w, h);
-    evaluateScene(scene, time, offCtx as unknown as CanvasRenderingContext2D);
+    engineEvaluateScene(scene, time, offCtx as unknown as CanvasRenderingContext2D);
 
     if (compositor) {
       compositor.renderToContext(targetCtx, off, { blur: 0, bloom: 0, bloomThreshold: 0.6 });
     } else {
-      // WebGL also unsupported — draw flat (no blur/glow, best we can do)
+      // WebGL also unavailable — flat blit, no blur/bloom post-fx
       targetCtx.clearRect(0, 0, w, h);
-      targetCtx.drawImage(off, 0, 0);
+      targetCtx.drawImage(off as CanvasImageSource, 0, 0);
+    }
+
+    // Release DOM canvas backing store if OffscreenCanvas was unavailable
+    if (!(off instanceof OffscreenCanvas)) {
+      (off as HTMLCanvasElement).width = 0;
+      (off as HTMLCanvasElement).height = 0;
     }
     return;
   }
 
-  // ctx.filter is supported — evaluate directly onto the target context
+  // ctx.filter supported — evaluate directly onto the target context
   targetCtx.clearRect(0, 0, w, h);
-  evaluateScene(scene, time, targetCtx);
+  engineEvaluateScene(scene, time, targetCtx);
 }
 
-// textEffectConfigToScene is pure — cache by config identity to avoid rebuilding
-// on every animation frame.
+// textEffectConfigToScene is pure — cache by config object identity to avoid
+// rebuilding the full SceneDocument on every animation frame.
 const _sceneCache = new WeakMap<object, ReturnType<typeof textEffectConfigToScene>>();
 
 function getOrBuildScene(cfg: TextEffectConfig) {
@@ -76,61 +80,49 @@ function getOrBuildScene(cfg: TextEffectConfig) {
 }
 
 /**
- * Build the engine config from a TextEffectDefinition + runtime params.
- * Correctly maps width/height → canvasWidth/canvasHeight for the engine.
+ * Build a TextEffectConfig from a TextEffectDefinition + runtime params.
+ * Maps width/height (local engine keys) → canvasWidth/canvasHeight (engine keys).
  */
 function buildEngineConfig(effect: TextEffectDefinition, text: string, fontSize: number, canvasWidth: number, canvasHeight: number, time?: number, clipStartTime?: number, clipDuration?: number): TextEffectConfig {
   const builtCfg = _buildConfig(effect, text, fontSize, canvasWidth, canvasHeight, time, clipStartTime, clipDuration);
   return {
     ...engineDefaultConfig,
     ...builtCfg,
-    // _buildConfig writes to width/height (legacy local-engine keys).
-    // The published engine uses canvasWidth/canvasHeight for text centering.
     canvasWidth,
     canvasHeight,
   } as TextEffectConfig;
 }
 
 /**
- * Core Canvas 2D Text Effects Rendering Context Engine.
- * Renders full text layers onto any rendering context.
+ * Render a text effect onto any 2D canvas context.
  *
- * Uses evaluateScene (the correct full pipeline) for API-fetched effects so
- * that stroke blur (ctx.filter), glow compositing, bevel, and all other
- * post-fx are applied correctly.
+ * Uses the full @clypra/engine pipeline (evaluateScene) for API-fetched effects
+ * so stroke blur (ctx.filter), glow compositing, bevel, and all post-fx are
+ * applied correctly. Locally registered engines (studio-generated classes) are
+ * called via their drawFrame() method.
  */
 export const renderTextEffectToContext = (ctx: CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D, text: string, effect: TextEffectDefinition, fontSize: number, _x: number, _y: number, canvasWidth: number, canvasHeight: number, time?: number, clipStartTime?: number, clipDuration?: number) => {
-  // ── Locally registered engine (studio-generated class) ────────────────────
-  // These are registered via register() in registry.ts and handle their own
-  // animation interception internally.
   if (hasRegisteredEngine(effect?.id)) {
-    const originalFillText = ctx.fillText;
-    const originalStrokeText = ctx.strokeText;
+    const originalFillText = ctx.fillText.bind(ctx);
+    const originalStrokeText = ctx.strokeText.bind(ctx);
     renderRegisteredEffect(ctx, effect, text, fontSize, canvasWidth, canvasHeight, time, clipStartTime, clipDuration);
     ctx.fillText = originalFillText;
     ctx.strokeText = originalStrokeText;
     return;
   }
 
-  // ── @clypra/engine pipeline (all API-fetched effects) ─────────────────────
-  // Routes through drawScene which detects ctx.filter support and falls back
-  // to WebGLCompositor when running inside Tauri's WKWebView.
   const cfg = buildEngineConfig(effect, text, fontSize, canvasWidth, canvasHeight, time, clipStartTime, clipDuration);
   drawScene(ctx as CanvasRenderingContext2D, cfg, time ?? 0);
 };
 
 /**
  * Render a text effect to an HTMLCanvasElement synchronously.
- * Canvas must be sized correctly before calling.
- *
- * For preview use, prefer renderTextEffectAsync which waits for fonts first.
+ * For preview, prefer renderTextEffectAsync which waits for fonts first.
  */
 export const renderTextEffect = (canvas: HTMLCanvasElement, text: string, effect: TextEffectDefinition, fontSize: number, time?: number) => {
   const ctx = canvas.getContext("2d");
   if (!ctx) return;
 
-  // Size must be set before drawing — engine centers relative to canvas dimensions.
-  // Only reset if not already sized to avoid clearing a pre-sized canvas.
   if (canvas.width === 0 || canvas.height === 0) {
     canvas.width = 640;
     canvas.height = 360;
@@ -141,31 +133,26 @@ export const renderTextEffect = (canvas: HTMLCanvasElement, text: string, effect
 };
 
 /**
- * Render a text effect to an HTMLCanvasElement, waiting for fonts first.
+ * Render a text effect to an HTMLCanvasElement after ensuring fonts are loaded.
  *
- * This is the correct entry point for preview rendering. It:
+ * This is the correct entry point for preview rendering:
  * 1. Sets canvas dimensions
- * 2. Injects/Loads the required font if needed via FontLoader
- * 3. Waits for the font to load
- * 4. Draws via evaluateScene (full engine pipeline including ctx.filter)
- * 5. Re-draws after document.fonts.ready to catch any late-loading variants
+ * 2. Pre-loads the required font via FontLoader (deduped, cached)
+ * 3. Waits for document.fonts.ready
+ * 4. Draws via engineEvaluateScene (full pipeline incl. ctx.filter / WebGL fallback)
  */
 export const renderTextEffectAsync = async (canvas: HTMLCanvasElement, text: string, effect: TextEffectDefinition, fontSize: number, time?: number): Promise<void> => {
   const ctx = canvas.getContext("2d");
   if (!ctx) return;
 
-  // Step 1 — Set canvas dimensions before any drawing.
-  // Engine centers text relative to canvasWidth/canvasHeight.
   canvas.width = 640;
   canvas.height = 360;
 
   const cfg = buildEngineConfig(effect, text, fontSize, canvas.width, canvas.height, time);
 
-  // Step 2 — Injects/Loads the required font if needed.
   if (effect?.font?.family) {
     try {
-      const fontLoader = getFontLoader();
-      await fontLoader.ensureFont({
+      await getFontLoader().ensureFont({
         family: effect.font.family,
         weight: effect.font.weight,
         style: effect.font.style,
@@ -175,21 +162,15 @@ export const renderTextEffectAsync = async (canvas: HTMLCanvasElement, text: str
     }
   }
 
-  // Wait for document.fonts.ready to ensure all fonts are fully registered before
-  // the first draw, preventing fallback-font renders.
   if (typeof document !== "undefined" && document.fonts) {
     await document.fonts.ready;
   }
 
-  // Step 3 — Draw (routes through WebGLCompositor if ctx.filter unsupported)
-  const draw = () => drawScene(ctx, cfg, time ?? 0);
-
-  draw();
+  drawScene(ctx, cfg, time ?? 0);
 };
 
 /**
- * Renders the full text effect on a configurable offscreen canvas and returns
- * a high-resolution export PNG data URL.
+ * Render a text effect to a PNG data URL (export / thumbnail use).
  */
 export const renderTextEffectToDataURL = (text: string, effect: TextEffectDefinition, fontSize: number, width = 800, height = 400): string => {
   const offscreen = document.createElement("canvas");

--- a/src/index.css
+++ b/src/index.css
@@ -384,3 +384,15 @@ input[type="range"]:focus-visible {
     @apply font-sans;
   }
 }
+
+/* Translucent Checkerboard pattern for alpha channel evaluation */
+.checkerboard {
+  background-image: linear-gradient(45deg, #181822 25%, transparent 25%), linear-gradient(-45deg, #181822 25%, transparent 25%), linear-gradient(45deg, transparent 75%, #181822 75%), linear-gradient(-45deg, transparent 75%, #181822 75%);
+  background-size: 20px 20px;
+  background-position:
+    0 0,
+    0 10px,
+    10px -10px,
+    -10px 0px;
+  background-color: #0e0e12;
+}

--- a/src/lib/__tests__/previewScene.test.ts
+++ b/src/lib/__tests__/previewScene.test.ts
@@ -1,5 +1,5 @@
 import { vi, describe, expect, it } from "vitest";
-import { evaluateScene } from "@/core/evaluation/evaluator";
+import { evaluateTimelineScene as evaluateScene } from "@/core/evaluation/evaluator";
 
 vi.mock("@tauri-apps/api/core", () => ({
   convertFileSrc: (value: string) => value,


### PR DESCRIPTION
## Summary

Implements the architecture refactor identified in the principal architect review. All 646 tests pass.

## Engine (@clypra/engine 1.1.0)

Pushed separately to `clypra-studio` — publish to npm before merging this PR so the version pin resolves.

## Changes in this PR

### evaluateScene naming collision resolved
- Renamed `evaluateScene` → `evaluateTimelineScene` and `evaluateSceneCached` → `evaluateTimelineSceneCached` in the NLE timeline evaluator
- Eliminates silent collision with `@clypra/engine`'s `evaluateScene(SceneDocument, time, ctx)` which has a completely different signature
- Updated all call sites: `ProgramPreview.tsx`, `FrameScheduler.ts`, all test mocks

### rasterizer.ts — text rendering correctness
- **Styled text**: adds `supportsCtxFilter()` guard — routes through `WebGLCompositor` when `ctx.filter` is unsupported (WKWebView on macOS Tauri). Previously stroke-blur and glow were silently broken on macOS.
- **Plain text**: fixes baseline from `textBaseline=middle` to `textBaseline=alphabetic` with `fontSize*0.82` offset, matching the engine's `textLayout.ts` convention. Eliminates vertical drift between preview and export.

### features/text-effects/renderer.ts
- Replace local `isCtxFilterSupported()` with `supportsCtxFilter()` from engine (canonical, single source)
- Replace bare `typeof OffscreenCanvas` check with `supportsOffscreenCanvas()`
- Release DOM canvas backing store after composite (prevents ~30fps memory leak on WKWebView)

### TextSourcePreview — full rewrite
- **Canvas dimensions**: was `640×360` (16:9, wrong), now `800×200` matching effect native size — fixes aspect ratio distortion
- **Animation loop**: adds rAF loop for animated effects (typewriter/wave/fade/glitch were frozen at `t=0`)
- **Cleanup**: `aborted` flag + `mountedRef` guard — no post-unmount draws, loop cancelled on preset change
- **Font loading**: pre-loads once before draw loop, not on every frame
- **Correct render path**: `renderTextEffectToContext` instead of `renderTextEffectAsync` (async is for one-shot thumbnails only)
- **Types**: `preset: any` → `EffectFullDefinition & { presetType? }`

### Styles
- Add `.checkerboard` utility to `index.css`

## Testing
```
Test Files  53 passed (53)
Tests       646 passed (646)
```