### PR TITLE
test: fix API mocking after TextEffectsApi rename

### DIFF
--- a/src/components/ui/__tests__/TemplateCard.test.tsx
+++ b/src/components/ui/__tests__/TemplateCard.test.tsx
@@ -9,9 +9,9 @@ vi.mock("@/features/text-templates/LottiePlayer", () => ({
   LottiePlayer: vi.fn(() => <div data-testid="mock-lottie-player" />),
 }));
 
-// Mock ClypraApi
-vi.mock("@/features/text-effects/api/clypraApi", () => ({
-  ClypraApi: {
+// Mock TextEffectsApi
+vi.mock("@/features/text-effects/api/textEffectsApi", () => ({
+  TextEffectsApi: {
     getLottieTemplate: vi.fn(),
   },
 }));

--- a/src/features/text-effects/components/__tests__/EffectGrid.test.tsx
+++ b/src/features/text-effects/components/__tests__/EffectGrid.test.tsx
@@ -7,9 +7,9 @@ import { useUIStore } from "@/store/uiStore";
 import { TextEffectsApi } from "../../api/textEffectsApi";
 import type { TextEffectDefinition } from "../../types/types";
 
-// Mock ClypraApi
-vi.mock("../../api/clypraApi", () => ({
-  ClypraApi: {
+// Mock TextEffectsApi
+vi.mock("../../api/textEffectsApi", () => ({
+  TextEffectsApi: {
     getFullEffect: vi.fn(),
   },
 }));

--- a/src/store/__tests__/projectStore.test.ts
+++ b/src/store/__tests__/projectStore.test.ts
@@ -82,7 +82,7 @@ describe("projectStore", () => {
 
     await useProjectStore.getState().loadProject(project, { tracks, clips, mediaAssets: [] });
 
-    expect(hydrateSpy).toHaveBeenCalledWith({ tracks, clips, transitions: [] });
+    expect(hydrateSpy).toHaveBeenCalledWith({ tracks, clips, transitions: [], gaps: [] });
     expect(useTimelineStore.getState().clips[0]).toMatchObject({ id: "clip-text", styleId: "premium-sticker" });
   });
 });


### PR DESCRIPTION
- Updated mock paths from ClypraApi to TextEffectsApi
- Fixed mock imports in TemplateCard.test.tsx
- Fixed mock imports in EffectGrid.test.tsx
- Updated projectStore test to expect gaps in hydrate call

Fixes 5 out of 8 failing tests. Remaining 3 failures are pre-existing gap management issues unrelated to refactoring.