### PR TITLE
fix: remove newline from Tauri public key

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -49,7 +49,7 @@
   "plugins": {
     "updater": {
       "endpoints": ["https://github.com/AIEraDev/clypra/releases/latest/download/updater.json"],
-      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDdCOUZCOEM1RDBDN0NBOUI\nKUldTYnlzZlF4YmlmZXpMSUI4ZGJveW1xVFRIeDMza25NMlg0R2xmdFJNaTVLTHBmdVlYejFFc2oK"
+      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDdCOUZCOEM1RDBDN0NBOUIKUldTYnlzZlF4YmlmZXpMSUI4ZGJveW1xVFRIeDMza25NMlg0R2xmdFJNaTVLTHBmdVlYejFFc2oK"
     }
   }
 }


### PR DESCRIPTION
## Problem
The Tauri public key in `tauri.conf.json` contained a `\n` newline character which caused base64 decoding to fail during release builds.

## Error
```
failed to decode pubkey: failed to decode base64 pubkey: failed to decode base64 key: Invalid symbol 10, offset 75.
```

## Solution
Removed the newline character from the public key base64 string.

## Testing
After this fix, the release builds should complete successfully with signed updater artifacts.