### PR TITLE
chore: bump version to 1.0.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clypra",
-  "version": "1.0.2",
+  "version": "1.0.4",
   "description": "A modern, open-source video editor built with Tauri, React, and TypeScript",
   "author": "Clypra Contributors",
   "license": "MIT",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Clypra",
-  "version": "1.0.2",
+  "version": "1.0.4",
   "identifier": "com.clypra.editor",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
Bump version to 1.0.4 for the new release with export pipeline fixes.