### PR TITLE
chore: Remove debug console.log statements

### DIFF
--- a/src/components/editor/EditorLayout.tsx
+++ b/src/components/editor/EditorLayout.tsx
@@ -385,15 +385,6 @@ export const EditorLayout: React.FC<EditorLayoutProps> = ({ onRequestClose }) =>
       // Filter must be downloaded first
       const cachedFilter = filterCacheManager.getCached(item.id);
 
-      console.log("[EditorLayout] handleAddToTimeline - filters:", {
-        itemId: item.id,
-        itemName: item.name,
-        hasCachedFilter: !!cachedFilter,
-        cachedFilterKeys: cachedFilter ? Object.keys(cachedFilter.filter) : [],
-        hasGradingParams: cachedFilter?.filter?.gradingParams ? true : false,
-        gradingParams: cachedFilter?.filter?.gradingParams,
-      });
-
       if (!cachedFilter) {
         useProjectStore.getState().showToast("Filter not downloaded yet", "warning");
         return;

--- a/src/components/editor/media-tabs/FiltersTab.tsx
+++ b/src/components/editor/media-tabs/FiltersTab.tsx
@@ -216,17 +216,6 @@ const FilterCard: React.FC<FilterCardProps> = ({ filter, isFavorite, onFavorite,
     if (isDownloading) return;
 
     try {
-      console.log(`[FilterCard] Adding filter "${filter.name}" to timeline`);
-      console.log(`[FilterCard] Filter object from listing:`, {
-        id: filter.id,
-        name: filter.name,
-        category: filter.category,
-        url: filter.url,
-        pipeline: filter.pipeline,
-        hasGradingParams: !!filter.gradingParams,
-        gradingParams: filter.gradingParams,
-        allKeys: Object.keys(filter),
-      });
       setIsDownloading(true);
 
       // Download filter JSON with minimum delay for visual feedback
@@ -234,19 +223,10 @@ const FilterCard: React.FC<FilterCardProps> = ({ filter, isFavorite, onFavorite,
       const delayPromise = new Promise((resolve) => setTimeout(resolve, 300));
 
       const [cachedFilter] = await Promise.all([downloadPromise, delayPromise]);
-      console.log(`[FilterCard] Filter "${filter.name}" downloaded successfully`);
-      console.log(`[FilterCard] Cached filter data:`, {
-        id: cachedFilter.id,
-        fileName: cachedFilter.fileName,
-        hasGradingParams: !!cachedFilter.filter.gradingParams,
-        gradingParams: cachedFilter.filter.gradingParams,
-        allKeys: Object.keys(cachedFilter.filter),
-      });
       setIsDownloaded(true);
 
       // Add to timeline
       onAddToTimeline(e);
-      console.log(`[FilterCard] Filter "${filter.name}" added to timeline`);
 
       // Show success feedback
       useProjectStore.getState().showToast(`Added ${filter.name} filter`);

--- a/src/core/render/filterCache.ts
+++ b/src/core/render/filterCache.ts
@@ -60,29 +60,12 @@ function buildStructuralKey(mediaLayer: EvaluatedMediaLayer, bodyMasks: Map<stri
 export function getOrUpdateFilters(mediaLayer: EvaluatedMediaLayer, width: number, height: number, bodyMasks: Map<string, any>): Filter[] {
   const clipId = mediaLayer.clipId;
 
-  console.log("[FilterCache] getOrUpdateFilters called:", {
-    clipId,
-    layerId: mediaLayer.layerId,
-    hasFilter: !!mediaLayer.filter,
-    filter: mediaLayer.filter,
-    effectsCount: mediaLayer.effects?.length || 0,
-    effects: mediaLayer.effects,
-  });
-
   const structuralKey = buildStructuralKey(mediaLayer, bodyMasks);
-  console.log("[FilterCache] structuralKey:", structuralKey);
 
   let entry = filterCache.get(clipId);
 
   if (!entry || entry.structuralKey !== structuralKey) {
     rebuildCounter++;
-    console.log("[Filters] rebuild count this session:", rebuildCounter);
-    console.log("[Filters] REBUILDING filter for clip:", clipId, {
-      oldKey: entry?.structuralKey,
-      newKey: structuralKey,
-      mediaLayerFilter: mediaLayer.filter,
-      mediaLayerEffects: mediaLayer.effects,
-    });
 
     // Structural change — full rebuild, but ONLY when the effect set actually changed
     if (entry) {

--- a/src/features/transitions/cache/transitionCache.ts
+++ b/src/features/transitions/cache/transitionCache.ts
@@ -139,10 +139,7 @@ class TransitionCacheManager {
    * Download and cache a transition definition JSON.
    * If already cached (and fresh), returns the cached entry immediately.
    */
-  async downloadTransition(
-    transition: TransitionAsset,
-    onProgress?: (progress: TransitionDownloadProgress) => void,
-  ): Promise<CachedTransition> {
+  async downloadTransition(transition: TransitionAsset, onProgress?: (progress: TransitionDownloadProgress) => void): Promise<CachedTransition> {
     await this.initialize();
 
     if (!this.cacheDir) {
@@ -156,7 +153,6 @@ class TransitionCacheManager {
         return cached;
       }
       // Stale — evict and re-download
-      console.log(`[TransitionCache] Entry for "${transition.name}" is stale (>7d). Re-downloading.`);
       this.cacheIndex.delete(transition.id);
     }
 
@@ -200,23 +196,17 @@ class TransitionCacheManager {
       this.cacheIndex.set(transition.id, cachedFile);
       await this.saveIndex();
 
-      console.log(`[TransitionCache] Cached transition: ${transition.name} → ${relativePath}`);
       return cachedFile;
     } catch (error) {
       console.error("[TransitionCache] Download failed:", error);
-      throw new Error(
-        `Failed to cache transition: ${error instanceof Error ? error.message : "Unknown error"}`,
-      );
+      throw new Error(`Failed to cache transition: ${error instanceof Error ? error.message : "Unknown error"}`);
     }
   }
 
   /**
    * Ensure a transition is cached (download if not already cached or if stale).
    */
-  async ensureDownloaded(
-    transition: TransitionAsset,
-    onProgress?: (progress: TransitionDownloadProgress) => void,
-  ): Promise<CachedTransition> {
+  async ensureDownloaded(transition: TransitionAsset, onProgress?: (progress: TransitionDownloadProgress) => void): Promise<CachedTransition> {
     await this.initialize();
 
     if (this.isCached(transition.id)) {
@@ -320,9 +310,7 @@ class TransitionCacheManager {
     }
 
     for (const id of staleIds) {
-      await this.clearCache(id).catch((err) =>
-        console.warn(`[TransitionCache] Failed to evict stale entry ${id}:`, err),
-      );
+      await this.clearCache(id).catch((err) => console.warn(`[TransitionCache] Failed to evict stale entry ${id}:`, err));
     }
 
     return staleIds.length;


### PR DESCRIPTION
- Remove filter-related debug logs from EditorLayout
- Remove filter cache verbose logging from filterCache.ts
- Remove filter card debug logs from FiltersTab.tsx
- Remove transition cache stale entry logs
- Clean up diagnostic output for production readiness