### PR TITLE
Fix transform overlay distortion for rotated clips

### DIFF
--- a/src/components/editor/transform/TransformOverlay.tsx
+++ b/src/components/editor/transform/TransformOverlay.tsx
@@ -488,30 +488,31 @@ export const TransformOverlay: React.FC<TransformOverlayProps> = ({ canvasWidth,
             }
           } else {
             // Gather all target X coordinates
-            const targetXCandidates: { value: number; type: 'canvas-left' | 'canvas-center' | 'canvas-right' | 'clip' }[] = [
-              { value: 0, type: 'canvas-left' },
-              { value: canvasWidth / 2, type: 'canvas-center' },
-              { value: canvasWidth, type: 'canvas-right' },
+            const targetXCandidates: { value: number; type: "canvas-left" | "canvas-center" | "canvas-right" | "clip" }[] = [
+              { value: 0, type: "canvas-left" },
+              { value: canvasWidth / 2, type: "canvas-center" },
+              { value: canvasWidth, type: "canvas-right" },
             ];
 
-            activeClips.forEach(c => {
-              targetXCandidates.push({ value: c.x, type: 'clip' });
-              targetXCandidates.push({ value: c.x + c.width / 2, type: 'clip' });
-              targetXCandidates.push({ value: c.x + c.width, type: 'clip' });
+            activeClips.forEach((c) => {
+              targetXCandidates.push({ value: c.x, type: "clip" });
+              targetXCandidates.push({ value: c.x + c.width / 2, type: "clip" });
+              targetXCandidates.push({ value: c.x + c.width, type: "clip" });
             });
 
             let bestSnapX: { targetVal: number; clipOffset: number; type: string } | null = null;
             let minDistanceX = Infinity;
 
-            const sourceXCandidates = rotation === 0
-              ? [
-                  { val: nextX, offset: 0 }, // left edge
-                  { val: nextCenterX, offset: -nextW / 2 }, // center X
-                  { val: nextX + nextW, offset: -nextW }, // right edge
-                ]
-              : [
-                  { val: nextCenterX, offset: -nextW / 2 }, // center X only
-                ];
+            const sourceXCandidates =
+              rotation === 0
+                ? [
+                    { val: nextX, offset: 0 }, // left edge
+                    { val: nextCenterX, offset: -nextW / 2 }, // center X
+                    { val: nextX + nextW, offset: -nextW }, // right edge
+                  ]
+                : [
+                    { val: nextCenterX, offset: -nextW / 2 }, // center X only
+                  ];
 
             for (const source of sourceXCandidates) {
               for (const target of targetXCandidates) {
@@ -534,11 +535,11 @@ export const TransformOverlay: React.FC<TransformOverlayProps> = ({ canvasWidth,
               snapClipXOffsetRef.current = bestSnapX.clipOffset;
 
               setSnapGuideX(bestSnapX.targetVal);
-              if (bestSnapX.type === 'canvas-left') {
+              if (bestSnapX.type === "canvas-left") {
                 setSnappedLeft(true);
-              } else if (bestSnapX.type === 'canvas-right') {
+              } else if (bestSnapX.type === "canvas-right") {
                 setSnappedRight(true);
-              } else if (bestSnapX.type === 'canvas-center') {
+              } else if (bestSnapX.type === "canvas-center") {
                 setSnappedX(true);
               } else {
                 setSnappedX(true);
@@ -565,30 +566,31 @@ export const TransformOverlay: React.FC<TransformOverlayProps> = ({ canvasWidth,
             }
           } else {
             // Gather all target Y coordinates
-            const targetYCandidates: { value: number; type: 'canvas-top' | 'canvas-center' | 'canvas-bottom' | 'clip' }[] = [
-              { value: 0, type: 'canvas-top' },
-              { value: canvasHeight / 2, type: 'canvas-center' },
-              { value: canvasHeight, type: 'canvas-bottom' },
+            const targetYCandidates: { value: number; type: "canvas-top" | "canvas-center" | "canvas-bottom" | "clip" }[] = [
+              { value: 0, type: "canvas-top" },
+              { value: canvasHeight / 2, type: "canvas-center" },
+              { value: canvasHeight, type: "canvas-bottom" },
             ];
 
-            activeClips.forEach(c => {
-              targetYCandidates.push({ value: c.y, type: 'clip' });
-              targetYCandidates.push({ value: c.y + c.height / 2, type: 'clip' });
-              targetYCandidates.push({ value: c.y + c.height, type: 'clip' });
+            activeClips.forEach((c) => {
+              targetYCandidates.push({ value: c.y, type: "clip" });
+              targetYCandidates.push({ value: c.y + c.height / 2, type: "clip" });
+              targetYCandidates.push({ value: c.y + c.height, type: "clip" });
             });
 
             let bestSnapY: { targetVal: number; clipOffset: number; type: string } | null = null;
             let minDistanceY = Infinity;
 
-            const sourceYCandidates = rotation === 0
-              ? [
-                  { val: nextY, offset: 0 }, // top edge
-                  { val: nextCenterY, offset: -nextH / 2 }, // center Y
-                  { val: nextY + nextH, offset: -nextH }, // bottom edge
-                ]
-              : [
-                  { val: nextCenterY, offset: -nextH / 2 }, // center Y only
-                ];
+            const sourceYCandidates =
+              rotation === 0
+                ? [
+                    { val: nextY, offset: 0 }, // top edge
+                    { val: nextCenterY, offset: -nextH / 2 }, // center Y
+                    { val: nextY + nextH, offset: -nextH }, // bottom edge
+                  ]
+                : [
+                    { val: nextCenterY, offset: -nextH / 2 }, // center Y only
+                  ];
 
             for (const source of sourceYCandidates) {
               for (const target of targetYCandidates) {
@@ -611,11 +613,11 @@ export const TransformOverlay: React.FC<TransformOverlayProps> = ({ canvasWidth,
               snapClipYOffsetRef.current = bestSnapY.clipOffset;
 
               setSnapGuideY(bestSnapY.targetVal);
-              if (bestSnapY.type === 'canvas-top') {
+              if (bestSnapY.type === "canvas-top") {
                 setSnappedTop(true);
-              } else if (bestSnapY.type === 'canvas-bottom') {
+              } else if (bestSnapY.type === "canvas-bottom") {
                 setSnappedBottom(true);
-              } else if (bestSnapY.type === 'canvas-center') {
+              } else if (bestSnapY.type === "canvas-center") {
                 setSnappedY(true);
               } else {
                 setSnappedY(true);
@@ -877,7 +879,7 @@ export const TransformOverlay: React.FC<TransformOverlayProps> = ({ canvasWidth,
       y: selectedClip.y,
       width: selectedClip.width,
       height: selectedClip.height,
-      ...(("fontSize" in selectedClip) ? { fontSize: (selectedClip as any).fontSize } : {})
+      ...("fontSize" in selectedClip ? { fontSize: (selectedClip as any).fontSize } : {}),
     };
 
     const canvasAspect = canvasWidth / canvasHeight;
@@ -918,7 +920,7 @@ export const TransformOverlay: React.FC<TransformOverlayProps> = ({ canvasWidth,
       y: selectedClip.y,
       width: selectedClip.width,
       height: selectedClip.height,
-      ...(("fontSize" in selectedClip) ? { fontSize: (selectedClip as any).fontSize } : {})
+      ...("fontSize" in selectedClip ? { fontSize: (selectedClip as any).fontSize } : {}),
     };
 
     const canvasAspect = canvasWidth / canvasHeight;
@@ -960,7 +962,7 @@ export const TransformOverlay: React.FC<TransformOverlayProps> = ({ canvasWidth,
       width: selectedClip.width,
       height: selectedClip.height,
       rotation: selectedClip.rotation,
-      ...(("fontSize" in selectedClip) ? { fontSize: (selectedClip as any).fontSize } : {})
+      ...("fontSize" in selectedClip ? { fontSize: (selectedClip as any).fontSize } : {}),
     };
 
     let newVal: Record<string, any> = {
@@ -990,30 +992,36 @@ export const TransformOverlay: React.FC<TransformOverlayProps> = ({ canvasWidth,
     execute(new TransformClipCommand(selectedClip.id, oldVal, newVal));
   }, [selectedClip, canvasWidth, canvasHeight, execute]);
 
-  const handleContextMenu = useCallback((e: React.MouseEvent) => {
-    e.preventDefault();
-    e.stopPropagation();
-    if (!selectedClip) return;
-    setContextMenu({ x: e.clientX, y: e.clientY });
-  }, [selectedClip]);
+  const handleContextMenu = useCallback(
+    (e: React.MouseEvent) => {
+      e.preventDefault();
+      e.stopPropagation();
+      if (!selectedClip) return;
+      setContextMenu({ x: e.clientX, y: e.clientY });
+    },
+    [selectedClip],
+  );
 
-  const contextMenuItems = React.useMemo(() => [
-    {
-      label: "Fit Canvas",
-      icon: Maximize2,
-      onClick: handleFitCanvas,
-    },
-    {
-      label: "Fill Canvas",
-      icon: Minimize2,
-      onClick: handleFillCanvas,
-    },
-    {
-      label: "Reset Transform",
-      icon: RotateCcw,
-      onClick: handleResetTransform,
-    },
-  ], [handleFitCanvas, handleFillCanvas, handleResetTransform]);
+  const contextMenuItems = React.useMemo(
+    () => [
+      {
+        label: "Fit Canvas",
+        icon: Maximize2,
+        onClick: handleFitCanvas,
+      },
+      {
+        label: "Fill Canvas",
+        icon: Minimize2,
+        onClick: handleFillCanvas,
+      },
+      {
+        label: "Reset Transform",
+        icon: RotateCcw,
+        onClick: handleResetTransform,
+      },
+    ],
+    [handleFitCanvas, handleFillCanvas, handleResetTransform],
+  );
 
   // Attach global mouse listeners during drag
   React.useEffect(() => {
@@ -1036,11 +1044,7 @@ export const TransformOverlay: React.FC<TransformOverlayProps> = ({ canvasWidth,
   }, []);
 
   // Convert clip bounds to screen coordinates for handle rendering
-  const isTransformable = selectedClip && 
-    selectedClip.kind !== "filter" && 
-    selectedClip.kind !== "video-effect" && 
-    selectedClip.kind !== "body-effect" && 
-    selectedClip.kind !== "audio";
+  const isTransformable = selectedClip && selectedClip.kind !== "filter" && selectedClip.kind !== "video-effect" && selectedClip.kind !== "body-effect" && selectedClip.kind !== "audio";
 
   if (!selectedClip || !isClipActiveAtTime(selectedClip, currentTime) || !isTransformable) {
     return (
@@ -1072,26 +1076,34 @@ export const TransformOverlay: React.FC<TransformOverlayProps> = ({ canvasWidth,
   // Pass zero offset because we're positioning within the overlay div itself
   // (which is already placed at displayOffset by the parent layout).
   const zeroOffset = { x: 0, y: 0 };
-  const topLeft = canvasToScreen(selectedClip.x, selectedClip.y, viewport, { width: canvasWidth, height: canvasHeight }, scale, zeroOffset);
-
-  const bottomRight = canvasToScreen(selectedClip.x + selectedClip.width, selectedClip.y + selectedClip.height, viewport, { width: canvasWidth, height: canvasHeight }, scale, zeroOffset);
-
-  const handleDisplayX = topLeft.x;
-  const handleDisplayY = topLeft.y;
-  const handleDisplayWidth = bottomRight.x - topLeft.x;
-  const handleDisplayHeight = bottomRight.y - topLeft.y;
   const rotation = selectedClip.rotation ?? 0;
+
+  // Calculate the center of the clip in canvas space
   const clipCenterX = selectedClip.x + selectedClip.width / 2;
   const clipCenterY = selectedClip.y + selectedClip.height / 2;
+
+  // Convert clip center to screen space
+  const clipCenterScreen = canvasToScreen(clipCenterX, clipCenterY, viewport, { width: canvasWidth, height: canvasHeight }, scale, zeroOffset);
+
+  // Calculate screen-space dimensions (accounting for scale and zoom)
+  const handleDisplayWidth = selectedClip.width * scale * viewport.zoom;
+  const handleDisplayHeight = selectedClip.height * scale * viewport.zoom;
+
+  // Position transform box centered at the clip center, rotation applied via CSS transform
+  const handleDisplayX = clipCenterScreen.x - handleDisplayWidth / 2;
+  const handleDisplayY = clipCenterScreen.y - handleDisplayHeight / 2;
+
+  // Calculate canvas center for guides
   const canvasCenterX = canvasWidth / 2;
   const canvasCenterY = canvasHeight / 2;
+  const centerScreen = canvasToScreen(canvasCenterX, canvasCenterY, viewport, { width: canvasWidth, height: canvasHeight }, scale, zeroOffset);
+
   const showVerticalCenterGuide = isDragging && snappedX;
   const showHorizontalCenterGuide = isDragging && snappedY;
   const showLeftGuide = isDragging && snappedLeft;
   const showRightGuide = isDragging && snappedRight;
   const showTopGuide = isDragging && snappedTop;
   const showBottomGuide = isDragging && snappedBottom;
-  const centerScreen = canvasToScreen(canvasCenterX, canvasCenterY, viewport, { width: canvasWidth, height: canvasHeight }, scale, zeroOffset);
 
   textRenderTrace("text-overlay-bounds", {
     clipId: selectedClip.id,
@@ -1327,13 +1339,7 @@ export const TransformOverlay: React.FC<TransformOverlayProps> = ({ canvasWidth,
         />
       )}
 
-      {contextMenu && (
-        <ContextMenu
-          items={contextMenuItems}
-          position={contextMenu}
-          onClose={() => setContextMenu(null)}
-        />
-      )}
+      {contextMenu && <ContextMenu items={contextMenuItems} position={contextMenu} onClose={() => setContextMenu(null)} />}
     </div>
   );
 };


### PR DESCRIPTION
Root Cause Analysis:
The transform box was calculating dimensions by converting the unrotated bounding box corners (top-left and bottom-right) to screen space, then calculating width/height by subtraction. This approach fails with rotation because canvasToScreen applies viewport transformations, and subtracting two transformed points doesn't give you properly scaled dimensions.

The Bug:
- Convert unrotated corners: topLeft and bottomRight
- Calculate: width = bottomRight.x - topLeft.x
- Apply CSS rotation to container
- Result: Distorted/skewed transform box on rotated clips

The Fix (CapCut's Approach):
- Calculate clip CENTER in canvas space
- Convert center to screen space
- Calculate dimensions directly: width = canvas_width × scale × zoom
- Position box centered at that point
- Apply CSS rotation around the geometric center

This ensures the transform box is always the correct size and properly centered, with rotation applied purely as a CSS transform.

Benefits:
- Transform box matches actual visual bounds for any rotation
- Handles now properly align with clip corners
- Works correctly with viewport zoom and pan
- Mathematically correct regardless of transformation state