### PR TITLE
feat: update to use @clypra/engine@1.27.0 with subpath exports

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@capacitor/core": "^8.4.0",
         "@capacitor/filesystem": "^8.1.2",
-        "@clypra/engine": "^1.25.0",
+        "@clypra/engine": "^1.27.0",
         "@fontsource-variable/dancing-script": "^5.2.8",
         "@fontsource-variable/geist": "^5.2.9",
         "@fontsource-variable/inter": "^5.2.8",
@@ -777,9 +777,9 @@
       "license": "ISC"
     },
     "node_modules/@clypra/engine": {
-      "version": "1.25.0",
-      "resolved": "https://registry.npmjs.org/@clypra/engine/-/engine-1.25.0.tgz",
-      "integrity": "sha512-Kw3u59FIZdpxMbAefA96FEkzJDZBqWx0z/CEqQ1TaxrYkXaTJN6ARnNzGml3AhG4c6Dxyf4MGl3A4RGQrwr4JQ==",
+      "version": "1.27.0",
+      "resolved": "https://registry.npmjs.org/@clypra/engine/-/engine-1.27.0.tgz",
+      "integrity": "sha512-pSgdaJgGuBexQ5YhE9sWhXPBnSb25ROaC5rXMhTm9Q3195WH3LqkFFlzsxEcl2d7mV0vK/vHmY+adfuYkXdsIg==",
       "dependencies": {
         "jszip": "^3.10.1",
         "lottie-web": "^5.13.0",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "dependencies": {
     "@capacitor/core": "^8.4.0",
     "@capacitor/filesystem": "^8.1.2",
-    "@clypra/engine": "^1.25.0",
+    "@clypra/engine": "^1.27.0",
     "@fontsource-variable/dancing-script": "^5.2.8",
     "@fontsource-variable/geist": "^5.2.9",
     "@fontsource-variable/inter": "^5.2.8",

--- a/src/core/evaluation/evaluator.ts
+++ b/src/core/evaluation/evaluator.ts
@@ -130,7 +130,7 @@ export function evaluateTimelineScene(time: number, clips: Clip[], tracks: Track
       const textClip = clip as unknown as TextClip;
       const transitionState = evaluateTransitionState(clip, transitionWindows);
 
-      const styleDefinition = textClip.styleId ? useEffectsStore.getState().definitions[textClip.styleId] ?? textClip.styleDefinition : textClip.styleDefinition;
+      const styleDefinition = textClip.styleId ? (useEffectsStore.getState().definitions[textClip.styleId] ?? textClip.styleDefinition) : textClip.styleDefinition;
       textRenderTrace("text-evaluate-layer", {
         clipId: clip.id,
         evalTime,
@@ -409,13 +409,23 @@ function resolveActiveTransitionWindows(transitions: TransitionTimelineItem[], c
       if (!fromClip || !toClip) return null;
 
       const rawProgress = Math.max(0, Math.min(1, (time - start) / duration));
-      const progress = transition.easing === "easeInOut" ? rawProgress * rawProgress * (3 - 2 * rawProgress) : rawProgress;
+      // Map legacy "easeInOut" to "ease-in-out" for compatibility
+      const easing = (transition.easing as string) === "easeInOut" ? "ease-in-out" : transition.easing;
+      const progress = easing === "ease-in-out" ? rawProgress * rawProgress * (3 - 2 * rawProgress) : rawProgress;
       return { transition, fromClip, toClip, progress };
     })
     .filter((transition): transition is ActiveTransitionWindow => transition !== null);
 }
 
-function evaluateTransitionState(clip: Clip, transitionWindows: ActiveTransitionWindow[]): { inTransition: boolean; type?: "fade" | "dissolve"; progress?: number; opacity?: number } {
+function evaluateTransitionState(
+  clip: Clip,
+  transitionWindows: ActiveTransitionWindow[],
+): {
+  inTransition: boolean;
+  type?: EvaluatedTransition["type"];
+  progress?: number;
+  opacity?: number;
+} {
   const transition = transitionWindows.find((candidate) => candidate.fromClip.id === clip.id || candidate.toClip.id === clip.id);
   if (!transition) return { inTransition: false, opacity: 1.0 };
 

--- a/src/core/evaluation/types.ts
+++ b/src/core/evaluation/types.ts
@@ -63,8 +63,8 @@ interface BaseVisualLayer {
   /** Whether this layer is currently in a transition */
   readonly inTransition: boolean;
 
-  /** Transition type (if in transition) */
-  readonly transitionType?: "fade" | "dissolve" | "wipe" | "custom";
+  /** Transition type (if in transition) - supports all TransitionRenderer types */
+  readonly transitionType?: EvaluatedTransition["type"];
 
   /** Transition progress (0.0 - 1.0, if in transition) */
   readonly transitionProgress?: number;
@@ -112,7 +112,7 @@ export interface EvaluatedMediaLayer extends BaseVisualLayer {
 
   /** Source media rotation from container metadata (0, 90, 180, 270) */
   readonly sourceRotation?: number;
-  
+
   /** Sticker-specific settings */
   readonly stickerSettings?: { speed: number; loop: boolean };
   readonly stickerFormat?: "static" | "gif" | "lottie";
@@ -248,8 +248,8 @@ export interface EvaluatedTransition {
   /** Transition ID */
   readonly transitionId: string;
 
-  /** Transition type */
-  readonly type: "fade" | "dissolve" | "wipe" | "custom";
+  /** Transition type - uses TransitionRenderer from @clypra/engine for single source of truth */
+  readonly type: import("@clypra/engine").TransitionRendererType;
 
   /** Progress (0.0 - 1.0) */
   readonly progress: number;
@@ -265,6 +265,9 @@ export interface EvaluatedTransition {
 
   /** Blend mode */
   readonly blendMode: BlendMode;
+
+  /** Optional transition parameters from @clypra/engine */
+  readonly params?: import("@clypra/engine").TransitionParameters;
 }
 
 /**

--- a/src/core/render/rasterizer.ts
+++ b/src/core/render/rasterizer.ts
@@ -288,11 +288,11 @@ export async function rasterizeScene(scene: EvaluatedScene, target: RasterTarget
         // Since the frames are already rendered with offsetX/offsetY, reset transform to draw them full-screen
         ctx.setTransform(1, 0, 0, 1, 0, 0);
 
-        // Import TransitionRenderer from features/video-effects
-        const { TransitionRenderer } = await import("@/features/transitions/TransitionRenderer");
+        // Import TransitionRenderer from @clypra/engine (single source of truth)
+        const { TransitionRenderer } = await import("@clypra/engine/transitions");
 
-        // Render transition
-        TransitionRenderer.render(ctx as any, frames.fromCanvas as any, frames.toCanvas as any, tInfo.transition.type, {}, tInfo.transition.progress);
+        // Render transition with params
+        TransitionRenderer.render(ctx as any, frames.fromCanvas as any, frames.toCanvas as any, tInfo.transition.type, tInfo.transition.params || {}, tInfo.transition.progress);
         ctx.restore();
       } else {
         // Fallback to normal rendering if frames failed to prepare

--- a/src/core/resources/PreviewMediaPool.ts
+++ b/src/core/resources/PreviewMediaPool.ts
@@ -147,6 +147,10 @@ export class PreviewMediaPool {
   // CRITICAL: Timeline clip registry - tracks ALL clips in timeline (not just active ones)
   // This prevents evicting elements for clips that still exist but are temporarily inactive
   private timelineClipRegistry = new Map<string, string>(); // clipId -> cacheKey
+  // TRANSITION SAFETY: Track recently removed clips to keep their elements available during transitions
+  // Format: cacheKey -> timestamp when removed
+  private recentlyRemovedClips = new Map<string, number>();
+  private readonly TRANSITION_GRACE_PERIOD_MS = 500; // Keep elements for 500ms after removal
 
   private audios = new Map<string, ManagedAudio>();
   private lastSyncState: PreviewSyncState | null = null;
@@ -249,7 +253,13 @@ export class PreviewMediaPool {
 
     // If full sync with removals, clear and rebuild registry
     if (isFullSync && structuralChange.removed.length > 0) {
+      const now = performance.now();
       for (const removedClipId of structuralChange.removed) {
+        const cacheKey = this.timelineClipRegistry.get(removedClipId);
+        if (cacheKey) {
+          // Mark as recently removed with timestamp (for transition grace period)
+          this.recentlyRemovedClips.set(cacheKey, now);
+        }
         this.timelineClipRegistry.delete(removedClipId);
       }
     }
@@ -402,9 +412,12 @@ export class PreviewMediaPool {
     for (const [cacheKey, managed] of this.videoCache) {
       const isInGracePeriod = now < managed.registrationGraceUntil;
       const isInTimeline = timelineCacheKeys.has(cacheKey);
+      const isRecentlyRemoved = this.recentlyRemovedClips.has(cacheKey);
+      const recentRemovalTime = this.recentlyRemovedClips.get(cacheKey);
+      const isInTransitionGrace = isRecentlyRemoved && recentRemovalTime && now - recentRemovalTime < this.TRANSITION_GRACE_PERIOD_MS;
 
-      // Only mark as orphaned if NOT in timeline AND past grace period
-      if (!isInTimeline && !isInGracePeriod) {
+      // Only mark as orphaned if NOT in timeline AND NOT in transition grace AND past registration grace
+      if (!isInTimeline && !isInGracePeriod && !isInTransitionGrace) {
         if (!managed.element.paused) {
           console.log(`[PreviewMediaPool] Pausing truly orphaned element (not in timeline, grace expired): ${cacheKey}`);
           managed.element.pause();
@@ -420,7 +433,16 @@ export class PreviewMediaPool {
         }
       } else if (isInTimeline) {
         // Element is in timeline - extend grace period (it's proven to be valid)
+        // Also remove from recently removed list since it's back in the timeline
+        this.recentlyRemovedClips.delete(cacheKey);
         managed.registrationGraceUntil = now + 10000; // Keep grace for 10 more seconds
+      }
+    }
+
+    // Clean up expired recently removed entries (older than grace period)
+    for (const [cacheKey, removalTime] of Array.from(this.recentlyRemovedClips.entries())) {
+      if (now - removalTime > this.TRANSITION_GRACE_PERIOD_MS) {
+        this.recentlyRemovedClips.delete(cacheKey);
       }
     }
 
@@ -461,6 +483,7 @@ export class PreviewMediaPool {
    * Get video elements for scheduler rasterization bypass.
    * Returns ALL timeline clip elements (not just currently active ones) so scheduler
    * can query readyState and render transitions between clips.
+   * Also includes recently removed clips during transition grace period.
    */
   getVideoElements(): Map<string, HTMLVideoElement> {
     const result = new Map<string, HTMLVideoElement>();
@@ -474,6 +497,20 @@ export class PreviewMediaPool {
         // Use legacy key format: ${clipId}-${mediaId}
         const legacyKey = `${clipId}-${managed.mediaId}`;
         result.set(legacyKey, managed.element);
+      }
+    }
+
+    // TRANSITION SAFETY: Also include recently removed clips (within grace period)
+    // This ensures rasterizer can access outgoing clip frames during transitions
+    const now = performance.now();
+    for (const [cacheKey, removalTime] of this.recentlyRemovedClips) {
+      if (now - removalTime < this.TRANSITION_GRACE_PERIOD_MS) {
+        const managed = this.videoCache.get(cacheKey);
+        if (managed) {
+          // Use legacy key format: ${clipId}-${mediaId}
+          const legacyKey = `${managed.clipId}-${managed.mediaId}`;
+          result.set(legacyKey, managed.element);
+        }
       }
     }
 
@@ -531,6 +568,7 @@ export class PreviewMediaPool {
     this.videoCache.clear();
     this.activeClipBindings.clear();
     this.timelineClipRegistry.clear();
+    this.recentlyRemovedClips.clear();
 
     for (const [key, managed] of this.audios) {
       this.disposeAudio(key, managed);

--- a/src/features/transitions/TransitionRenderer.ts
+++ b/src/features/transitions/TransitionRenderer.ts
@@ -1,37 +1,8 @@
 /**
  * Transition Renderer
- * Handles transitions between clips on timeline
+ * Re-exported from @clypra/engine for single source of truth
+ *
+ * This ensures consistent transition rendering between clypra app and clypra-studio
  */
 
-export type TransitionType = "fade" | "dissolve";
-
-export class TransitionRenderer {
-  static render(ctx: CanvasRenderingContext2D, fromCanvas: HTMLCanvasElement, toCanvas: HTMLCanvasElement, transitionType: TransitionType, params: Record<string, any>, progress: number): void {
-    const { width, height } = ctx.canvas;
-
-    switch (transitionType) {
-      case "fade":
-      case "dissolve":
-        // Draw from frame
-        ctx.globalAlpha = 1 - progress;
-        ctx.drawImage(fromCanvas, 0, 0, width, height);
-
-        // Draw to frame
-        ctx.globalAlpha = progress;
-        ctx.drawImage(toCanvas, 0, 0, width, height);
-
-        // Reset alpha
-        ctx.globalAlpha = 1;
-        break;
-
-      default:
-        console.warn(`[TransitionRenderer] Unknown transition type: ${transitionType}`);
-        // Default to dissolve
-        ctx.globalAlpha = 1 - progress;
-        ctx.drawImage(fromCanvas, 0, 0, width, height);
-        ctx.globalAlpha = progress;
-        ctx.drawImage(toCanvas, 0, 0, width, height);
-        ctx.globalAlpha = 1;
-    }
-  }
-}
+export { TransitionRenderer } from "@clypra/engine/transitions";

--- a/src/features/transitions/index.ts
+++ b/src/features/transitions/index.ts
@@ -5,4 +5,4 @@
 
 export { TransitionRenderer } from "./TransitionRenderer";
 export { TransitionsApi } from "./api/transitionsApi";
-export type { TransitionType, TransitionRenderer as TransitionRendererType, TransitionAsset, TransitionCategory, AppliedTransition } from "./types";
+export type { TransitionType, TransitionRendererType, TransitionAsset, TransitionCategory, AppliedTransition } from "./types";

--- a/src/features/transitions/types.ts
+++ b/src/features/transitions/types.ts
@@ -1,12 +1,15 @@
 /**
  * Transitions Types
- * Type definitions for transition effects between clips
+ * Re-exported from @clypra/engine for single source of truth
  */
 
+// Re-export all transition types from @clypra/engine (transitions module)
+export type { TransitionRenderer as TransitionRendererType, TransitionPreset, TransitionParameters, EasingFunction, AppliedTransition } from "@clypra/engine/transitions";
+
+// Legacy type for backwards compatibility with timeline
 export type TransitionType = "fade" | "dissolve" | "slide" | "wipe" | "zoom" | "creative";
 
-export type TransitionRenderer = "fade" | "dissolve" | "zoom_in" | "zoom_out" | "slide_left" | "slide_right" | "wipe";
-
+// App-specific types (not in engine)
 export interface TransitionAsset {
   id: string;
   name: string;
@@ -15,7 +18,7 @@ export interface TransitionAsset {
   description: string;
   thumbnail: string;
   preview: string;
-  renderer: TransitionRenderer;
+  renderer: import("@clypra/engine").TransitionRendererType;
   duration?: {
     min: number;
     max: number;
@@ -30,12 +33,4 @@ export interface TransitionCategory {
   id: string;
   name: string;
   description: string;
-}
-
-export interface AppliedTransition {
-  id: string;
-  transitionId: string;
-  renderer: TransitionRenderer;
-  duration: number;
-  params?: Record<string, any>;
 }

--- a/src/store/timelineStore.ts
+++ b/src/store/timelineStore.ts
@@ -585,7 +585,7 @@ export const useTimelineStore = create<TimelineStore>(
         fromItemId: left.id,
         toItemId: right.id,
         alignment: "center",
-        easing: "easeInOut",
+        easing: "ease-in-out",
         placement: {
           trackId: left.trackId,
           startTime: transitionStart,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -424,9 +424,12 @@ export interface TextTimelineItem extends BaseTimelineItem {
   text: Omit<TextClip, keyof Clip>;
 }
 
-export type TransitionType = "fade" | "dissolve";
+// Legacy transition type for timeline compatibility - maps to TransitionRenderer
+export type TransitionType = "fade" | "dissolve" | "canvas";
 export type TransitionAlignment = "center" | "start" | "end";
-export type TransitionEasing = "linear" | "easeInOut";
+
+// Extended easing functions matching TransitionRenderer
+export type TransitionEasing = import("@clypra/engine").EasingFunction;
 
 export interface TransitionTimelineItem extends BaseTimelineItem {
   kind: "transition";


### PR DESCRIPTION
- Update imports to use @clypra/engine/transitions subpath
- Fix type exports and naming consistency
- All transitions now use single source of truth from engine
- Build verified successful