### PR TITLE
chore: update @clypra-studio/engine to v1.0.6 with TypeScript declarations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
       "dependencies": {
         "@capacitor/core": "^8.4.0",
         "@capacitor/filesystem": "^8.1.2",
-        "@clypra-studio/engine": "^1.0.4",
+        "@clypra-studio/engine": "^1.0.6",
+        "@clypra-studio/shaders": "^0.1.5",
         "@fontsource-variable/dancing-script": "^5.2.8",
         "@fontsource-variable/geist": "^5.2.9",
         "@fontsource-variable/inter": "^5.2.8",
@@ -781,12 +782,12 @@
       "license": "ISC"
     },
     "node_modules/@clypra-studio/engine": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@clypra-studio/engine/-/engine-1.0.4.tgz",
-      "integrity": "sha512-+AhhQwqok50iGwHSeanUnN6oS1SgebUQ5zPMbjZeNnM7lpknh3wJ+B+/VKUe8/xHaaHkPOukiB/bmtuvb8IhhA==",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@clypra-studio/engine/-/engine-1.0.6.tgz",
+      "integrity": "sha512-rmW45+0+cw5Nd5zXIAUDXCiWAnzam4vY9uy1zHnebP+tNOAnMbxgU4kU9Z3m1ei2nCbRtatV/1Rn0WY+DImagw==",
       "license": "MIT",
       "dependencies": {
-        "@clypra-studio/shaders": "^0.1.3",
+        "@clypra-studio/shaders": "^0.1.4",
         "@clypra-studio/types": "^0.2.0",
         "jszip": "^3.10.1",
         "lottie-web": "^5.13.0",
@@ -805,9 +806,9 @@
       }
     },
     "node_modules/@clypra-studio/shaders": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@clypra-studio/shaders/-/shaders-0.1.3.tgz",
-      "integrity": "sha512-8Md9PNuWMFWVWOXKNkE1ykk541mkuJ2WOozRM89qTgS9o4akwiOIMA3dT3i6mHXvbUgIrD/zjckrdUzCpRnOHQ==",
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/@clypra-studio/shaders/-/shaders-0.1.5.tgz",
+      "integrity": "sha512-HxaREVUzAbPqC4dq+VCKDQCdWdJIY/HDOJ3+k/Le6ReSrI8UN2OWPIbki2h/qrppIvfZFxCZ0Lcm/ZnQZEM6LA==",
       "license": "MIT"
     },
     "node_modules/@clypra-studio/types": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
   "dependencies": {
     "@capacitor/core": "^8.4.0",
     "@capacitor/filesystem": "^8.1.2",
-    "@clypra-studio/engine": "^1.0.4",
+    "@clypra-studio/engine": "^1.0.6",
+    "@clypra-studio/shaders": "^0.1.5",
     "@fontsource-variable/dancing-script": "^5.2.8",
     "@fontsource-variable/geist": "^5.2.9",
     "@fontsource-variable/inter": "^5.2.8",


### PR DESCRIPTION
Updates the clypra-engine dependency to v1.0.6 which now includes proper TypeScript declaration files and uses the fixed shaders v0.1.5 package.

**Changes:**
- Updated @clypra-studio/engine from ^1.0.4 to ^1.0.6
- Engine v1.0.6 includes TypeScript type definitions
- Includes shaders v0.1.5 with proper exports configuration

**Build Status:**
- ✅ TypeScript compilation successful
- ✅ Vite production build successful
- ✅ All tests passing