### PR TITLE
Add Tauri signing configuration for release builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -177,6 +177,8 @@ jobs:
         uses: tauri-apps/tauri-action@v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         with:
           projectPath: clypra
           releaseId: ${{ needs.create-release.outputs.release_id }}

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -48,10 +48,8 @@
   },
   "plugins": {
     "updater": {
-      "endpoints": [
-        "https://github.com/AIEraDev/clypra/releases/latest/download/updater.json"
-      ],
-      "pubkey": "dW51c2VkX3B1YmxpY19rZXlfZm9yX3VwZGF0ZXJfZGVtbw=="
+      "endpoints": ["https://github.com/AIEraDev/clypra/releases/latest/download/updater.json"],
+      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDdCOUZCOEM1RDBDN0NBOUI\nKUldTYnlzZlF4YmlmZXpMSUI4ZGJveW1xVFRIeDMza25NMlg0R2xmdFJNaTVLTHBmdVlYejFFc2oK"
     }
   }
 }


### PR DESCRIPTION
## Changes

This PR fixes the release build failures by properly configuring Tauri code signing:

### What's Fixed
- ✅ Generated new Tauri signing key pair with password protection
- ✅ Updated `tauri.conf.json` with the real public key (replacing demo key)
- ✅ Updated `.github/workflows/release.yml` to use signing credentials from GitHub secrets
- ✅ Keeps `createUpdaterArtifacts: true` for auto-update functionality

### What Was Failing
All platform builds (Windows, macOS, Linux) were failing with:
```
Error: A public key has been found, but no private key. 
Make sure to set TAURI_SIGNING_PRIVATE_KEY environment variable.
```

### GitHub Secrets Added
The following secrets have been added to the repository:
- `TAURI_SIGNING_PRIVATE_KEY` - The encrypted private key for signing
- `TAURI_SIGNING_PRIVATE_KEY_PASSWORD` - The password to decrypt the private key

### Testing
After merging, the v1.0.2 release workflow can be re-run and should complete successfully with signed installers for all platforms.

Fixes #144