### PR TITLE
fix: add missing mp4-muxer dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clypra",
-  "version": "1.0.6",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clypra",
-      "version": "1.0.6",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
         "@capacitor/core": "^8.4.0",
@@ -47,6 +47,7 @@
         "clsx": "^2.1.1",
         "lottie-web": "^5.13.0",
         "lucide-react": "^1.12.0",
+        "mp4-muxer": "^5.2.2",
         "radix-ui": "^1.4.3",
         "react": "^19.1.0",
         "react-dnd": "^16.0.1",
@@ -4997,6 +4998,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/dom-webcodecs": {
+      "version": "0.1.18",
+      "resolved": "https://registry.npmjs.org/@types/dom-webcodecs/-/dom-webcodecs-0.1.18.tgz",
+      "integrity": "sha512-vAvE8C9DGWR+tkb19xyjk1TSUlJ7RUzzp4a9Anu7mwBT+fpyePWK1UxmH14tMO5zHmrnrRIMg5NutnnDztLxgg==",
+      "license": "MIT"
+    },
     "node_modules/@types/earcut": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@types/earcut/-/earcut-3.0.0.tgz",
@@ -5091,6 +5098,12 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/validate-npm-package-name/-/validate-npm-package-name-4.0.2.tgz",
       "integrity": "sha512-lrpDziQipxCEeK5kWxvljWYhUvOiB2A9izZd9B2AFarYAkqZshb4lPbRs7zKEic6eGtH8V/2qJW+dPp9OtF6bw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/wicg-file-system-access": {
+      "version": "2020.9.8",
+      "resolved": "https://registry.npmjs.org/@types/wicg-file-system-access/-/wicg-file-system-access-2020.9.8.tgz",
+      "integrity": "sha512-ggMz8nOygG7d/stpH40WVaNvBwuyYLnrg5Mbyf6bmsj/8+gb6Ei4ZZ9/4PNpcPNTT8th9Q8sM8wYmWGjMWLX/A==",
       "license": "MIT"
     },
     "node_modules/@vitejs/plugin-react": {
@@ -8285,6 +8298,17 @@
       "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
       "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
       "license": "MIT"
+    },
+    "node_modules/mp4-muxer": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/mp4-muxer/-/mp4-muxer-5.2.2.tgz",
+      "integrity": "sha512-dhozjTywI0h2qFzeShagt8YYw811fh1XlwiDCE2f6Aeqf6xG2CyuShoSa5E0AZDO8pPF0JOZ3wOmWBNWIGdSpQ==",
+      "deprecated": "This library is superseded by Mediabunny. Please migrate to it.",
+      "license": "MIT",
+      "dependencies": {
+        "@types/dom-webcodecs": "^0.1.6",
+        "@types/wicg-file-system-access": "^2020.9.5"
+      }
     },
     "node_modules/mrmime": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "clsx": "^2.1.1",
     "lottie-web": "^5.13.0",
     "lucide-react": "^1.12.0",
+    "mp4-muxer": "^5.2.2",
     "radix-ui": "^1.4.3",
     "react": "^19.1.0",
     "react-dnd": "^16.0.1",


### PR DESCRIPTION
- Added mp4-muxer for WebCodecs mobile export
- Required for MobileExportEncoder to create MP4 containers
- Fixes build failure in GitHub Actions