### PR TITLE
fix: remove needless borrow in export.rs write_all call

### DIFF
--- a/src-tauri/src/commands/export.rs
+++ b/src-tauri/src/commands/export.rs
@@ -349,7 +349,7 @@ pub async fn write_export_frame(
     // Write frame data to FFmpeg stdin
     session
         .stdin
-        .write_all(&frame_data)
+        .write_all(frame_data)
         .await
         .map_err(|e| format!("Failed to write frame: {}", e))?;
     


### PR DESCRIPTION
- Fixed clippy warning: clippy::needless_borrow
- Changed .write_all(&frame_data) to .write_all(frame_data)
- Cargo clippy now passes with -D warnings