### PR TITLE
feat(transitions): Support API-published transitions in editor

### DIFF
--- a/src/components/editor/EditorLayout.tsx
+++ b/src/components/editor/EditorLayout.tsx
@@ -320,11 +320,12 @@ export const EditorLayout: React.FC<EditorLayoutProps> = ({ onRequestClose }) =>
         return;
       }
 
-      // Use the transition renderer from the API instead of hardcoding
+      // Use the transition renderer from the API
       const transitionType = item?.renderer || item?.category || "fade";
       const transitionDuration = item?.duration?.default || Number(item?.duration) || 0.5;
+      const renderer = item?.renderer; // Store the renderer ID for GPU lookup
 
-      const result = createTransitionBetweenClips(pair[0], pair[1], transitionType, transitionDuration);
+      const result = createTransitionBetweenClips(pair[0], pair[1], transitionType, transitionDuration, renderer);
       if (result.error) {
         useProjectStore.getState().showToast(result.error, "warning");
       } else {

--- a/src/core/render/pixiSceneCompositor.ts
+++ b/src/core/render/pixiSceneCompositor.ts
@@ -116,7 +116,11 @@ export class PixiSceneCompositor {
     let definition: any = null;
 
     if (activeTransition) {
-      const resolved = resolveTransitionDefinition(activeTransition.type, ALL_TRANSITIONS);
+      const resolved = resolveTransitionDefinition(
+        activeTransition.type,
+        ALL_TRANSITIONS,
+        activeTransition.renderer, // Pass renderer from API transition if available
+      );
 
       if (resolved) {
         definition = resolved.definition;

--- a/src/core/render/utils/transitionResolver.ts
+++ b/src/core/render/utils/transitionResolver.ts
@@ -2,7 +2,7 @@
  * Transition Resolver
  *
  * Resolves transition types to GPU transition definitions,
- * handling legacy mappings and parameter merging.
+ * handling API transitions, legacy mappings, and parameter merging.
  */
 
 const RENDERER_TO_GPU_TRANSITION: Record<string, { id: string; params?: Record<string, any> }> = {
@@ -39,24 +39,33 @@ const RENDERER_TO_GPU_TRANSITION: Record<string, { id: string; params?: Record<s
 /**
  * Resolve transition type to GPU transition definition.
  *
- * Handles:
- * - Direct matches (transition type maps directly to GPU definition ID)
- * - Legacy mappings (old renderer types map to new GPU types)
- * - Parameter merging (default params from mapping + runtime params)
+ * Resolution priority:
+ * 1. Direct match with GPU definition ID (e.g., "cross-dissolve", "push", "glitch")
+ * 2. API transition renderer field (for custom published transitions)
+ * 3. Legacy mapping (old renderer types like "fade" → "cross-dissolve")
  *
- * @param transitionType - Transition type string
+ * @param transitionType - Transition type string (ID or renderer)
  * @param ALL_TRANSITIONS - Array of available GPU transition definitions
+ * @param rendererOverride - Optional renderer ID from API TransitionAsset
  * @returns Transition definition with merged parameters, or null if not found
  */
-export function resolveTransitionDefinition(transitionType: string, ALL_TRANSITIONS: any[]): { definition: any; params: Record<string, any> } | null {
-  // Direct match: transition type is a GPU definition ID
+export function resolveTransitionDefinition(transitionType: string, ALL_TRANSITIONS: any[], rendererOverride?: string): { definition: any; params: Record<string, any> } | null {
+  // Priority 1: Use renderer override from API (if provided)
+  if (rendererOverride) {
+    const definition = ALL_TRANSITIONS.find((t) => t.id === rendererOverride);
+    if (definition) {
+      return { definition, params: {} };
+    }
+  }
+
+  // Priority 2: Direct match - transition type is a GPU definition ID
   let definition = ALL_TRANSITIONS.find((t) => t.id === transitionType);
 
   if (definition) {
     return { definition, params: {} };
   }
 
-  // Legacy mapping: transition type needs conversion
+  // Priority 3: Legacy mapping - transition type needs conversion
   const mapping = RENDERER_TO_GPU_TRANSITION[transitionType];
 
   if (mapping) {
@@ -72,7 +81,7 @@ export function resolveTransitionDefinition(transitionType: string, ALL_TRANSITI
 
   // Not found
   if (import.meta.env.DEV) {
-    console.warn(`[TransitionResolver] Unknown transition type: ${transitionType}`);
+    console.warn(`[TransitionResolver] Unknown transition type: ${transitionType}, renderer: ${rendererOverride || "none"}`);
   }
 
   return null;

--- a/src/store/timelineStore.ts
+++ b/src/store/timelineStore.ts
@@ -83,7 +83,7 @@ interface TimelineStore {
   addTransition: (transition: TransitionTimelineItem) => void;
   removeTransition: (transitionId: string) => void;
   updateTransition: (transitionId: string, updates: Partial<TransitionTimelineItem>) => void;
-  createTransitionBetweenClips: (fromClipId: string, toClipId: string, type: TransitionType, duration?: number) => { transition?: TransitionTimelineItem; error: string | null };
+  createTransitionBetweenClips: (fromClipId: string, toClipId: string, type: TransitionType, duration?: number, renderer?: string) => { transition?: TransitionTimelineItem; error: string | null };
   moveClip: (clipId: string, startTime: number) => void;
   setZoom: (level: number) => void;
   /** Clamps to the SRP zoom range and syncs `zoomLevel` to `pixelsPerSecond / 100`. */
@@ -601,7 +601,7 @@ export const useTimelineStore = create<TimelineStore>(
       });
     },
 
-    createTransitionBetweenClips: (fromClipId, toClipId, type, duration = 0.5) => {
+    createTransitionBetweenClips: (fromClipId, toClipId, type, duration = 0.5, renderer) => {
       const state = get();
       const fromClip = state.clips.find((clip) => clip.id === fromClipId);
       const toClip = state.clips.find((clip) => clip.id === toClipId);
@@ -624,6 +624,7 @@ export const useTimelineStore = create<TimelineStore>(
         id: generateId("transition"),
         kind: "transition",
         type,
+        renderer, // Store renderer ID from API transition
         fromItemId: left.id,
         toItemId: right.id,
         alignment: "center",

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -439,6 +439,8 @@ export type TransitionEasing = import("@clypra-studio/engine").EasingFunction;
 export interface TransitionTimelineItem extends BaseTimelineItem {
   kind: "transition";
   type: TransitionType;
+  /** Renderer ID for GPU transition (e.g., "cross-dissolve", "push", "glitch") - used to resolve GPU implementation */
+  renderer?: string;
   fromItemId: string;
   toItemId: string;
   alignment: TransitionAlignment;


### PR DESCRIPTION
## Summary
Enables the clypra editor to use transitions published via the Transition Lab API.

## Changes Made
- **Added  field** to  type for GPU transition lookup
- **Enhanced ** with 3-level priority:
  1. API renderer override (custom published transitions)
  2. Direct GPU definition ID match  
  3. Legacy renderer mapping (backward compatibility)
- **Updated timeline store** to accept and store renderer parameter
- **Modified EditorLayout** to pass renderer ID from API TransitionAsset
- **Updated compositor** to pass renderer to resolution function

## Benefits
✅ Transitions published via Transition Lab now work in editor
✅ API transitions render with correct GPU shaders
✅ Full backward compatibility with legacy transition types
✅ Seamless integration between Transition Lab and Editor

## Testing
- Tested with existing legacy transitions (fade, dissolve, etc.)
- Tested with API transitions (cross-dissolve, push, glitch, etc.)
- Verified renderer field is properly stored and resolved