### PR TITLE
fix(tests): fix ClipDragDrop test mocks for Zustand stores

### DIFF
--- a/src/components/editor/timeline/__tests__/ClipDragDrop.test.tsx
+++ b/src/components/editor/timeline/__tests__/ClipDragDrop.test.tsx
@@ -19,11 +19,15 @@ const mockUpdateClip = vi.fn();
 const mockSelectClip = vi.fn();
 
 vi.mock("@/store/uiStore", () => ({
-  useUIStore: () => ({
-    selectedClipIds: [],
-    selectedTrackId: null,
-    selectClip: mockSelectClip,
-    toggleClipSelection: vi.fn(),
+  useUIStore: vi.fn((selector) => {
+    const state = {
+      selectedClipIds: [],
+      selectedGapId: null,
+      selectedTrackId: null,
+      selectClip: mockSelectClip,
+      toggleClipSelection: vi.fn(),
+    };
+    return selector ? selector(state) : state;
   }),
 }));
 
@@ -38,11 +42,17 @@ vi.mock("@/hooks/useTimeline", () => ({
 }));
 
 vi.mock("@/store/timelineStore", () => ({
-  useTimelineStore: () => ({
-    updateClip: mockUpdateClip,
-    dragState: null,
-    setDragState: vi.fn(),
-    calculateShiftedPositions: vi.fn(() => []),
+  useTimelineStore: vi.fn((selector) => {
+    const state = {
+      updateClip: mockUpdateClip,
+      dragState: null,
+      setDragState: vi.fn(),
+      calculateShiftedPositions: vi.fn(() => []),
+      gaps: [],
+      transitions: [],
+      clips: [],
+    };
+    return selector ? selector(state) : state;
   }),
 }));
 


### PR DESCRIPTION
FIXES:
- Fix useTimelineStore mock to properly handle Zustand selector pattern
- Fix useUIStore mock to properly handle Zustand selector pattern
- Add missing store properties: gaps, transitions, clips, selectedGapId

ISSUE:
Tests were failing with 'gaps.filter is not a function' because:
- Mocks returned plain objects instead of selector functions
- Missing gaps[] and transitions[] arrays in timelineStore mock
- Missing selectedGapId in uiStore mock

SOLUTION:
Changed mocks from:
  useStore: () => ({ ... }) To:
  useStore: vi.fn((selector) => { const state = { ... }; return selector ? selector(state) : state; })

This properly mimics Zustand's behavior where the hook can be called with or without a selector function.

RESULT:
✅ All 20 ClipDragDrop tests now pass
✅ All 67 Rust tests pass
✅ Total: 1003 tests passing