### PR TITLE
chore: update @clypra-studio/engine to v1.0.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@capacitor/core": "^8.4.0",
         "@capacitor/filesystem": "^8.1.2",
-        "@clypra-studio/engine": "^1.0.3",
+        "@clypra-studio/engine": "^1.0.4",
         "@fontsource-variable/dancing-script": "^5.2.8",
         "@fontsource-variable/geist": "^5.2.9",
         "@fontsource-variable/inter": "^5.2.8",
@@ -781,10 +781,12 @@
       "license": "ISC"
     },
     "node_modules/@clypra-studio/engine": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@clypra-studio/engine/-/engine-1.0.3.tgz",
-      "integrity": "sha512-hBI4dwTdsBaCfOf6fM6Cg/mQ5SjAPIwBQvVDZaJKZyzfIgoqymHz2rjL76o3Cs1LKTgnL6xDUN6CXFIubux2KA==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@clypra-studio/engine/-/engine-1.0.4.tgz",
+      "integrity": "sha512-+AhhQwqok50iGwHSeanUnN6oS1SgebUQ5zPMbjZeNnM7lpknh3wJ+B+/VKUe8/xHaaHkPOukiB/bmtuvb8IhhA==",
+      "license": "MIT",
       "dependencies": {
+        "@clypra-studio/shaders": "^0.1.3",
         "@clypra-studio/types": "^0.2.0",
         "jszip": "^3.10.1",
         "lottie-web": "^5.13.0",
@@ -801,6 +803,12 @@
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
+    },
+    "node_modules/@clypra-studio/shaders": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@clypra-studio/shaders/-/shaders-0.1.3.tgz",
+      "integrity": "sha512-8Md9PNuWMFWVWOXKNkE1ykk541mkuJ2WOozRM89qTgS9o4akwiOIMA3dT3i6mHXvbUgIrD/zjckrdUzCpRnOHQ==",
+      "license": "MIT"
     },
     "node_modules/@clypra-studio/types": {
       "version": "0.2.0",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "dependencies": {
     "@capacitor/core": "^8.4.0",
     "@capacitor/filesystem": "^8.1.2",
-    "@clypra-studio/engine": "^1.0.3",
+    "@clypra-studio/engine": "^1.0.4",
     "@fontsource-variable/dancing-script": "^5.2.8",
     "@fontsource-variable/geist": "^5.2.9",
     "@fontsource-variable/inter": "^5.2.8",


### PR DESCRIPTION
Updates the clypra-engine dependency to v1.0.4 which includes the latest shader improvements.