### PR TITLE
feat: add viral cuts workflow

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5468,9 +5468,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -6557,12 +6557,12 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.4.1",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.4.1.tgz",
-      "integrity": "sha512-NGVYwQSAyEQgzxX1iCM978PP9AdO/hW93gMcF6ZwQCm+rFvLsBH6w4xcXWTcliS8La5EPRN3p9wzItqBwJrfNw==",
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
+      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
       "license": "MIT",
       "dependencies": {
-        "ip-address": "10.1.0"
+        "ip-address": "^10.2.0"
       },
       "engines": {
         "node": ">= 16"
@@ -6635,9 +6635,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "funding": [
         {
           "type": "github",
@@ -7077,9 +7077,9 @@
       "license": "MIT"
     },
     "node_modules/hono": {
-      "version": "4.12.15",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.15.tgz",
-      "integrity": "sha512-qM0jDhFEaCBb4TxoW7f53Qrpv9RBiayUHo0S52JudprkhvpjIrGoU1mnnr29Fvd1U335ZFPZQY1wlkqgfGXyLg==",
+      "version": "4.12.25",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.25.tgz",
+      "integrity": "sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -7230,9 +7230,9 @@
       "license": "ISC"
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -8948,9 +8948,9 @@
       "license": "MIT"
     },
     "node_modules/qs": {
-      "version": "6.15.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
-      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -3,9 +3,11 @@ pub mod project;
 pub mod export;
 pub mod thumbnail;
 pub mod whisper;
+pub mod viral_cuts;
 
 pub use media::*;
 pub use project::*;
 pub use export::*;
 pub use thumbnail::*;
 pub use whisper::*;
+pub use viral_cuts::*;

--- a/src-tauri/src/commands/viral_cuts.rs
+++ b/src-tauri/src/commands/viral_cuts.rs
@@ -1,0 +1,298 @@
+use serde::{Deserialize, Serialize};
+use std::fs;
+use std::path::Path;
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ViralCutAsset {
+    pub id: String,
+    pub name: String,
+    pub path: String,
+    pub duration: f64,
+    pub width: Option<u32>,
+    pub height: Option<u32>,
+    pub size: Option<u64>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ViralCutAnalysisRequest {
+    pub assets: Vec<ViralCutAsset>,
+    pub target_duration: Option<f64>,
+    pub max_suggestions: Option<usize>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ViralCutMetrics {
+    pub position_score: f64,
+    pub duration_score: f64,
+    pub bitrate_score: f64,
+    pub structure_score: f64,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ViralCutSuggestion {
+    pub id: String,
+    pub asset_id: String,
+    pub asset_name: String,
+    pub start: f64,
+    pub end: f64,
+    pub duration: f64,
+    pub score: f64,
+    pub confidence: String,
+    pub title: String,
+    pub reasons: Vec<String>,
+    pub source: String,
+    pub metrics: ViralCutMetrics,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ViralCutAnalysisResult {
+    pub suggestions: Vec<ViralCutSuggestion>,
+    pub analyzed_asset_ids: Vec<String>,
+    pub skipped_asset_ids: Vec<String>,
+    pub generated_at: u64,
+}
+
+const MIN_CUT_DURATION_SECONDS: f64 = 6.0;
+const MAX_CUT_DURATION_SECONDS: f64 = 60.0;
+const DEFAULT_TARGET_DURATION_SECONDS: f64 = 24.0;
+const DEFAULT_MAX_SUGGESTIONS: usize = 12;
+
+fn clamp(value: f64, min: f64, max: f64) -> f64 {
+    value.max(min).min(max)
+}
+
+fn round(value: f64, precision: i32) -> f64 {
+    let factor = 10_f64.powi(precision);
+    (value * factor).round() / factor
+}
+
+fn stable_noise(seed: &str) -> f64 {
+    let mut hash: u32 = 2_166_136_261;
+    for byte in seed.as_bytes() {
+        hash ^= *byte as u32;
+        hash = hash.wrapping_mul(16_777_619);
+    }
+    (hash % 1000) as f64 / 1000.0
+}
+
+fn score_position(start: f64, duration: f64) -> f64 {
+    if duration <= 0.0 {
+        return 0.0;
+    }
+    let progress = start / duration;
+    let opening = (1.0 - progress / 0.18).max(0.0);
+    let payoff = (1.0 - ((progress - 0.68).abs() / 0.22)).max(0.0);
+    let middle = (1.0 - ((progress - 0.36).abs() / 0.24)).max(0.0);
+    clamp(opening.max(payoff * 0.92).max(middle * 0.72), 0.0, 1.0)
+}
+
+fn score_duration(duration: f64, target_duration: f64) -> f64 {
+    clamp(1.0 - ((duration - target_duration).abs() / target_duration), 0.0, 1.0)
+}
+
+fn score_bitrate(asset: &ViralCutAsset) -> f64 {
+    let size = asset.size.or_else(|| fs::metadata(&asset.path).ok().map(|m| m.len()));
+    let Some(size) = size else {
+        return 0.45;
+    };
+    let bytes_per_second = size as f64 / asset.duration.max(1.0);
+    let ten_mbps_bytes_per_second = 10_000_000.0 / 8.0;
+    clamp(bytes_per_second / ten_mbps_bytes_per_second, 0.0, 1.0)
+}
+
+fn score_structure(asset: &ViralCutAsset, start: f64) -> f64 {
+    let is_four_k = asset.width.unwrap_or(0) >= 3000 && asset.height.unwrap_or(0) >= 1600;
+    let name_pulse = stable_noise(&format!("{}:{}", asset.name, (start * 10.0).round()));
+    clamp(if is_four_k { 0.58 } else { 0.38 } + name_pulse * 0.34, 0.0, 1.0)
+}
+
+fn candidate_duration(asset_duration: f64, target_duration: f64) -> f64 {
+    if asset_duration <= MIN_CUT_DURATION_SECONDS {
+        return asset_duration.max(0.0);
+    }
+    if asset_duration < target_duration {
+        return clamp(asset_duration, MIN_CUT_DURATION_SECONDS, target_duration);
+    }
+    if asset_duration >= 600.0 {
+        return clamp(target_duration + 6.0, MIN_CUT_DURATION_SECONDS, MAX_CUT_DURATION_SECONDS);
+    }
+    target_duration
+}
+
+fn candidate_starts(asset_duration: f64, duration: f64) -> Vec<f64> {
+    let max_start = (asset_duration - duration).max(0.0);
+    if max_start <= 0.0 {
+        return vec![0.0];
+    }
+
+    let mut starts: Vec<f64> = [0.0, 0.05, 0.12, 0.22, 0.36, 0.52, 0.68, 0.82, 0.93]
+        .iter()
+        .map(|ratio| (max_start * ratio).round())
+        .collect();
+
+    if asset_duration > 180.0 {
+        let step = if asset_duration > 720.0 { 150.0 } else { 90.0 };
+        let mut cursor = 60.0;
+        while cursor < max_start {
+            starts.push(cursor.round());
+            cursor += step;
+        }
+    }
+
+    starts.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+    starts.dedup_by(|a, b| (*a - *b).abs() < f64::EPSILON);
+    starts.into_iter().take(16).collect()
+}
+
+fn title_for(start: f64, asset_duration: f64, score: f64) -> String {
+    let progress = if asset_duration > 0.0 { start / asset_duration } else { 0.0 };
+    if progress < 0.18 {
+        "Opening hook candidate".to_string()
+    } else if progress > 0.58 {
+        if score >= 0.78 {
+            "Payoff moment candidate".to_string()
+        } else {
+            "Late highlight candidate".to_string()
+        }
+    } else {
+        "Mid-video lift candidate".to_string()
+    }
+}
+
+fn confidence_for(score: f64) -> String {
+    if score >= 0.78 {
+        "high".to_string()
+    } else if score >= 0.62 {
+        "medium".to_string()
+    } else {
+        "low".to_string()
+    }
+}
+
+fn reasons_for(start: f64, asset: &ViralCutAsset, duration_score: f64, bitrate_score: f64, structure_score: f64) -> Vec<String> {
+    let progress = if asset.duration > 0.0 { start / asset.duration } else { 0.0 };
+    let mut reasons = Vec::new();
+
+    if progress < 0.18 {
+        reasons.push("early hook".to_string());
+    }
+    if progress > 0.58 {
+        reasons.push("late payoff".to_string());
+    }
+    if duration_score > 0.82 {
+        reasons.push("short-form length".to_string());
+    }
+    if bitrate_score > 0.66 {
+        reasons.push("high-detail source".to_string());
+    }
+    if structure_score > 0.68 {
+        reasons.push("strong visual candidate".to_string());
+    }
+
+    reasons.truncate(3);
+    reasons
+}
+
+#[tauri::command]
+pub async fn analyze_viral_cuts(request: ViralCutAnalysisRequest) -> Result<ViralCutAnalysisResult, String> {
+    if request.assets.len() > 200 {
+        return Err("Too many assets for one analysis pass".to_string());
+    }
+
+    let target_duration = clamp(
+        request.target_duration.unwrap_or(DEFAULT_TARGET_DURATION_SECONDS),
+        MIN_CUT_DURATION_SECONDS,
+        MAX_CUT_DURATION_SECONDS,
+    );
+    let max_suggestions = request.max_suggestions.unwrap_or(DEFAULT_MAX_SUGGESTIONS).clamp(1, 50);
+    let mut suggestions = Vec::new();
+    let mut analyzed_asset_ids = Vec::new();
+    let mut skipped_asset_ids = Vec::new();
+
+    for asset in &request.assets {
+        if asset.path.len() > 4096 || !Path::new(&asset.path).exists() {
+            skipped_asset_ids.push(asset.id.clone());
+            continue;
+        }
+        if !asset.duration.is_finite() || asset.duration < 1.0 {
+            skipped_asset_ids.push(asset.id.clone());
+            continue;
+        }
+
+        analyzed_asset_ids.push(asset.id.clone());
+        let cut_duration = candidate_duration(asset.duration, target_duration);
+
+        for start in candidate_starts(asset.duration, cut_duration) {
+            let end = clamp(start + cut_duration, start, asset.duration);
+            let duration = end - start;
+            if duration < MIN_CUT_DURATION_SECONDS.min(asset.duration) {
+                continue;
+            }
+
+            let position_score = score_position(start, asset.duration);
+            let duration_score = score_duration(duration, target_duration);
+            let bitrate_score = score_bitrate(asset);
+            let structure_score = score_structure(asset, start);
+            let score = clamp(
+                position_score * 0.36 + duration_score * 0.26 + bitrate_score * 0.18 + structure_score * 0.2,
+                0.0,
+                1.0,
+            );
+
+            suggestions.push(ViralCutSuggestion {
+                id: format!("viral-{}-{}-{}", asset.id, (start * 100.0).round(), (end * 100.0).round()),
+                asset_id: asset.id.clone(),
+                asset_name: asset.name.clone(),
+                start: round(start, 3),
+                end: round(end, 3),
+                duration: round(duration, 3),
+                score: round(score, 4),
+                confidence: confidence_for(score),
+                title: title_for(start, asset.duration, score),
+                reasons: reasons_for(start, asset, duration_score, bitrate_score, structure_score),
+                source: "native".to_string(),
+                metrics: ViralCutMetrics {
+                    position_score: round(position_score, 4),
+                    duration_score: round(duration_score, 4),
+                    bitrate_score: round(bitrate_score, 4),
+                    structure_score: round(structure_score, 4),
+                },
+            });
+        }
+    }
+
+    suggestions.sort_by(|a, b| {
+        b.score
+            .partial_cmp(&a.score)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then_with(|| b.duration.partial_cmp(&a.duration).unwrap_or(std::cmp::Ordering::Equal))
+    });
+
+    let mut per_asset_count = std::collections::HashMap::<String, usize>::new();
+    suggestions.retain(|suggestion| {
+        let count = per_asset_count.entry(suggestion.asset_id.clone()).or_insert(0);
+        if *count >= 3 {
+            return false;
+        }
+        *count += 1;
+        true
+    });
+    suggestions.truncate(max_suggestions);
+
+    let generated_at = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as u64;
+
+    Ok(ViralCutAnalysisResult {
+        suggestions,
+        analyzed_asset_ids,
+        skipped_asset_ids,
+        generated_at,
+    })
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -75,6 +75,7 @@ pub fn run() {
             list_downloaded_models,
             cancel_whisper_download,
             verify_whisper_model_exists,
+            analyze_viral_cuts,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 // Deprecated methods used across the system
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { LaunchScreen } from "@/components/screens/LaunchScreen";
 import { EditorScreen } from "@/components/screens/EditorScreen";
 import { TooltipProvider } from "@/components/ui/Tooltip";
@@ -13,7 +13,7 @@ import { SettingsModal } from "./components/ui/SettingsModal";
 const isExternalOrDataUrl = (value: string) => value.startsWith("data:") || value.startsWith("http") || value.startsWith("asset://");
 
 const App = () => {
-  const { project, createProject, loadProject, setRecentProjects } = useProjectStore();
+  const { project, createProject, loadProject, recentProjects, setRecentProjects } = useProjectStore();
   const [isLoading, setIsLoading] = useState(true);
   const { showSettingsModal, toggleSettingsModal } = useUIStore();
 
@@ -66,7 +66,7 @@ const App = () => {
     createProject(name, aspectRatio, frameRate);
   };
 
-  const handleOpenProject = async (proj: Project) => {
+  const handleOpenProject = useCallback(async (proj: Project) => {
     try {
       useUIStore.getState().exitSourceMode();
 
@@ -112,7 +112,28 @@ const App = () => {
       console.error("[OpenProject] Failed to open project:", error);
       useProjectStore.getState().showToast("Failed to open project", "error");
     }
-  };
+  }, [loadProject]);
+
+  useEffect(() => {
+    if (isLoading || project) return;
+
+    const params = new URLSearchParams(window.location.search);
+    const projectId = params.get("openProject") || sessionStorage.getItem("clypra_open_project_after_seed");
+    if (!projectId) return;
+
+    const targetProject = recentProjects.find((recentProject) => recentProject.id === projectId);
+    if (!targetProject) return;
+
+    sessionStorage.removeItem("clypra_open_project_after_seed");
+
+    if (params.has("openProject")) {
+      params.delete("openProject");
+      const nextQuery = params.toString();
+      window.history.replaceState(null, "", `${window.location.pathname}${nextQuery ? `?${nextQuery}` : ""}${window.location.hash}`);
+    }
+
+    void handleOpenProject(targetProject);
+  }, [handleOpenProject, isLoading, project, recentProjects]);
 
   if (isLoading) {
     return (

--- a/src/components/editor/EditorLayout.tsx
+++ b/src/components/editor/EditorLayout.tsx
@@ -29,6 +29,10 @@ export const EditorLayout: React.FC = () => {
     return <MobileEditorLayout />;
   }
 
+  return <DesktopEditorLayout />;
+};
+
+const DesktopEditorLayout: React.FC = () => {
   // Only subscribe to actions, not state - prevents re-renders when clips/tracks change
   const addClip = useTimelineStore((s) => s.addClip);
   const updateClip = useTimelineStore((s) => s.updateClip);

--- a/src/components/editor/media-panel/EnhancedMediaPanel.tsx
+++ b/src/components/editor/media-panel/EnhancedMediaPanel.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
-import { Music, Smile, Wand2, MessageSquare, Filter, Shuffle } from "lucide-react";
-import { MediaTab, AudioTab, TextTab, StickersTab, FiltersTab, TransitionsTab, CaptionsTab, type TabType, MediaTabProps } from "../media-tabs";
+import { Music, Smile, Wand2, MessageSquare, Filter, Shuffle, Scissors } from "lucide-react";
+import { MediaTab, ViralCutsTab, AudioTab, TextTab, StickersTab, FiltersTab, TransitionsTab, CaptionsTab, type TabType, MediaTabProps } from "../media-tabs";
 import { EffectsPanel } from "@/features/video-effects/components/EffectsPanel";
 import { TextIcon, YouTubeIcon } from "../../ui/icons";
 
@@ -13,6 +13,7 @@ export const EnhancedMediaPanel: React.FC<MediaTabProps> = ({ onAddToTimeline, i
 
   const tabs = [
     { id: "media" as const, icon: YouTubeIcon, label: "Media" },
+    { id: "cuts" as const, icon: Scissors, label: "Cuts" },
     { id: "audio" as const, icon: Music, label: "Audio" },
     { id: "text" as const, icon: TextIcon, label: "Text" },
     { id: "stickers" as const, icon: Smile, label: "Stickers" },
@@ -49,6 +50,7 @@ export const EnhancedMediaPanel: React.FC<MediaTabProps> = ({ onAddToTimeline, i
       {/* Tab Content */}
       <div className="flex-1 overflow-hidden flex flex-col">
         {activeTab === "media" && <MediaTab onAddToTimeline={onAddToTimeline} />}
+        {activeTab === "cuts" && <ViralCutsTab />}
         {activeTab === "audio" && <AudioTab onAddToTimeline={onAddToTimeline} />}
         {activeTab === "text" && <TextTab onAddToTimeline={onAddToTimeline} />}
         {activeTab === "stickers" && <StickersTab onAddToTimeline={onAddToTimeline} />}

--- a/src/components/editor/media-tabs/MediaTab.tsx
+++ b/src/components/editor/media-tabs/MediaTab.tsx
@@ -1,7 +1,5 @@
 import React, { useState, useCallback, useMemo } from "react";
 import { CloudUpload } from "lucide-react";
-import { invoke } from "@tauri-apps/api/core";
-import { convertFileSrc } from "@tauri-apps/api/core";
 
 import { Button } from "@/components/ui/Button";
 import { EmptyState } from "@/components/ui/EmptyState";
@@ -15,11 +13,12 @@ import { useHistoryStore } from "@/store/historyStore";
 import { useSettingsStore } from "@/store/settingsStore";
 import { RippleDeleteCommand } from "@/core/history/commands/RippleDeleteCommand";
 import { DeleteClipCommand } from "@/core/history/commands/DeleteClipCommand";
-import type { VideoMetadata } from "@/types";
+import type { VideoMetadata } from "@/core/platform";
 import type { MediaTabProps } from "./types";
 import { generateId } from "@/lib/utils/id";
 import { SuccessToast } from "@/components/ui/SuccessToast";
 import { MediaCard } from "@/components/ui/MediaCard";
+import { platform } from "@/core/platform";
 
 export const MediaTab: React.FC<MediaTabProps> = ({ onAddToTimeline }) => {
   const { mediaAssets, removeMediaAsset, addMediaAsset } = useProjectStore();
@@ -57,9 +56,9 @@ export const MediaTab: React.FC<MediaTabProps> = ({ onAddToTimeline }) => {
 
           // Import new asset
           if (type === "video" || type === "audio") {
-            const metadata: VideoMetadata = await invoke("get_video_metadata", { path: filePath });
+            const metadata: VideoMetadata = await platform.getMediaMetadata(filePath);
             // Use extract_poster_frame_command which extracts at 10% of duration (avoids black frames at 0s)
-            const posterFrame: string | undefined = type === "video" ? ((await invoke("extract_poster_frame_command", { videoPath: filePath, duration: metadata.duration, dpr: window.devicePixelRatio || 1.0 }).catch(() => undefined)) as string | undefined) : undefined;
+            const posterFrame: string | undefined = type === "video" ? await platform.extractPosterFrame(filePath, metadata.duration, window.devicePixelRatio || 1.0).catch(() => undefined) : undefined;
 
             const asset = {
               id: generateId("asset"),
@@ -70,7 +69,7 @@ export const MediaTab: React.FC<MediaTabProps> = ({ onAddToTimeline }) => {
               width: metadata.width,
               height: metadata.height,
               posterFrame,
-              size: metadata.size,
+              size: (metadata as any).size ?? 0,
             };
 
             addMediaAsset(asset);
@@ -82,7 +81,7 @@ export const MediaTab: React.FC<MediaTabProps> = ({ onAddToTimeline }) => {
               type: "image" as const,
               duration: 0,
               size: 0,
-              posterFrame: convertFileSrc(filePath),
+              posterFrame: platform.convertFileSrc(filePath),
             };
 
             addMediaAsset(asset);

--- a/src/components/editor/media-tabs/ViralCutsTab.tsx
+++ b/src/components/editor/media-tabs/ViralCutsTab.tsx
@@ -1,0 +1,210 @@
+import React, { useMemo, useState } from "react";
+import { BadgeCheck, Loader2, Play, Plus, RefreshCw, Scissors, X } from "lucide-react";
+import { Button } from "@/components/ui/Button";
+import { EmptyState } from "@/components/ui/EmptyState";
+import { getInsertIndexForNewTrack, useTimelineStore } from "@/store/timelineStore";
+import { useProjectStore } from "@/store/projectStore";
+import { useUIStore } from "@/store/uiStore";
+import { getActiveSessionOrNull } from "@/core/runtime/ProjectSession";
+import { formatTime } from "@/lib/utils/timeFormatting";
+import { autoAdaptSequenceForFirstVisualClip } from "@/lib/sequence/sequenceAutoAspect";
+import { analyzeViralCuts, createViralCutClip, findUsableVideoTrack, mediaAssetToViralCutAsset, useViralCutsStore } from "@/features/viral-cuts";
+import type { MediaAsset } from "@/types";
+
+const scoreLabel = (score: number) => `${Math.round(score * 100)}%`;
+
+export const ViralCutsTab: React.FC = () => {
+  const { mediaAssets, project, updateProject, showToast } = useProjectStore();
+  const { tracks, clips, addClip, insertTrackAt, getTimelineEndTime } = useTimelineStore();
+  const { setPreviewMedia, previewAsset, markSourceIn, markSourceOut } = useUIStore();
+  const { status, suggestions, error, dismissedIds, insertedIds, setAnalyzing, setResults, setError, dismissSuggestion, markInserted } = useViralCutsStore();
+  const [targetDuration, setTargetDuration] = useState(24);
+
+  const videoAssets = useMemo(() => mediaAssets.filter((asset) => asset.type === "video" && asset.duration > 0), [mediaAssets]);
+  const visibleSuggestions = useMemo(() => suggestions.filter((suggestion) => !dismissedIds.includes(suggestion.id)), [dismissedIds, suggestions]);
+
+  const runAnalysis = async () => {
+    if (videoAssets.length === 0) {
+      showToast("No video assets to analyze", "warning");
+      return;
+    }
+
+    setAnalyzing();
+    try {
+      const result = await analyzeViralCuts({
+        assets: videoAssets.map(mediaAssetToViralCutAsset),
+        targetDuration,
+        maxSuggestions: 18,
+      });
+      setResults(result.suggestions);
+      showToast(`Found ${result.suggestions.length} cut candidates`);
+    } catch (analysisError) {
+      console.error("[ViralCutsTab] Analysis failed:", analysisError);
+      setError("Analysis failed");
+      showToast("Analysis failed", "error");
+    }
+  };
+
+  const getAsset = (assetId: string): MediaAsset | undefined => mediaAssets.find((asset) => asset.id === assetId);
+
+  const previewSuggestion = (suggestion: (typeof suggestions)[number]) => {
+    const asset = getAsset(suggestion.assetId);
+    if (!asset) return;
+
+    setPreviewMedia(asset.id);
+    previewAsset(asset);
+    markSourceIn(suggestion.start);
+    markSourceOut(suggestion.end);
+    getActiveSessionOrNull()?.transportAuthority?.setActiveContext("source");
+  };
+
+  const insertSuggestion = (suggestion: (typeof suggestions)[number], startTime?: number) => {
+    const asset = getAsset(suggestion.assetId);
+    if (!asset || !project) return;
+
+    const latestTracks = useTimelineStore.getState().tracks;
+    let trackId = findUsableVideoTrack(latestTracks);
+    if (!trackId) {
+      trackId = insertTrackAt("video", getInsertIndexForNewTrack(latestTracks, "video"));
+    }
+    if (!trackId) return;
+
+    if (clips.length === 0) {
+      autoAdaptSequenceForFirstVisualClip({
+        project,
+        existingClips: clips,
+        asset,
+        updateProject,
+      });
+    }
+
+    const nextProject = useProjectStore.getState().project ?? project;
+    const clip = createViralCutClip({
+      suggestion,
+      asset,
+      trackId,
+      startTime: startTime ?? getTimelineEndTime(),
+      project: {
+        canvasWidth: nextProject.canvasWidth,
+        canvasHeight: nextProject.canvasHeight,
+      },
+    });
+
+    addClip(clip);
+    markInserted(suggestion.id);
+    showToast("Cut inserted");
+  };
+
+  const insertTopCuts = () => {
+    if (!project) return;
+    let nextStart = getTimelineEndTime();
+    visibleSuggestions.slice(0, 3).forEach((suggestion) => {
+      insertSuggestion(suggestion, nextStart);
+      nextStart += suggestion.duration;
+    });
+  };
+
+  return (
+    <div className="flex-1 flex flex-col min-h-0 overflow-hidden">
+      <div className="p-2 border-b border-border space-y-2">
+        <div className="flex items-center gap-2">
+          <Button variant="secondary" size="sm" className="flex-1" onClick={runAnalysis} disabled={status === "analyzing" || videoAssets.length === 0}>
+            {status === "analyzing" ? <Loader2 className="w-4 h-4 animate-spin" /> : <Scissors className="w-4 h-4" />}
+            Find Cuts
+          </Button>
+          <Button variant="ghost" size="icon-sm" title="Refresh" onClick={runAnalysis} disabled={status === "analyzing" || videoAssets.length === 0}>
+            <RefreshCw className="w-4 h-4" />
+          </Button>
+        </div>
+
+        <div className="flex items-center gap-2 text-[11px] text-text-muted">
+          <span className="shrink-0">Length</span>
+          <input
+            type="range"
+            min={12}
+            max={45}
+            step={3}
+            value={targetDuration}
+            onChange={(event) => setTargetDuration(Number(event.target.value))}
+            className="min-w-0 flex-1 accent-accent"
+            aria-label="Target cut length"
+          />
+          <span className="w-8 text-right tabular-nums">{targetDuration}s</span>
+        </div>
+
+        {visibleSuggestions.length > 0 && (
+          <Button variant="default" size="sm" className="w-full" onClick={insertTopCuts}>
+            <Plus className="w-4 h-4" />
+            Insert Top 3
+          </Button>
+        )}
+      </div>
+
+      <div className="flex-1 overflow-y-auto scrollbar-thin">
+        {videoAssets.length === 0 ? (
+          <EmptyState icon={Scissors} title="No video media" />
+        ) : status === "error" ? (
+          <EmptyState icon={Scissors} title={error ?? "Analysis failed"} />
+        ) : visibleSuggestions.length === 0 ? (
+          <EmptyState icon={Scissors} title={status === "analyzing" ? "Analyzing" : "No cuts yet"} />
+        ) : (
+          <div className="p-2 space-y-2">
+            {visibleSuggestions.map((suggestion) => {
+              const inserted = insertedIds.includes(suggestion.id);
+              return (
+                <div key={suggestion.id} className="rounded-md border border-border bg-surface-raised overflow-hidden">
+                  <div className="p-2 space-y-2">
+                    <div className="flex items-start justify-between gap-2">
+                      <div className="min-w-0">
+                        <div className="flex items-center gap-1.5">
+                          <span className="text-[12px] font-semibold text-text-primary truncate">{suggestion.title}</span>
+                          {inserted && <BadgeCheck className="w-3.5 h-3.5 text-accent shrink-0" />}
+                        </div>
+                        <p className="text-[10px] text-text-muted truncate">{suggestion.assetName}</p>
+                      </div>
+                      <div className="shrink-0 text-right">
+                        <div className="text-[12px] font-semibold text-accent tabular-nums">{scoreLabel(suggestion.score)}</div>
+                        <div className="text-[9px] uppercase text-text-muted">{suggestion.confidence}</div>
+                      </div>
+                    </div>
+
+                    <div className="flex items-center justify-between gap-2 text-[10px] text-text-muted">
+                      <span className="font-mono tabular-nums">
+                        {formatTime(suggestion.start)} - {formatTime(suggestion.end)}
+                      </span>
+                      <span className="font-mono tabular-nums">{formatTime(suggestion.duration)}</span>
+                    </div>
+
+                    {suggestion.reasons.length > 0 && (
+                      <div className="flex flex-wrap gap-1">
+                        {suggestion.reasons.map((reason) => (
+                          <span key={reason} className="px-1.5 py-0.5 rounded bg-bg text-[9px] text-text-muted">
+                            {reason}
+                          </span>
+                        ))}
+                      </div>
+                    )}
+
+                    <div className="flex items-center gap-1">
+                      <Button variant="secondary" size="xs" className="flex-1" onClick={() => previewSuggestion(suggestion)}>
+                        <Play className="w-3 h-3" />
+                        Preview
+                      </Button>
+                      <Button variant="default" size="xs" className="flex-1" onClick={() => insertSuggestion(suggestion)} disabled={inserted}>
+                        <Plus className="w-3 h-3" />
+                        {inserted ? "Inserted" : "Insert"}
+                      </Button>
+                      <Button variant="ghost" size="icon-xs" title="Dismiss" onClick={() => dismissSuggestion(suggestion.id)}>
+                        <X className="w-3 h-3" />
+                      </Button>
+                    </div>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/src/components/editor/media-tabs/index.ts
+++ b/src/components/editor/media-tabs/index.ts
@@ -1,4 +1,5 @@
 export { MediaTab } from "./MediaTab";
+export { ViralCutsTab } from "./ViralCutsTab";
 export { AudioTab } from "./AudioTab";
 export { TextTab } from "./TextTab";
 export { StickersTab } from "./StickersTab";

--- a/src/components/editor/media-tabs/types.ts
+++ b/src/components/editor/media-tabs/types.ts
@@ -1,4 +1,4 @@
-export type TabType = "media" | "audio" | "text" | "stickers" | "effects" | "filters" | "transitions" | "captions" | "video-effects" | "body-effects" | "animated-overlays";
+export type TabType = "media" | "cuts" | "audio" | "text" | "stickers" | "effects" | "filters" | "transitions" | "captions" | "video-effects" | "body-effects" | "animated-overlays";
 
 export interface TabProps {
   onAddToTimeline?: (item: any, type: TabType) => void;

--- a/src/components/editor/preview/SourcePreview.tsx
+++ b/src/components/editor/preview/SourcePreview.tsx
@@ -1,6 +1,6 @@
 import React, { useRef, useState, useEffect, useCallback, useMemo } from "react";
 import { Plus, X, RotateCcw, Play, Loader2 } from "lucide-react";
-import { convertFileSrc } from "@tauri-apps/api/core";
+import { platform } from "@/core/platform";
 import { useUIStore } from "@/store/uiStore";
 import { usePreviewMode } from "@/hooks/usePreviewMode";
 import { getInsertIndexForNewTrack, useTimelineStore } from "@/store/timelineStore";
@@ -21,7 +21,7 @@ import { useEffectsStore } from "@/features/text-effects/store/effectsStore";
 import { TemplatePreviewPlayer, type TemplatePreviewPlayerHandle } from "@/features/text-templates";
 import { useStickersStore } from "@/features/stickers/store/stickersStore";
 
-const isExternalOrDataUrl = (value: string) => value.startsWith("data:") || value.startsWith("http") || value.startsWith("asset://");
+const isExternalOrDataUrl = (value: string) => value.startsWith("data:") || value.startsWith("http://") || value.startsWith("https://") || value.startsWith("asset://") || value.startsWith("blob:");
 
 // GPU preview for scrubbing only (precise frame-accurate seeking)
 // Use HTML5 video for playback (hardware decode, buffering, smooth playback)
@@ -441,7 +441,7 @@ export const SourcePreview: React.FC = () => {
   const hasMarks = sourceInPoint !== null || sourceOutPoint !== null;
   const hasCompleteMarks = sourceInPoint !== null && sourceOutPoint !== null;
 
-  const sourcePath = sourceAsset.path ? (isExternalOrDataUrl(sourceAsset.path) ? sourceAsset.path : convertFileSrc(sourceAsset.path)) : "";
+  const sourcePath = sourceAsset.path ? (isExternalOrDataUrl(sourceAsset.path) ? sourceAsset.path : platform.convertFileSrc(sourceAsset.path)) : "";
   const mediaLabel = sourceAsset.type === "video" ? "video" : sourceAsset.type === "audio" ? "audio" : sourceAsset.type === "text" ? "text" : "image";
 
   return (

--- a/src/core/evaluation/evaluator.ts
+++ b/src/core/evaluation/evaluator.ts
@@ -21,9 +21,9 @@ import type { Clip, Track, MediaAsset, Project, TextClip, TransitionTimelineItem
 import type { EvaluatedScene, EvaluatedVisualLayer, EvaluatedMediaLayer, EvaluatedTextLayer, EvaluatedAudioLayer, EvaluatedTransition, SceneMetadata, BlendMode } from "./types";
 import { toCompositorClips } from "../timeline/adapter";
 import { getClipEndTime } from "@/lib/timeline/timelineClip";
-import { convertFileSrc } from "@tauri-apps/api/core";
+import { platform } from "@/core/platform";
 
-const isExternalOrDataUrl = (value: string) => value.startsWith("data:") || value.startsWith("http") || value.startsWith("asset://");
+const isExternalOrDataUrl = (value: string) => value.startsWith("data:") || value.startsWith("http://") || value.startsWith("https://") || value.startsWith("asset://") || value.startsWith("blob:");
 import { getEvaluationCache, computeClipVersion } from "./cache";
 import { evaluateProperty } from "./animation";
 import { resolveClipSourceTime } from "../timeline/sourceTime";
@@ -229,7 +229,7 @@ export function evaluateTimelineScene(time: number, clips: Clip[], tracks: Track
       clampToRange: true,
       frameRate: project?.frameRate ?? 30,
     }).sourceTime;
-    const sourcePath = asset.path ? (isExternalOrDataUrl(asset.path) ? asset.path : convertFileSrc(asset.path)) : asset.posterFrame || "";
+    const sourcePath = asset.path ? (isExternalOrDataUrl(asset.path) ? asset.path : platform.convertFileSrc(asset.path)) : asset.posterFrame || "";
     if (!sourcePath) continue;
 
     const transitionState = evaluateTransitionState(clip, transitionWindows);
@@ -303,7 +303,7 @@ export function evaluateTimelineScene(time: number, clips: Clip[], tracks: Track
       clampToRange: true,
       frameRate: project?.frameRate ?? 30,
     }).sourceTime;
-    const sourcePath = asset.path ? (isExternalOrDataUrl(asset.path) ? asset.path : convertFileSrc(asset.path)) : "";
+    const sourcePath = asset.path ? (isExternalOrDataUrl(asset.path) ? asset.path : platform.convertFileSrc(asset.path)) : "";
     if (!sourcePath) continue;
 
     audioLayers.push({

--- a/src/core/platform/adapters/tauriAdapter.ts
+++ b/src/core/platform/adapters/tauriAdapter.ts
@@ -1,7 +1,8 @@
 import { convertFileSrc } from "@tauri-apps/api/core";
 import { PlatformInterface, VideoMetadata, SelectedFile } from "../platform";
 
-const isExternalOrDataUrl = (value: string) => value.startsWith("data:") || value.startsWith("http") || value.startsWith("asset://") || value.startsWith("https://");
+const isExternalOrDataUrl = (value: string) =>
+  value.startsWith("data:") || value.startsWith("http://") || value.startsWith("https://") || value.startsWith("asset://");
 
 export class TauriPlatformAdapter implements PlatformInterface {
   type = "tauri" as const;

--- a/src/core/resources/PreviewMediaPool.ts
+++ b/src/core/resources/PreviewMediaPool.ts
@@ -16,7 +16,10 @@
  */
 
 import type { Clip, MediaAsset } from "@/types";
-import { convertFileSrc } from "@tauri-apps/api/core";
+import { platform } from "@/core/platform";
+
+const isExternalOrDataUrl = (value: string) => value.startsWith("data:") || value.startsWith("http://") || value.startsWith("https://") || value.startsWith("asset://") || value.startsWith("blob:");
+const toMediaElementSrc = (value: string) => (isExternalOrDataUrl(value) ? value : platform.convertFileSrc(value));
 
 export interface PreviewSyncState {
   /** Current playback time (seconds) */
@@ -171,7 +174,7 @@ export class PreviewMediaPool {
       if (track?.visible === false) continue;
 
       const key = `${clip.id}-${clip.mediaId}`;
-      const sourcePath = asset.path.startsWith("asset://") ? asset.path : convertFileSrc(asset.path);
+      const sourcePath = toMediaElementSrc(asset.path);
 
       let managed = this.videos.get(key);
       if (!managed) {
@@ -201,7 +204,7 @@ export class PreviewMediaPool {
 
       const rawPath = asset ? asset.path : directAudioPath!;
       const key = `${clip.id}-${clip.mediaId}`;
-      const sourcePath = rawPath.startsWith("asset://") ? rawPath : convertFileSrc(rawPath);
+      const sourcePath = toMediaElementSrc(rawPath);
 
       let managed = this.audios.get(key);
       if (!managed) {

--- a/src/features/viral-cuts/__tests__/applySuggestion.test.ts
+++ b/src/features/viral-cuts/__tests__/applySuggestion.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { createViralCutClip } from "../applySuggestion";
+import type { MediaAsset } from "@/types";
+import type { ViralCutSuggestion } from "../types";
+
+describe("createViralCutClip", () => {
+  it("creates a trimmed timeline clip from a suggestion", () => {
+    const asset: MediaAsset = {
+      id: "asset-1",
+      name: "source.mp4",
+      path: "/source.mp4",
+      type: "video",
+      duration: 120,
+      width: 3840,
+      height: 2160,
+      size: 1000,
+    };
+    const suggestion: ViralCutSuggestion = {
+      id: "viral-1",
+      assetId: asset.id,
+      assetName: asset.name,
+      start: 12,
+      end: 36,
+      duration: 24,
+      score: 0.8,
+      confidence: "high",
+      title: "Opening hook candidate",
+      reasons: ["early hook"],
+      source: "heuristic",
+      metrics: { positionScore: 1, durationScore: 1, bitrateScore: 0.4, structureScore: 0.7 },
+    };
+
+    const clip = createViralCutClip({
+      suggestion,
+      asset,
+      trackId: "track-1",
+      startTime: 5,
+      project: { canvasWidth: 1080, canvasHeight: 1920 },
+    });
+
+    expect(clip.mediaId).toBe(asset.id);
+    expect(clip.trackId).toBe("track-1");
+    expect(clip.startTime).toBe(5);
+    expect(clip.trimIn).toBe(12);
+    expect(clip.trimOut).toBe(36);
+    expect(clip.duration).toBe(24);
+  });
+});

--- a/src/features/viral-cuts/__tests__/scoring.test.ts
+++ b/src/features/viral-cuts/__tests__/scoring.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it, vi } from "vitest";
+import { analyzeViralCutsHeuristic } from "../scoring";
+
+describe("analyzeViralCutsHeuristic", () => {
+  it("ranks bounded suggestions for long video assets", () => {
+    vi.setSystemTime(new Date("2026-06-12T00:00:00Z"));
+
+    const result = analyzeViralCutsHeuristic({
+      maxSuggestions: 4,
+      targetDuration: 24,
+      assets: [
+        {
+          id: "asset-long",
+          name: "20260523150028_000015.MP4",
+          path: "/Volumes/NO NAME/DCIM/MOVIE/20260523150028_000015.MP4",
+          duration: 900,
+          width: 3840,
+          height: 2160,
+          size: 2_413_761_911,
+        },
+      ],
+    });
+
+    expect(result.analyzedAssetIds).toEqual(["asset-long"]);
+    expect(result.suggestions).toHaveLength(3);
+    expect(result.suggestions[0].start).toBeGreaterThanOrEqual(0);
+    expect(result.suggestions[0].end).toBeLessThanOrEqual(900);
+    expect(result.suggestions[0].duration).toBeGreaterThanOrEqual(6);
+    expect(result.suggestions[0].score).toBeGreaterThan(0.5);
+  });
+
+  it("skips assets without usable duration", () => {
+    const result = analyzeViralCutsHeuristic({
+      assets: [{ id: "broken", name: "broken.mp4", path: "/broken.mp4", duration: 0 }],
+    });
+
+    expect(result.suggestions).toEqual([]);
+    expect(result.skippedAssetIds).toEqual(["broken"]);
+  });
+});

--- a/src/features/viral-cuts/analyzer.ts
+++ b/src/features/viral-cuts/analyzer.ts
@@ -1,0 +1,40 @@
+import { invoke } from "@tauri-apps/api/core";
+import { platform } from "@/core/platform";
+import { analyzeViralCutsHeuristic } from "./scoring";
+import type { ViralCutAnalysisRequest, ViralCutAnalysisResult, ViralCutSuggestion } from "./types";
+
+const normalizeSuggestion = (suggestion: ViralCutSuggestion): ViralCutSuggestion => ({
+  ...suggestion,
+  start: Math.max(0, Number(suggestion.start) || 0),
+  end: Math.max(Number(suggestion.start) || 0, Number(suggestion.end) || 0),
+  duration: Math.max(0, Number(suggestion.duration) || Number(suggestion.end) - Number(suggestion.start) || 0),
+  score: Math.max(0, Math.min(1, Number(suggestion.score) || 0)),
+  confidence: suggestion.confidence ?? "medium",
+  reasons: Array.isArray(suggestion.reasons) ? suggestion.reasons.slice(0, 4) : [],
+  source: suggestion.source ?? "native",
+  metrics: suggestion.metrics ?? {
+    positionScore: 0,
+    durationScore: 0,
+    bitrateScore: 0,
+    structureScore: 0,
+  },
+});
+
+export async function analyzeViralCuts(request: ViralCutAnalysisRequest): Promise<ViralCutAnalysisResult> {
+  if (platform.isTauri()) {
+    try {
+      const native = await invoke<ViralCutAnalysisResult>("analyze_viral_cuts", { request });
+      if (native?.suggestions?.length) {
+        return {
+          ...native,
+          suggestions: native.suggestions.map(normalizeSuggestion),
+          generatedAt: native.generatedAt ?? Date.now(),
+        };
+      }
+    } catch (error) {
+      console.warn("[viral-cuts] Native analysis failed, using heuristic fallback:", error);
+    }
+  }
+
+  return analyzeViralCutsHeuristic(request);
+}

--- a/src/features/viral-cuts/applySuggestion.ts
+++ b/src/features/viral-cuts/applySuggestion.ts
@@ -1,0 +1,34 @@
+import type { Clip, MediaAsset, Project, Track } from "@/types";
+import { createClipFromAsset } from "@/lib/timeline/timelineClip";
+import { resolveDefaultFitModeForAsset } from "@/lib/timeline/placementPolicy";
+import type { ViralCutSuggestion } from "./types";
+
+interface CreateViralCutClipParams {
+  suggestion: ViralCutSuggestion;
+  asset: MediaAsset;
+  trackId: string;
+  startTime: number;
+  project: Pick<Project, "canvasWidth" | "canvasHeight">;
+}
+
+export const createViralCutClip = ({ suggestion, asset, trackId, startTime, project }: CreateViralCutClipParams): Clip => {
+  const trimIn = Math.max(0, Math.min(suggestion.start, asset.duration));
+  const trimOut = Math.max(trimIn, Math.min(suggestion.end, asset.duration));
+  const clip = createClipFromAsset({
+    asset,
+    trackId,
+    startTime,
+    width: project.canvasWidth,
+    height: project.canvasHeight,
+    fitMode: resolveDefaultFitModeForAsset(asset),
+  });
+
+  return {
+    ...clip,
+    trimIn,
+    trimOut,
+    duration: Math.max(0, trimOut - trimIn),
+  };
+};
+
+export const findUsableVideoTrack = (tracks: Track[]) => tracks.find((track) => track.type === "video" && !track.locked)?.id ?? null;

--- a/src/features/viral-cuts/index.ts
+++ b/src/features/viral-cuts/index.ts
@@ -1,0 +1,5 @@
+export * from "./analyzer";
+export * from "./applySuggestion";
+export * from "./scoring";
+export * from "./store";
+export * from "./types";

--- a/src/features/viral-cuts/scoring.ts
+++ b/src/features/viral-cuts/scoring.ts
@@ -1,0 +1,176 @@
+import type { ViralCutAnalysisRequest, ViralCutAnalysisResult, ViralCutAsset, ViralCutSuggestion } from "./types";
+
+const DEFAULT_TARGET_DURATION_SECONDS = 24;
+const DEFAULT_MAX_SUGGESTIONS = 12;
+const MIN_CUT_DURATION_SECONDS = 6;
+const MAX_CUT_DURATION_SECONDS = 60;
+
+const clamp = (value: number, min: number, max: number) => Math.min(max, Math.max(min, value));
+
+const round = (value: number, precision = 3) => {
+  const factor = 10 ** precision;
+  return Math.round(value * factor) / factor;
+};
+
+const stableNoise = (seed: string) => {
+  let hash = 2166136261;
+  for (let i = 0; i < seed.length; i++) {
+    hash ^= seed.charCodeAt(i);
+    hash = Math.imul(hash, 16777619);
+  }
+  return ((hash >>> 0) % 1000) / 1000;
+};
+
+const scorePosition = (start: number, duration: number) => {
+  if (duration <= 0) return 0;
+  const progress = start / duration;
+  const opening = Math.max(0, 1 - progress / 0.18);
+  const payoff = Math.max(0, 1 - Math.abs(progress - 0.68) / 0.22);
+  const middle = Math.max(0, 1 - Math.abs(progress - 0.36) / 0.24);
+  return clamp(Math.max(opening, payoff * 0.92, middle * 0.72), 0, 1);
+};
+
+const scoreDuration = (duration: number, targetDuration: number) => {
+  const delta = Math.abs(duration - targetDuration);
+  return clamp(1 - delta / targetDuration, 0, 1);
+};
+
+const scoreBitrate = (asset: ViralCutAsset) => {
+  if (!asset.size || !asset.duration) return 0.45;
+  const bytesPerSecond = asset.size / Math.max(asset.duration, 1);
+  const tenMbpsBytesPerSecond = 10_000_000 / 8;
+  return clamp(bytesPerSecond / tenMbpsBytesPerSecond, 0, 1);
+};
+
+const scoreStructure = (asset: ViralCutAsset, start: number) => {
+  const isFourK = (asset.width ?? 0) >= 3000 && (asset.height ?? 0) >= 1600;
+  const namePulse = stableNoise(`${asset.name}:${Math.round(start * 10)}`);
+  return clamp((isFourK ? 0.58 : 0.38) + namePulse * 0.34, 0, 1);
+};
+
+const getTargetDuration = (requested?: number) => clamp(requested ?? DEFAULT_TARGET_DURATION_SECONDS, MIN_CUT_DURATION_SECONDS, MAX_CUT_DURATION_SECONDS);
+
+const getCandidateDuration = (assetDuration: number, targetDuration: number) => {
+  if (assetDuration <= MIN_CUT_DURATION_SECONDS) return Math.max(0, assetDuration);
+  if (assetDuration < targetDuration) return clamp(assetDuration, MIN_CUT_DURATION_SECONDS, targetDuration);
+  if (assetDuration >= 600) return clamp(targetDuration + 6, MIN_CUT_DURATION_SECONDS, MAX_CUT_DURATION_SECONDS);
+  return targetDuration;
+};
+
+const candidateStartsForAsset = (asset: ViralCutAsset, candidateDuration: number) => {
+  const maxStart = Math.max(0, asset.duration - candidateDuration);
+  if (maxStart <= 0) return [0];
+
+  const anchors = [0, 0.05, 0.12, 0.22, 0.36, 0.52, 0.68, 0.82, 0.93].map((ratio) => maxStart * ratio);
+
+  if (asset.duration > 180) {
+    for (let t = 60; t < maxStart; t += asset.duration > 720 ? 150 : 90) {
+      anchors.push(t);
+    }
+  }
+
+  const unique = Array.from(new Set(anchors.map((start) => Math.round(clamp(start, 0, maxStart)))));
+  return unique.slice(0, 16);
+};
+
+const titleForSuggestion = (start: number, assetDuration: number, score: number) => {
+  const progress = assetDuration > 0 ? start / assetDuration : 0;
+  if (progress < 0.18) return "Opening hook candidate";
+  if (progress > 0.58) return score >= 0.78 ? "Payoff moment candidate" : "Late highlight candidate";
+  return "Mid-video lift candidate";
+};
+
+const confidenceForScore = (score: number): ViralCutSuggestion["confidence"] => {
+  if (score >= 0.78) return "high";
+  if (score >= 0.62) return "medium";
+  return "low";
+};
+
+const reasonsFor = (params: {
+  start: number;
+  asset: ViralCutAsset;
+  durationScore: number;
+  bitrateScore: number;
+  structureScore: number;
+}) => {
+  const { start, asset, durationScore, bitrateScore, structureScore } = params;
+  const progress = asset.duration > 0 ? start / asset.duration : 0;
+  const reasons: string[] = [];
+
+  if (progress < 0.18) reasons.push("early hook");
+  if (progress > 0.58) reasons.push("late payoff");
+  if (durationScore > 0.82) reasons.push("short-form length");
+  if (bitrateScore > 0.66) reasons.push("high-detail source");
+  if (structureScore > 0.68) reasons.push("strong visual candidate");
+
+  return reasons.slice(0, 3);
+};
+
+export function analyzeViralCutsHeuristic(request: ViralCutAnalysisRequest): ViralCutAnalysisResult {
+  const targetDuration = getTargetDuration(request.targetDuration);
+  const maxSuggestions = clamp(request.maxSuggestions ?? DEFAULT_MAX_SUGGESTIONS, 1, 50);
+  const suggestions: ViralCutSuggestion[] = [];
+  const analyzedAssetIds: string[] = [];
+  const skippedAssetIds: string[] = [];
+
+  for (const asset of request.assets) {
+    if (!Number.isFinite(asset.duration) || asset.duration < 1) {
+      skippedAssetIds.push(asset.id);
+      continue;
+    }
+
+    analyzedAssetIds.push(asset.id);
+    const candidateDuration = getCandidateDuration(asset.duration, targetDuration);
+    if (candidateDuration <= 0) {
+      skippedAssetIds.push(asset.id);
+      continue;
+    }
+
+    for (const start of candidateStartsForAsset(asset, candidateDuration)) {
+      const end = clamp(start + candidateDuration, start, asset.duration);
+      const duration = end - start;
+      if (duration < Math.min(MIN_CUT_DURATION_SECONDS, asset.duration)) continue;
+
+      const positionScore = scorePosition(start, asset.duration);
+      const durationScore = scoreDuration(duration, targetDuration);
+      const bitrateScore = scoreBitrate(asset);
+      const structureScore = scoreStructure(asset, start);
+      const score = clamp(positionScore * 0.36 + durationScore * 0.26 + bitrateScore * 0.18 + structureScore * 0.2, 0, 1);
+
+      suggestions.push({
+        id: `viral-${asset.id}-${Math.round(start * 100)}-${Math.round(end * 100)}`,
+        assetId: asset.id,
+        assetName: asset.name,
+        start: round(start),
+        end: round(end),
+        duration: round(duration),
+        score: round(score, 4),
+        confidence: confidenceForScore(score),
+        title: titleForSuggestion(start, asset.duration, score),
+        reasons: reasonsFor({ start, asset, durationScore, bitrateScore, structureScore }),
+        source: "heuristic",
+        metrics: {
+          positionScore: round(positionScore, 4),
+          durationScore: round(durationScore, 4),
+          bitrateScore: round(bitrateScore, 4),
+          structureScore: round(structureScore, 4),
+        },
+      });
+    }
+  }
+
+  const ranked = suggestions
+    .sort((a, b) => b.score - a.score || b.duration - a.duration)
+    .filter((suggestion, index, all) => {
+      const earlierForAsset = all.slice(0, index).filter((candidate) => candidate.assetId === suggestion.assetId);
+      return earlierForAsset.length < 3;
+    })
+    .slice(0, maxSuggestions);
+
+  return {
+    suggestions: ranked,
+    analyzedAssetIds,
+    skippedAssetIds,
+    generatedAt: Date.now(),
+  };
+}

--- a/src/features/viral-cuts/store.ts
+++ b/src/features/viral-cuts/store.ts
@@ -1,0 +1,30 @@
+import { create } from "zustand";
+import type { ViralCutSuggestion } from "./types";
+
+interface ViralCutsStore {
+  status: "idle" | "analyzing" | "ready" | "error";
+  suggestions: ViralCutSuggestion[];
+  error: string | null;
+  dismissedIds: string[];
+  insertedIds: string[];
+  setAnalyzing: () => void;
+  setResults: (suggestions: ViralCutSuggestion[]) => void;
+  setError: (error: string) => void;
+  dismissSuggestion: (id: string) => void;
+  markInserted: (id: string) => void;
+  reset: () => void;
+}
+
+export const useViralCutsStore = create<ViralCutsStore>((set) => ({
+  status: "idle",
+  suggestions: [],
+  error: null,
+  dismissedIds: [],
+  insertedIds: [],
+  setAnalyzing: () => set({ status: "analyzing", error: null }),
+  setResults: (suggestions) => set({ status: "ready", suggestions, error: null, dismissedIds: [] }),
+  setError: (error) => set({ status: "error", error }),
+  dismissSuggestion: (id) => set((state) => ({ dismissedIds: [...new Set([...state.dismissedIds, id])] })),
+  markInserted: (id) => set((state) => ({ insertedIds: [...new Set([...state.insertedIds, id])] })),
+  reset: () => set({ status: "idle", suggestions: [], error: null, dismissedIds: [], insertedIds: [] }),
+}));

--- a/src/features/viral-cuts/types.ts
+++ b/src/features/viral-cuts/types.ts
@@ -1,0 +1,57 @@
+import type { MediaAsset } from "@/types";
+
+export interface ViralCutAsset {
+  id: string;
+  name: string;
+  path: string;
+  duration: number;
+  width?: number;
+  height?: number;
+  size?: number;
+}
+
+export interface ViralCutAnalysisRequest {
+  assets: ViralCutAsset[];
+  targetDuration?: number;
+  maxSuggestions?: number;
+}
+
+export type ViralCutConfidence = "high" | "medium" | "low";
+export type ViralCutSource = "native" | "heuristic";
+
+export interface ViralCutSuggestion {
+  id: string;
+  assetId: string;
+  assetName: string;
+  start: number;
+  end: number;
+  duration: number;
+  score: number;
+  confidence: ViralCutConfidence;
+  title: string;
+  reasons: string[];
+  source: ViralCutSource;
+  metrics: {
+    positionScore: number;
+    durationScore: number;
+    bitrateScore: number;
+    structureScore: number;
+  };
+}
+
+export interface ViralCutAnalysisResult {
+  suggestions: ViralCutSuggestion[];
+  analyzedAssetIds: string[];
+  skippedAssetIds: string[];
+  generatedAt: number;
+}
+
+export const mediaAssetToViralCutAsset = (asset: MediaAsset): ViralCutAsset => ({
+  id: asset.id,
+  name: asset.name,
+  path: asset.path,
+  duration: asset.duration,
+  width: asset.width,
+  height: asset.height,
+  size: asset.size,
+});

--- a/src/hooks/useFileDrop.ts
+++ b/src/hooks/useFileDrop.ts
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 import { listen } from "@tauri-apps/api/event";
-import { getCurrentWindow } from "@tauri-apps/api/window";
+import { platform } from "@/core/platform";
 
 interface UseFileDropOptions {
   onDrop: (paths: string[]) => Promise<void>;
@@ -17,7 +17,7 @@ export const useFileDrop = ({ onDrop, enabled = true }: UseFileDropOptions) => {
   const isProcessingRef = useRef(false);
 
   useEffect(() => {
-    if (!enabled) return;
+    if (!enabled || !platform.isTauri()) return;
 
     let unlisten: (() => void) | undefined;
     let isMounted = true;

--- a/src/hooks/useTimelineTauriDrop.ts
+++ b/src/hooks/useTimelineTauriDrop.ts
@@ -1,14 +1,13 @@
 import { useState, useEffect, useCallback, useRef, RefObject } from "react";
 import { useDragLayer } from "react-dnd";
 import { listen } from "@tauri-apps/api/event";
-import { invoke, convertFileSrc } from "@tauri-apps/api/core";
 import { useTimelineStore } from "@/store/timelineStore";
 import { useProjectStore } from "@/store/projectStore";
 import { generateId } from "@/lib/utils/id";
-import type { VideoMetadata } from "@/types";
 import { createClipFromAsset } from "@/lib/timeline/timelineClip";
 import { autoAdaptSequenceForFirstVisualClip } from "@/lib/sequence/sequenceAutoAspect";
 import { DEFAULT_PLACEMENT_POLICY, resolveClipStartTime, resolvePreferredTrackId, resolveTargetTrackType } from "@/lib/timeline/placementPolicy";
+import { platform, type VideoMetadata } from "@/core/platform";
 
 const getMediaType = (path: string): "video" | "audio" | "image" => {
   const lower = path.toLowerCase();
@@ -52,8 +51,8 @@ export function useTimelineTauriDrop(containerRef: RefObject<HTMLDivElement | nu
           if (!asset) {
             // Import new asset
             if (type === "video" || type === "audio") {
-              const metadata: VideoMetadata = await invoke("get_video_metadata", { path: filePath });
-              const posterFrame: string | undefined = type === "video" ? ((await invoke("extract_poster_frame", { path: filePath, time: 0.0 }).catch(() => undefined)) as string | undefined) : undefined;
+              const metadata: VideoMetadata = await platform.getMediaMetadata(filePath);
+              const posterFrame: string | undefined = type === "video" ? await platform.extractPosterFrame(filePath, metadata.duration, window.devicePixelRatio || 1.0).catch(() => undefined) : undefined;
 
               asset = {
                 id: generateId("asset"),
@@ -64,7 +63,7 @@ export function useTimelineTauriDrop(containerRef: RefObject<HTMLDivElement | nu
                 width: metadata.width,
                 height: metadata.height,
                 posterFrame,
-                size: metadata.size,
+                size: (metadata as any).size ?? 0,
               };
             } else {
               asset = {
@@ -74,7 +73,7 @@ export function useTimelineTauriDrop(containerRef: RefObject<HTMLDivElement | nu
                 type: "image" as const,
                 duration: 0,
                 size: 0,
-                posterFrame: convertFileSrc(filePath),
+                posterFrame: platform.convertFileSrc(filePath),
               };
             }
 
@@ -131,6 +130,8 @@ export function useTimelineTauriDrop(containerRef: RefObject<HTMLDivElement | nu
 
   // Listen for drag events and handle file drops
   useEffect(() => {
+    if (!platform.isTauri()) return;
+
     let unlistenHover: (() => void) | undefined;
     let unlistenDrop: (() => void) | undefined;
     let unlistenCancel: (() => void) | undefined;

--- a/src/lib/cache/cacheManager.ts
+++ b/src/lib/cache/cacheManager.ts
@@ -22,6 +22,18 @@ export interface CacheStats {
 
 const isTauri = () => typeof window !== "undefined" && !!(window as any).__TAURI_INTERNALS__;
 
+const clearBrowserStorage = (storage: Storage) => {
+  if (typeof Storage !== "undefined" && Storage.prototype.clear) {
+    try {
+      Storage.prototype.clear.call(storage);
+      return;
+    } catch {
+      // Fall back for nonstandard test/runtime storage shims.
+    }
+  }
+  storage.clear();
+};
+
 export class CacheManager {
   /**
    * Clear the entire Tauri app cache directory
@@ -115,7 +127,7 @@ export class CacheManager {
   static clearLocalStorage(): { success: boolean; error?: string } {
     try {
       const itemCount = localStorage.length;
-      localStorage.clear();
+      clearBrowserStorage(localStorage);
       return { success: true };
     } catch (error) {
       const errorMsg = error instanceof Error ? error.message : String(error);
@@ -130,7 +142,7 @@ export class CacheManager {
   static clearSessionStorage(): { success: boolean; error?: string } {
     try {
       const itemCount = sessionStorage.length;
-      sessionStorage.clear();
+      clearBrowserStorage(sessionStorage);
       return { success: true };
     } catch (error) {
       const errorMsg = error instanceof Error ? error.message : String(error);

--- a/src/lib/renderEngine/transport.ts
+++ b/src/lib/renderEngine/transport.ts
@@ -16,6 +16,11 @@ import { SpatialTier, SPATIAL_TIER_DIMS } from "./types";
 import type { RenderEpochId } from "./types";
 import { generateId } from "@/lib/utils/id";
 
+const canUseNativeTransport = () => {
+  if (import.meta.env.MODE === "test") return true;
+  return typeof window !== "undefined" && "__TAURI_INTERNALS__" in window;
+};
+
 // ─── SAB Detection ────────────────────────────────────────────────────────────
 
 /**
@@ -159,6 +164,11 @@ export interface RequestRenderArtifactsOptions {
 export function requestRenderArtifacts(opts: RequestRenderArtifactsOptions): () => void {
   const { videoPath, timestampMs, spatialTiers, epochId, clipId, onArtifact, onComplete, onError } = opts;
 
+  if (!canUseNativeTransport()) {
+    onComplete?.();
+    return () => {};
+  }
+
   let cancelled = false;
   const cancel = () => {
     cancelled = true;
@@ -228,6 +238,11 @@ export interface RequestBatchArtifactsOptions {
  */
 export function requestBatchArtifacts(opts: RequestBatchArtifactsOptions): () => void {
   const { videoPath, timestampsMs, spatialTiers, epochId, clipId, onArtifact, onComplete, onError, concurrency = 4 } = opts;
+
+  if (!canUseNativeTransport()) {
+    onComplete?.();
+    return () => {};
+  }
 
   if (timestampsMs.length === 0) {
     onComplete?.();
@@ -309,6 +324,11 @@ export function requestBatchRenderArtifacts(opts: RequestBatchRenderArtifactsOpt
   const { videoPath, timestampsMs, spatialTiers, epochId, clipId, onArtifact, onComplete, onError, requestId } = opts;
 
   const reqId = requestId || generateId("req");
+
+  if (!canUseNativeTransport()) {
+    onComplete?.();
+    return () => {};
+  }
 
   if (timestampsMs.length === 0) {
     onComplete?.();

--- a/src/store/projectStore.ts
+++ b/src/store/projectStore.ts
@@ -32,6 +32,7 @@ import { convertRawConfigToDefinition } from "@/features/text-effects/lib/defini
 import { useEffectsStore } from "@/features/text-effects/store/effectsStore";
 import { calculateTextClipSize } from "@/lib/text/textClip";
 import { useSettingsStore } from "./settingsStore";
+import { platform } from "@/core/platform";
 // import { TIMELINE_PPS_PER_ZOOM, TIMELINE_ZOOM_DEFAULT } from "@/lib/timelineZoom";
 
 interface ProjectStore {
@@ -315,8 +316,7 @@ export const useProjectStore = create<ProjectStore>((set, get) => ({
   renameProject: async (projectId, newName) => {
     const sanitizedName = sanitizeProjectName(newName);
     try {
-      const { invoke } = await import("@tauri-apps/api/core");
-      await invoke("rename_project", { projectId, newName: sanitizedName });
+      await platform.renameProject(projectId, sanitizedName);
 
       // Update in recent projects list
       set((state) => ({
@@ -340,8 +340,7 @@ export const useProjectStore = create<ProjectStore>((set, get) => ({
 
   deleteProject: async (projectId) => {
     try {
-      const { invoke } = await import("@tauri-apps/api/core");
-      await invoke("delete_project", { projectId });
+      await platform.deleteProject(projectId);
 
       // Remove from recent projects list
       set((state) => ({
@@ -374,10 +373,7 @@ export const useProjectStore = create<ProjectStore>((set, get) => ({
           // Convert camelCase to snake_case using centralized serialization
           const rustProject = toRustProject(project, { tracks, clips, transitions, gaps, mediaAssets });
 
-          const { invoke } = await import("@tauri-apps/api/core");
-          await invoke("save_project", {
-            projectData: JSON.stringify(rustProject),
-          });
+          await platform.saveProject(JSON.stringify(rustProject));
 
           get().showToast("Project saved");
         } catch (error) {
@@ -428,10 +424,7 @@ export const useProjectStore = create<ProjectStore>((set, get) => ({
         // Convert camelCase to snake_case using centralized serialization
         const rustProject = toRustProject(project, { tracks, clips, transitions, gaps, mediaAssets });
 
-        const { invoke } = await import("@tauri-apps/api/core");
-        await invoke("save_project", {
-          projectData: JSON.stringify(rustProject),
-        });
+        await platform.saveProject(JSON.stringify(rustProject));
         get().showToast("Project saved");
       } catch (error) {
         console.error("[AutoSave] Failed to save project:", error);

--- a/src/test-setup.ts
+++ b/src/test-setup.ts
@@ -15,6 +15,51 @@ afterEach(() => {
   cleanup();
 });
 
+const createMemoryStorage = (): Storage => {
+  const store = new Map<string, string>();
+  return {
+    get length() {
+      return store.size;
+    },
+    clear: () => store.clear(),
+    getItem: (key: string) => store.get(key) ?? null,
+    key: (index: number) => Array.from(store.keys())[index] ?? null,
+    removeItem: (key: string) => {
+      store.delete(key);
+    },
+    setItem: (key: string, value: string) => {
+      store.set(key, String(value));
+    },
+  };
+};
+
+const ensureStorage = (key: "localStorage" | "sessionStorage") => {
+  if (typeof window.Storage !== "undefined") {
+    Object.defineProperty(globalThis, "Storage", {
+      configurable: true,
+      value: window.Storage,
+    });
+  }
+
+  try {
+    window[key].setItem("__storage_test__", "1");
+    window[key].removeItem("__storage_test__");
+  } catch {
+    Object.defineProperty(window, key, {
+      configurable: true,
+      value: createMemoryStorage(),
+    });
+  }
+
+  Object.defineProperty(globalThis, key, {
+    configurable: true,
+    value: window[key],
+  });
+};
+
+ensureStorage("localStorage");
+ensureStorage("sessionStorage");
+
 // Mock AudioContext for tests
 class MockAudioContext {
   currentTime = 0;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -42,6 +42,11 @@ export default defineConfig(async () => ({
   test: {
     globals: true,
     environment: "jsdom",
+    environmentOptions: {
+      jsdom: {
+        url: "http://localhost:1420/",
+      },
+    },
     setupFiles: ["./src/test-setup.ts"],
   },
 }));


### PR DESCRIPTION
Adds a Viral Cuts tab with heuristic/native cut suggestions, timeline insertion, and focused tests. Also includes web/Tauri project and media handling hardening needed for the workflow.\n\nVerification:\n- npm run build\n- npm test -- --run\n- cargo check