### PR TITLE
Fix text templates to always render with transparent background

### DIFF
--- a/src/components/editor/preview/SourcePreview.tsx
+++ b/src/components/editor/preview/SourcePreview.tsx
@@ -494,7 +494,7 @@ export const SourcePreview: React.FC = () => {
       )}
 
       {/* ── Video Area ─────────────────────────────────────────────── */}
-      <div className="flex-1 flex items-center justify-center overflow-hidden bg-[#06080a] relative">
+      <div className="flex-1 flex items-center justify-center overflow-hidden checkerboard relative">
         <div className="w-full h-full flex items-center justify-center relative z-10">
           {sourceAsset.type === "video" ? (
             useGPU && !gpuFailed ? (

--- a/src/components/editor/preview/TextSourcePreview.tsx
+++ b/src/components/editor/preview/TextSourcePreview.tsx
@@ -22,7 +22,10 @@ const normalizePreviewFontWeight = (value: unknown): number => {
       return normalizePreviewFontWeight(numeric);
     }
 
-    const normalized = value.trim().toLowerCase().replace(/[\s_-]/g, "");
+    const normalized = value
+      .trim()
+      .toLowerCase()
+      .replace(/[\s_-]/g, "");
     if (normalized === "thin") return 100;
     if (normalized === "extralight" || normalized === "ultralight") return 200;
     if (normalized === "light") return 300;
@@ -209,7 +212,7 @@ export const TextSourcePreview: React.FC<TextSourcePreviewProps> = ({ preset }) 
 
   if (isTemplate) {
     return (
-      <div className="w-full aspect-video bg-black flex items-center justify-center relative p-8 shadow-[0_0_40px_rgba(0,0,0,0.8)] border border-white/5 overflow-hidden">
+      <div className="w-full aspect-video checkerboard flex items-center justify-center relative p-8 shadow-[0_0_40px_rgba(0,0,0,0.8)] border border-white/5 overflow-hidden">
         <TemplatePreviewPlayer lottieData={(preset as any).injectedData || (preset as any).lottieData || preset} autoplay={true} loop={true} mode="canvas" fitToContent={true} className="w-full h-full object-contain" />
       </div>
     );

--- a/src/core/render/rasterizer.ts
+++ b/src/core/render/rasterizer.ts
@@ -179,9 +179,17 @@ export async function rasterizeScene(scene: EvaluatedScene, target: RasterTarget
     ctx.scale(pixelRatio, pixelRatio);
   }
 
+  // Detect if scene contains text template layers which require transparent background
+  const hasTextTemplate = scene.visualLayers.some((layer) => layer.layerType === "text" && (layer as any).templateId);
+
   // Clear with background
-  ctx.fillStyle = backgroundColor;
-  ctx.fillRect(0, 0, width, height);
+  // Text templates always render with transparent background
+  if (hasTextTemplate) {
+    ctx.clearRect(0, 0, width, height);
+  } else {
+    ctx.fillStyle = backgroundColor;
+    ctx.fillRect(0, 0, width, height);
+  }
 
   // Calculate scale factors (target size / scene size)
   // Use uniform scaling to preserve aspect ratio
@@ -1080,7 +1088,7 @@ async function rasterizeTextLayer(ctx: CanvasRenderingContext2D | OffscreenCanva
         const { TextEffectsApi } = await import("@/features/text-effects/api/textEffectsApi");
         const lottieData = await TextEffectsApi.getLottieTemplate(rawTemplate.category, rawTemplate.id);
         useTemplateStore.setState((state) => ({
-          templates: state.templates.map((t) => t.id === rawTemplate.id ? { ...t, lottieData } : t)
+          templates: state.templates.map((t) => (t.id === rawTemplate.id ? { ...t, lottieData } : t)),
         }));
         template = lottieData;
       } catch (err) {
@@ -1115,11 +1123,7 @@ async function rasterizeTextLayer(ctx: CanvasRenderingContext2D | OffscreenCanva
           }
           renderer.updateLayer(tLayer.id, changes);
         } else if (tLayer.kind === "shape") {
-          const colorOverride = tLayer.id === "primary-fill-layer" 
-            ? customization.primaryColor 
-            : tLayer.id === "secondary-fill-layer" 
-              ? customization.secondaryColor 
-              : undefined;
+          const colorOverride = tLayer.id === "primary-fill-layer" ? customization.primaryColor : tLayer.id === "secondary-fill-layer" ? customization.secondaryColor : undefined;
           if (colorOverride) {
             renderer.updateLayer(tLayer.id, { fill: colorOverride });
           }
@@ -1127,12 +1131,12 @@ async function rasterizeTextLayer(ctx: CanvasRenderingContext2D | OffscreenCanva
       }
 
       const localTime = layer.time !== undefined && layer.clipStartTime !== undefined ? layer.time - layer.clipStartTime : 0;
-      
+
       ctx.save();
       const sX = width / template.canvasWidth;
       const sY = height / template.canvasHeight;
       ctx.scale(sX, sY);
-      
+
       renderer.drawFrame(ctx as CanvasRenderingContext2D, localTime);
       ctx.restore();
       return;


### PR DESCRIPTION
- Changed SourcePreview video area background from solid dark to checkerboard
- Changed TextSourcePreview template preview from bg-black to checkerboard
- Modified rasterizer to detect text template layers and use transparent background
- Text templates now render consistently transparent in both source preview and program preview
- Prevents black background from appearing behind template animations