### PR TITLE
chore: add .env.example file for local development (closes #63)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,11 @@
+# Clypra API key (required for text effects)
+VITE_CLYPRA_API_KEY=
+
+# Tauri dev server host (optional, defaults to localhost)
+TAURI_DEV_HOST=localhost
+
+# Body segmentation overrides (optional)
+# VITE_CLYPRA_BODY_SEGMENTATION_RUNTIME=
+# VITE_CLYPRA_BODY_SEGMENTATION_MODEL_URL=
+# VITE_CLYPRA_BODY_SEGMENTATION_RUNTIME_SCRIPT_URL=
+# VITE_CLYPRA_BODY_SEGMENTATION_WASM_BASE_URL=


### PR DESCRIPTION
Closes #63.

Provides .env.example with all documented env vars:
- VITE_CLYPRA_API_KEY (required, README tells users to add this)
- TAURI_DEV_HOST (optional, used by Vite dev server)
- Advanced body-segmentation overrides (optional, commented out)