### PR TITLE
Fix failing filterEvaluation test

### DIFF
--- a/src/core/evaluation/__tests__/filterEvaluation.test.ts
+++ b/src/core/evaluation/__tests__/filterEvaluation.test.ts
@@ -127,11 +127,16 @@ describe("Filter Evaluation", () => {
 
     const scene = evaluateTimelineScene(2.5, [imageClip, filterClip], tracks, assets, project);
 
-    // Check if the visual layer for image has no clip filter (since filter track filter is track-level)
+    // Check if the visual layer for image has the filter applied from the filter track
     const imageLayer = scene.visualLayers.find((l) => l.clipId === "clip-image");
     expect(imageLayer).toBeDefined();
     expect(imageLayer?.layerType).toBe("media");
-    expect((imageLayer as any).filter).toBeUndefined();
+    // Filter from filter track is now applied to each media layer
+    expect((imageLayer as any).filter).toEqual({
+      id: "filter-sepia",
+      name: "Sepia Tone",
+      intensity: 0.8,
+    });
 
     // Verify the track-level filter is correctly attached at the scene level
     expect(scene.activeFilter).toEqual({


### PR DESCRIPTION
## Summary
Fixes the failing GitHub Actions test in filterEvaluation.test.ts

## Problem
The test was expecting the old behavior where filters from filter tracks were only set on `scene.activeFilter` but not on individual layer's `.filter` property.

## Solution
Our filter rendering fix (PR #135) correctly applies the filter from filter track to each media layer's `.filter` property. This is the fix that made filters actually render in the preview.

Updated the test expectations to reflect this correct behavior:
- `layer.filter` now contains the filter object (not undefined)
- `scene.activeFilter` still contains the filter (backward compatibility)

## Testing
✅ Test passes locally
✅ Validates the fix that made filters work in production

Fixes the failing CI pipeline.