### PR TITLE
feat(transitions): Use GPU transition categories only

### DIFF
--- a/src/components/editor/media-tabs/TransitionsTab.tsx
+++ b/src/components/editor/media-tabs/TransitionsTab.tsx
@@ -15,19 +15,21 @@ import type { TransitionAsset } from "@/features/transitions/types";
 import { getPlaybackClock } from "@/hooks/usePlaybackClock";
 
 // Hardcoded transition categories for instant UI rendering
+// Matches GPU transition categories from Transition Lab Console
 const TRANSITION_CATEGORIES = [
-  { id: "fade", label: "Fade" },
-  { id: "slide", label: "Slide" },
-  { id: "wipe", label: "Wipe" },
-  { id: "zoom", label: "Zoom" },
-  { id: "dissolve", label: "Dissolve" },
-  { id: "creative", label: "Creative" },
+  { id: "geometric", label: "Geometric" },
+  { id: "optical-distortion", label: "Optical Distortion" },
+  { id: "temporal", label: "Temporal" },
+  { id: "particle-dissolve", label: "Particle Dissolve" },
+  { id: "light-based", label: "Light Based" },
+  { id: "depth-based", label: "Depth Based" },
+  { id: "physics-simulated", label: "Physics Simulated" },
 ] as const;
 
 type TransitionCategory = (typeof TRANSITION_CATEGORIES)[number]["id"];
 
 export const TransitionsTab: React.FC<TabProps> = ({ onAddToTimeline }) => {
-  const [activeCategory, setActiveCategory] = useState<TransitionCategory>("fade");
+  const [activeCategory, setActiveCategory] = useState<TransitionCategory>("geometric");
   const [transitions, setTransitions] = useState<TransitionAsset[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);


### PR DESCRIPTION
- Replace legacy categories (fade, slide, wipe, zoom, dissolve, creative)
- Use GPU categories: geometric, optical-distortion, temporal, particle-dissolve, light-based, depth-based, physics-simulated
- Matches Transition Lab Console categories
- Default to 'geometric' category