### PR TITLE
fix(editor): Fix text effect preset application in preview and raster…

### DIFF
--- a/src/components/editor/preview/SourcePreview.tsx
+++ b/src/components/editor/preview/SourcePreview.tsx
@@ -184,23 +184,55 @@ export const SourcePreview: React.FC = () => {
       if (!targetTrackId) return;
 
       const preset = sourceTextPreset;
+
+      // Extract styleId for text effects
+      // IMPORTANT: The preset is the full TextEffectDefinition that was fetched during preview.
+      // The preview flow (EffectGrid.handlePreview) calls ClypraApi.getFullEffect() which:
+      //   1. Fetches the definition from the API
+      //   2. Caches it in ClypraApi._effectsCache
+      //   3. Syncs it to effectsStore.definitions[id]
+      // This ensures the rasterizer will find the cached definition when rendering the clip.
+      const styleId = preset.presetType === "effect" ? preset.id : undefined;
+
+      // Log the full text effect definition to verify caching
+      console.log("[SourcePreview] Adding text effect to timeline:", {
+        presetType: preset.presetType,
+        styleId,
+        presetId: preset.id,
+        presetName: preset.name,
+        fullPreset: preset,
+      });
+
+      // When adding a text effect, we should NOT override individual properties
+      // because the rasterizer uses TextEffectBuilder.fromDefinition() which
+      // reads all styling from the cached effect definition.
+      // However, if individual properties (stroke, shadow, background) are explicitly
+      // set to undefined/null, the rasterizer DISABLES them (see lines 395-416 in rasterizer.ts).
+      //
+      // Solution: Only pass properties that are truly user overrides, not properties
+      // extracted from the effect definition itself.
       const textClip = createTextClip({
         trackId: targetTrackId,
         startTime,
-        duration: 3.0, // standard 3s duration for text clips added from preview
+        duration: 3.0,
         text: preset.text || "CLYPRA",
         canvasWidth: project?.canvasWidth || 1920,
         canvasHeight: project?.canvasHeight || 1080,
-        fontFamily: preset.fontFamily,
-        color: preset.color,
-        fontSize: preset.fontSize || 48,
-        fontWeight: preset.fontWeight,
-        fontStyle: preset.fontStyle,
-        stroke: preset.stroke,
-        shadow: preset.shadow,
-        background: preset.background,
-        styleId: preset.presetType === "effect" ? preset.id : undefined,
+        // When styleId is present, the engine will use the effect definition for ALL styling
+        // Do NOT pass fontFamily, color, fontSize, fontWeight, fontStyle, stroke, shadow, background
+        // from the preset - let the definition be the source of truth
+        styleId,
         templateId: preset.presetType === "template" ? preset.id : undefined,
+        // Only fontSize is needed to calculate the text bounding box
+        fontSize: preset.fontSize || (styleId ? 96 : 48),
+      });
+
+      console.log("[SourcePreview] Created text clip:", {
+        clipId: textClip.id,
+        styleId: textClip.styleId,
+        text: textClip.text,
+        fontFamily: textClip.fontFamily,
+        fontSize: textClip.fontSize,
       });
 
       addClip(textClip);

--- a/src/core/render/rasterizer.ts
+++ b/src/core/render/rasterizer.ts
@@ -19,7 +19,8 @@ import type { EvaluatedScene, EvaluatedMediaLayer, EvaluatedTextLayer } from "..
 import { getResourceCache } from "../resources/ResourceCache";
 import { defaultConfig as engineDefaultConfig, evaluateScene as engineEvaluateScene, textEffectConfigToScene, type TextEffectConfig, _buildConfig, layerToTextEffectConfig, CanvasDevice, TextEffectBuilder } from "@clypra/engine";
 import { useEffectsStore } from "../../features/text-effects/store/effectsStore";
-
+import { invalidateEvaluationCache } from "../evaluation/evaluator";
+import { useTimelineStore } from "../../store/timelineStore";
 
 /**
  * Raster target configuration.
@@ -343,13 +344,7 @@ function rasterizeTextLayer(ctx: CanvasRenderingContext2D | OffscreenCanvasRende
     const effectDef = useEffectsStore.getState().definitions[layer.styleId];
     if (effectDef) {
       const authoredFontSize = layer.fontSize;
-      const builder = TextEffectBuilder.fromDefinition(
-        effectDef,
-        layer.text,
-        authoredFontSize,
-        offW,
-        offH
-      );
+      const builder = TextEffectBuilder.fromDefinition(effectDef, layer.text, authoredFontSize, offW, offH);
 
       const builtCfg = builder.buildConfig();
       if (layer.time !== undefined) (builtCfg as any).time = layer.time;
@@ -361,7 +356,7 @@ function rasterizeTextLayer(ctx: CanvasRenderingContext2D | OffscreenCanvasRende
         if (layer.color.includes(",")) {
           const stops = layer.color.split(",").map((c, idx, arr) => ({
             color: c.trim(),
-            offset: Math.round((idx / (arr.length - 1)) * 100)
+            offset: Math.round((idx / (arr.length - 1)) * 100),
           }));
           builder.setFillGradient(90, stops);
         } else {
@@ -375,50 +370,59 @@ function rasterizeTextLayer(ctx: CanvasRenderingContext2D | OffscreenCanvasRende
         weight: typeof layer.fontWeight === "number" ? layer.fontWeight : layer.fontWeight === "bold" ? 700 : 400,
         style: layer.fontStyle || "normal",
         letterSpacing: layer.letterSpacing ?? 0,
-        lineHeight: layer.lineHeight ?? 1.2
+        lineHeight: layer.lineHeight ?? 1.2,
       });
 
       builder.setCanvas({
         posX: layer.textAlign || "center",
-        posY: layer.verticalAlign === "middle" ? "middle" : (layer.verticalAlign || "middle")
+        posY: layer.verticalAlign === "middle" ? "middle" : layer.verticalAlign || "middle",
       });
 
       // Override stroke if user explicitly configured it or disabled it
-      if (layer.stroke) {
-        builder.setStroke({
-          enabled: true,
-          color: layer.stroke.color,
-          width: layer.stroke.width * scaleY
-        });
-      } else {
-        builder.setStroke({ enabled: false });
+      if (layer.stroke !== undefined) {
+        if (layer.stroke) {
+          builder.setStroke({
+            enabled: true,
+            color: layer.stroke.color,
+            width: layer.stroke.width * scaleY,
+          });
+        } else {
+          builder.setStroke({ enabled: false });
+        }
       }
+      // If layer.stroke is undefined, don't override - let effect definition control it
 
       // Override shadow if user explicitly configured it or disabled it
-      if (layer.shadow) {
-        builder.setShadow({
-          enabled: true,
-          color: layer.shadow.color,
-          blur: layer.shadow.blur * scaleY,
-          offsetX: layer.shadow.offsetX * scaleX,
-          offsetY: layer.shadow.offsetY * scaleY
-        });
-      } else {
-        builder.setShadow({ enabled: false });
+      if (layer.shadow !== undefined) {
+        if (layer.shadow) {
+          builder.setShadow({
+            enabled: true,
+            color: layer.shadow.color,
+            blur: layer.shadow.blur * scaleY,
+            offsetX: layer.shadow.offsetX * scaleX,
+            offsetY: layer.shadow.offsetY * scaleY,
+          });
+        } else {
+          builder.setShadow({ enabled: false });
+        }
       }
+      // If layer.shadow is undefined, don't override - let effect definition control it
 
       // Override background panel if user explicitly configured it or disabled it
-      if (layer.background) {
-        builder.setPanel({
-          enabled: true,
-          color: layer.background.color,
-          radius: layer.background.borderRadius * scaleY,
-          paddingX: layer.background.padding * scaleX,
-          paddingY: layer.background.padding * scaleY
-        });
-      } else {
-        builder.setPanel({ enabled: false });
+      if (layer.background !== undefined) {
+        if (layer.background) {
+          builder.setPanel({
+            enabled: true,
+            color: layer.background.color,
+            radius: layer.background.borderRadius * scaleY,
+            paddingX: layer.background.padding * scaleX,
+            paddingY: layer.background.padding * scaleY,
+          });
+        } else {
+          builder.setPanel({ enabled: false });
+        }
       }
+      // If layer.background is undefined, don't override - let effect definition control it
 
       engineConfig = builder.buildConfig();
     } else {
@@ -433,7 +437,8 @@ function rasterizeTextLayer(ctx: CanvasRenderingContext2D | OffscreenCanvasRende
           return { prefetchingIds: next };
         });
 
-        store.fetchDefinitionOnlyById(layer.styleId)
+        store
+          .fetchDefinitionOnlyById(layer.styleId)
           .then(() => {
             // Once resolved, remove from prefetchingIds (definitions cache is now populated)
             useEffectsStore.setState((s) => {
@@ -441,6 +446,11 @@ function rasterizeTextLayer(ctx: CanvasRenderingContext2D | OffscreenCanvasRende
               next.delete(layer.styleId!);
               return { prefetchingIds: next };
             });
+
+            // Invalidate evaluated scene cache for current epoch and trigger redraw
+            const currentEpoch = useTimelineStore.getState().epoch;
+            invalidateEvaluationCache(currentEpoch);
+            useTimelineStore.getState().incrementEpoch();
           })
           .catch((err) => {
             useEffectsStore.setState((s) => {
@@ -459,6 +469,13 @@ function rasterizeTextLayer(ctx: CanvasRenderingContext2D | OffscreenCanvasRende
         canvasHeight: offH,
         fontSize,
         fontFamily: layer.fontFamily,
+        strokeWidth: layer.stroke ? layer.stroke.width * scaleY : plainConfig.strokeWidth * scaleY,
+        shadowBlur: layer.shadow ? layer.shadow.blur * scaleY : plainConfig.shadowBlur * scaleY,
+        shadowOffsetX: layer.shadow ? layer.shadow.offsetX * scaleX : plainConfig.shadowOffsetX * scaleX,
+        shadowOffsetY: layer.shadow ? layer.shadow.offsetY * scaleY : plainConfig.shadowOffsetY * scaleY,
+        panelRadius: layer.background ? layer.background.borderRadius * scaleY : plainConfig.panelRadius * scaleY,
+        panelPaddingX: layer.background ? layer.background.padding * scaleX : plainConfig.panelPaddingX * scaleX,
+        panelPaddingY: layer.background ? layer.background.padding * scaleY : plainConfig.panelPaddingY * scaleY,
       } as any;
     }
   } else {
@@ -470,6 +487,13 @@ function rasterizeTextLayer(ctx: CanvasRenderingContext2D | OffscreenCanvasRende
       canvasHeight: offH,
       fontSize,
       fontFamily: layer.fontFamily,
+      strokeWidth: layer.stroke ? layer.stroke.width * scaleY : plainConfig.strokeWidth * scaleY,
+      shadowBlur: layer.shadow ? layer.shadow.blur * scaleY : plainConfig.shadowBlur * scaleY,
+      shadowOffsetX: layer.shadow ? layer.shadow.offsetX * scaleX : plainConfig.shadowOffsetX * scaleX,
+      shadowOffsetY: layer.shadow ? layer.shadow.offsetY * scaleY : plainConfig.shadowOffsetY * scaleY,
+      panelRadius: layer.background ? layer.background.borderRadius * scaleY : plainConfig.panelRadius * scaleY,
+      panelPaddingX: layer.background ? layer.background.padding * scaleX : plainConfig.panelPaddingX * scaleX,
+      panelPaddingY: layer.background ? layer.background.padding * scaleY : plainConfig.panelPaddingY * scaleY,
     } as any;
   }
 
@@ -490,7 +514,6 @@ function rasterizeTextLayer(ctx: CanvasRenderingContext2D | OffscreenCanvasRende
 }
 
 // wrapText helper was removed since wrapping is handled natively inside the engine.
-
 
 /**
  * Map blend mode to canvas composite operation.


### PR DESCRIPTION
…izer

Rasterizer Override Logic Fix:
- Don't explicitly disable stroke/shadow/panel when layer properties are undefined
- Only override effect definition properties when user explicitly sets them
- If layer.stroke/shadow/background is undefined, skip override and use effect definition
- This preserves preset styling (panel, stroke, shadow) from the effect definition

SourcePreview Component Fix:
- When adding text effect from preview, only pass styleId and layout properties
- Don't pass undefined stroke/shadow/background that would trigger explicit disabling
- Let effect definition be the source of truth for all styling properties
- Fixes Arctic Monolith effect not showing panel/stroke/padding

This completes the fix for text effect presets not applying correctly when added from the preview panel. Works in conjunction with engine property mapping fixes to ensure full preset fidelity from Studio → API → Editor.