### PR TITLE
Fix sticker blinking and audio library export issues

### DIFF
--- a/src/core/evaluation/evaluator.ts
+++ b/src/core/evaluation/evaluator.ts
@@ -161,7 +161,7 @@ export function evaluateTimelineScene(time: number, clips: Clip[], tracks: Track
       const finalHeight = evalH * animationState.scale;
 
       const textLayer: EvaluatedTextLayer = {
-        layerId: `${clip.id}-${evalTime}`,
+        layerId: clip.id,
         clipId: clip.id,
         role: clip.role,
         clipKind: clip.kind,
@@ -232,7 +232,7 @@ export function evaluateTimelineScene(time: number, clips: Clip[], tracks: Track
     const transitionState = evaluateTransitionState(clip, transitionWindows);
 
     const mediaLayer: EvaluatedMediaLayer = {
-      layerId: `${clip.id}-${evalTime}`,
+      layerId: clip.id,
       clipId: clip.id,
       role: clip.role,
       clipKind: clip.kind,
@@ -316,7 +316,7 @@ export function evaluateTimelineScene(time: number, clips: Clip[], tracks: Track
     if (!sourcePath) continue;
 
     audioLayers.push({
-      layerId: `${clip.id}-audio-${evalTime}`,
+      layerId: `${clip.id}-audio`,
       clipId: clip.id,
       mediaId: clip.mediaId,
       sourcePath,

--- a/src/core/timeline/audioClips.ts
+++ b/src/core/timeline/audioClips.ts
@@ -63,10 +63,10 @@ export function getActiveAudioClips(clips: Clip[], tracks: Track[], assets: Medi
 
       // Find asset
       const asset = assets.find((a) => a.id === clip.mediaId);
-      if (!asset) return false;
+      const directAudioPath = (clip as any).audioPath as string | undefined;
+      const isAudioClip = asset?.type === "audio" || asset?.type === "video" || (clip.kind === "audio" && !!directAudioPath);
 
-      // Only include audio and video clips (video may have audio track)
-      if (asset.type !== "audio" && asset.type !== "video") return false;
+      if (!isAudioClip) return false;
 
       // Check if clip overlaps with export time range
       const clipStart = clip.startTime;
@@ -74,7 +74,9 @@ export function getActiveAudioClips(clips: Clip[], tracks: Track[], assets: Medi
       return clipStart < endTime && clipEnd > startTime;
     })
     .map((clip) => {
-      const asset = assets.find((a) => a.id === clip.mediaId)!;
+      const asset = assets.find((a) => a.id === clip.mediaId);
+      const directAudioPath = (clip as any).audioPath as string | undefined;
+      const rawPath = asset ? asset.path : directAudioPath!;
 
       // Calculate overlap with export time range
       const clipStart = clip.startTime;
@@ -97,8 +99,8 @@ export function getActiveAudioClips(clips: Clip[], tracks: Track[], assets: Medi
       const volume = Math.max(0, Math.min(1, clip.volume ?? 1.0));
 
       return {
-        // Normalize to native FS path — asset.path may be an asset:// or file:// URL
-        path: toNativePath(asset.path),
+        // Normalize to native FS path — asset.path or directAudioPath may be an asset:// or file:// URL
+        path: toNativePath(rawPath),
         startTime: relativeStartTime,
         duration: relativeDuration,
         trimIn: relativeTrimIn,


### PR DESCRIPTION
## Summary
This PR fixes two critical issues:

### 1. Sticker/Text Blinking Issue
**Problem**: Stickers and text were blinking/flickering during playback and export.

**Root Cause**: The timeline evaluator was generating unique layer IDs containing the frame time (`${clip.id}-${evalTime}`) on every frame. This caused the rendering engine to destroy and recreate Lottie players, text canvases, and WebGL textures on every frame, resulting in visible blinking.

**Solution**: Changed to static, consistent layer IDs (`clip.id` and `clip.id-audio`). This allows the engine to reuse resources across frames, eliminating blinking and significantly improving performance.

### 2. Audio Library Export Issue
**Problem**: Audio clips from the audio library weren't being exported with the video.

**Root Cause**: Audio library items are deliberately kept out of the project's media assets list to avoid cluttering the media upload tab. However, the export's audio filter only checked clips that mapped to a project asset, so library items were ignored.

**Solution**: Updated `getActiveAudioClips` to recognize and export clips that have a direct `audioPath` fallback property, mirroring the preview player's logic.

## Changes
- `src/core/evaluation/evaluator.ts`: Use static layer IDs instead of dynamic time-based IDs
- `src/core/timeline/audioClips.ts`: Support direct audioPath fallback for audio library clips

## Testing
All existing tests pass. Both issues have been verified as resolved.