### PR TITLE
feat: streamline timeline editing flow

### DIFF
--- a/src/components/editor/timeline/Timeline.tsx
+++ b/src/components/editor/timeline/Timeline.tsx
@@ -1,10 +1,8 @@
 import React, { useRef, useEffect, useCallback, useMemo } from "react";
 import { useTimelineStore } from "@/store/timelineStore";
 import { useUIStore } from "@/store/uiStore";
-import { useHistoryStore } from "@/store/historyStore";
-import { RippleDeleteCommand } from "@/core/history/commands/RippleDeleteCommand";
-import { DeleteClipCommand } from "@/core/history/commands/DeleteClipCommand";
 import { GapManager } from "@/lib/timeline/gapManager";
+import { EditingActions } from "@/core/interactions";
 import { usePreviewMode } from "@/hooks/usePreviewMode";
 import { usePlaybackClock, usePlaybackControls, getPlaybackClock } from "@/hooks/usePlaybackClock";
 import { getTimelineViewportEnd } from "@/lib/timeline/timelineClip";
@@ -201,9 +199,6 @@ export const Timeline: React.FC = () => {
 
       const uiState = useUIStore.getState();
       const store = useTimelineStore.getState();
-      const { execute, beginTransaction, commitTransaction } = useHistoryStore.getState();
-      const rippleEnabled = store.rippleEditEnabled;
-
       // Delete/Backspace: Remove selected clips or gaps
       if (e.key === "Delete" || e.key === "Backspace") {
         const { selectedClipIds, selectedGapId } = uiState;
@@ -223,31 +218,7 @@ export const Timeline: React.FC = () => {
         if (selectedClipIds.length === 0) return;
         e.preventDefault();
 
-        const { normalizeTrack, removeEmptyNonMainTracks, withBatch } = store;
-        const affectedTracks = new Set<string>();
-
-        beginTransaction("Delete Clips");
-
-        selectedClipIds.forEach((clipId) => {
-          const clip = store.clips.find((c) => c.id === clipId);
-          if (clip) {
-            affectedTracks.add(clip.trackId);
-            // Use ripple delete if ripple mode is enabled, otherwise regular delete
-            if (rippleEnabled) {
-              execute(new RippleDeleteCommand(clipId));
-            } else {
-              execute(new DeleteClipCommand(clipId));
-            }
-          }
-        });
-
-        commitTransaction();
-
-        withBatch(() => {
-          removeEmptyNonMainTracks(Array.from(affectedTracks));
-        });
-
-        uiState.clearSelection();
+        EditingActions.deleteSelection(selectedClipIds, e.altKey);
         return;
       }
 

--- a/src/components/editor/timeline/TimelineToolbar.tsx
+++ b/src/components/editor/timeline/TimelineToolbar.tsx
@@ -1,5 +1,5 @@
 import React, { useRef, useState } from "react";
-import { Link2, Mic, Search, ZoomIn, ZoomOut, ArrowLeftRight, Waves, Undo2, Redo2, ScissorsLineDashed, ChevronLeft, ChevronRight, Trash2, Copy } from "lucide-react";
+import { Link2, Mic, Search, ZoomIn, ZoomOut, ArrowLeftRight, Undo2, Redo2, ScissorsLineDashed, ChevronLeft, ChevronRight, Trash2, Copy, Maximize2 } from "lucide-react";
 import { Button } from "@/components/ui/Button";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/Tooltip";
 import { useTimelineStore } from "@/store/timelineStore";
@@ -7,8 +7,6 @@ import { useUIStore } from "@/store/uiStore";
 import { generateId } from "@/lib/utils/id";
 import { useSettingsStore } from "@/store/settingsStore";
 import { useHistoryStore } from "@/store/historyStore";
-import { RippleDeleteCommand } from "@/core/history/commands/RippleDeleteCommand";
-import { DeleteClipCommand } from "@/core/history/commands/DeleteClipCommand";
 import { SuccessToast } from "@/components/ui/SuccessToast";
 import { DEFAULT_SRP_CONFIG, SpatialTier } from "@/lib/renderEngine/types";
 import { clampTimelineZoom, formatCadenceSeconds, getSrpTierForZoom, getTimelineTemporalDetail, getZoomFromRatio, getZoomRatio, snapTimelineZoomToTierAnchors, TIMELINE_TIER_LABELS, TIMELINE_ZOOM_MAX, TIMELINE_ZOOM_MIN, TIMELINE_ZOOM_STEP } from "@/lib/timeline/timelineZoom";
@@ -17,15 +15,15 @@ import { EditingActions } from "@/core/interactions";
 import { useAnchoredTimelineZoom, type TimelineZoomAnchor } from "@/hooks/useAnchoredTimelineZoom";
 
 export const TimelineToolbar: React.FC = () => {
-  const { zoomLevel, pixelsPerSecond, swapClips, rippleEditEnabled, toggleRippleEdit, tracks, normalizeTrack } = useTimelineStore();
-  const { selectedClipIds, clearSelection } = useUIStore();
+  const { zoomLevel, pixelsPerSecond, swapClips, tracks, normalizeTrack } = useTimelineStore();
+  const { selectedClipIds } = useUIStore();
   const { state: historyState, undo, redo } = useHistoryStore();
   const [splitMode, setSplitMode] = useState(false);
   // const [linkMode, setLinkMode] = useState(true);
   const [toastMessage, setToastMessage] = useState<string | null>(null);
   const zoomRailRef = useRef<HTMLDivElement>(null);
   const zoomGestureAnchorRef = useRef<TimelineZoomAnchor | null>(null);
-  const { captureZoomAnchor, applyZoomLevel, zoomByStep } = useAnchoredTimelineZoom();
+  const { captureZoomAnchor, applyZoomLevel, zoomByStep, fitSequence } = useAnchoredTimelineZoom();
 
   // Split mode hook
   useSplitMode({
@@ -164,35 +162,9 @@ export const TimelineToolbar: React.FC = () => {
 
   const handleDeleteSelectedClips = () => {
     if (selectedClipIds.length === 0) return;
-
-    const { clips, normalizeTrack, removeEmptyNonMainTracks, withBatch } = useTimelineStore.getState();
-    const { execute, beginTransaction, commitTransaction } = useHistoryStore.getState();
-    const affectedTracks = new Set<string>();
-
-    // Use transaction to group all deletes into a single undo/redo unit
-    beginTransaction("Delete Clips");
-
-    selectedClipIds.forEach((clipId) => {
-      const clip = clips.find((c) => c.id === clipId);
-      if (!clip) return;
-      affectedTracks.add(clip.trackId);
-      // Use ripple delete if ripple mode is enabled, otherwise regular delete
-      if (rippleEditEnabled) {
-        execute(new RippleDeleteCommand(clipId));
-      } else {
-        execute(new DeleteClipCommand(clipId));
-      }
-    });
-
-    commitTransaction();
-
-    // Remove empty tracks after deletion (not part of undo/redo)
-    withBatch(() => {
-      removeEmptyNonMainTracks(Array.from(affectedTracks));
-    });
-
-    clearSelection();
+    const result = EditingActions.deleteSelection(selectedClipIds);
     setToastMessage(`Deleted ${selectedClipIds.length} clip${selectedClipIds.length > 1 ? "s" : ""}`);
+    if (!result) setToastMessage("No unlocked clips selected");
     setTimeout(() => setToastMessage(null), 2000);
   };
 
@@ -272,12 +244,6 @@ export const TimelineToolbar: React.FC = () => {
             </Button>
           </Tool> */}
 
-          <Tool label="Ripple mode (R) - Affects drag, trim, and delete operations">
-            <Button variant="ghost" size="icon-sm" className={rippleEditEnabled ? activeButton : toolButton} onClick={toggleRippleEdit}>
-              <Waves className="w-4 h-4" />
-            </Button>
-          </Tool>
-
           <Tool label="Delete selected clip(s)">
             <Button variant="ghost" size="icon-sm" className={toolButton} onClick={handleDeleteSelectedClips} disabled={selectedClipIds.length === 0}>
               <Trash2 className="w-4 h-4" />
@@ -299,6 +265,9 @@ export const TimelineToolbar: React.FC = () => {
 
         <div className="ml-auto flex items-center gap-2">
           <span className="inline-flex items-center gap-1">
+            <Button title="Fit sequence (Shift+Z)" variant="ghost" size="icon-sm" className={zoomButton} onClick={fitSequence} aria-label="Fit sequence">
+              <Maximize2 className="w-3.5 h-3.5" strokeWidth={2} />
+            </Button>
             <Button title="Zoom Out" variant="ghost" size="icon-sm" className={zoomButton} onClick={() => zoomByStep(-1)} disabled={zoomLevel <= TIMELINE_ZOOM_MIN} aria-label="Zoom out timeline">
               <ZoomOut className="w-2 h-2" strokeWidth={2} />
             </Button>

--- a/src/components/editor/timeline/Track.tsx
+++ b/src/components/editor/timeline/Track.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import { Lock } from "lucide-react";
 import { useDrop } from "react-dnd";
 import { useUIStore } from "@/store/uiStore";
@@ -8,6 +8,10 @@ import { Clip } from "./Clip";
 import { GapIndicator } from "./GapIndicator";
 import { TransitionIndicator } from "./TransitionIndicator";
 import { handleDropOnTrack } from "@/lib/timeline/timelineUtils";
+import { resolveInsertEdit } from "@/lib/timeline/insertEdit";
+import { getTimelineLaneClientX } from "@/lib/timeline/timelineViewport";
+import { resolveClipDuration } from "@/lib/timeline/timelineClip";
+import { useProjectStore } from "@/store/projectStore";
 import type { Clip as ClipType, Track as TrackType, DragItem } from "@/types";
 
 interface TrackProps {
@@ -31,18 +35,40 @@ interface TrackProps {
 }
 
 const TrackInner: React.FC<TrackProps> = ({ track, pixelsPerSecond, clips, onClipDragStart, onClipDragMove, onClipDragEnd, dragState }) => {
-  const selectedClipIds = useUIStore((s) => s.selectedClipIds);
-  const selectedGapId = useUIStore((s) => s.selectedGapId);
-  const selectedTrackId = useUIStore((s) => s.selectedTrackId);
-  const gaps = useTimelineStore((s) => s.gaps ?? []);
-  const transitions = useTimelineStore((s) => s.transitions ?? []);
-  const allClips = useTimelineStore((s) => s.clips);
+  const selectedClipIds = useUIStore((state) => state.selectedClipIds);
+  const selectedGapId = useUIStore((state) => state.selectedGapId);
+  const selectedTrackId = useUIStore((state) => state.selectedTrackId);
+  const gaps = useTimelineStore((state) => state.gaps ?? []);
+  const transitions = useTimelineStore((state) => state.transitions ?? []);
+  const allClips = useTimelineStore((state) => state.clips);
+  const scrollLeft = useTimelineStore((state) => state.scrollLeft);
+  const frameRate = useProjectStore((state) => state.project?.frameRate ?? 30);
   const { getMediaAsset } = useTimeline();
+  const [mediaDropPreview, setMediaDropPreview] = useState<{ startTime: number; duration: number; splitClipId: string | null; shiftedClipIds: string[] } | null>(null);
 
   // Drop handler for media assets from MediaTab
   const [{ isOver, canDrop }, drop] = useDrop(
     () => ({
       accept: ["MEDIA_ASSET"],
+      hover: (item: DragItem, monitor: any) => {
+        if (item.type !== "MEDIA_ASSET") return;
+        const offset = monitor.getClientOffset();
+        const container = document.getElementById("timeline-tracks-container");
+        if (!offset || !container) return;
+        const rect = container.getBoundingClientRect();
+        const requestedTime = (getTimelineLaneClientX(offset.x, rect.left, allClips.length > 0) + scrollLeft) / pixelsPerSecond;
+        const decision = resolveInsertEdit({ track, asset: item.asset, clips: allClips, requestedTime, frameRate });
+        setMediaDropPreview(
+          decision.accepted
+            ? {
+                startTime: decision.insertionTime,
+                duration: resolveClipDuration(item.asset),
+                splitClipId: decision.splitClipId,
+                shiftedClipIds: decision.shiftedClipIds,
+              }
+            : null,
+        );
+      },
       drop: (item: DragItem, monitor: any) => {
         if (!track.locked && track.type !== "text") {
           handleDropOnTrack(item, monitor, track.id);
@@ -54,8 +80,12 @@ const TrackInner: React.FC<TrackProps> = ({ track, pixelsPerSecond, clips, onCli
         canDrop: monitor.canDrop(),
       }),
     }),
-    [track.id, track.locked, track.type],
+    [track, allClips, scrollLeft, pixelsPerSecond, frameRate],
   );
+
+  useEffect(() => {
+    if (!isOver) setMediaDropPreview(null);
+  }, [isOver]);
 
   // FIX: clips are now pre-filtered by Timeline, so trackClips === clips
   // No need to filter again - this was causing unnecessary re-computation
@@ -72,6 +102,17 @@ const TrackInner: React.FC<TrackProps> = ({ track, pixelsPerSecond, clips, onCli
 
   // Calculate display info from placement preview (single source of truth)
   const displayInfo = useMemo(() => {
+    if ((!dragState || !dragState.draggedClipIds) && mediaDropPreview) {
+      const shifted = new Set(mediaDropPreview.shiftedClipIds);
+      return {
+        displayPositions: new Map(sortedTrackClips.map((clip) => [clip.id, shifted.has(clip.id) ? clip.startTime + mediaDropPreview.duration : clip.startTime])),
+        gapIndicator: {
+          startTime: mediaDropPreview.startTime,
+          duration: mediaDropPreview.duration,
+        },
+      };
+    }
+
     if (!dragState || !dragState.draggedClipIds) {
       return { displayPositions: null, gapIndicator: null };
     }
@@ -148,7 +189,7 @@ const TrackInner: React.FC<TrackProps> = ({ track, pixelsPerSecond, clips, onCli
     }
 
     return { displayPositions: null, gapIndicator: null };
-  }, [dragState, track.id, sortedTrackClips, pixelsPerSecond]);
+  }, [dragState, track.id, sortedTrackClips, pixelsPerSecond, mediaDropPreview]);
 
   const { displayPositions, gapIndicator } = displayInfo;
 
@@ -175,7 +216,15 @@ const TrackInner: React.FC<TrackProps> = ({ track, pixelsPerSecond, clips, onCli
           const isShifted = displayStartTime !== clip.startTime;
 
           // Override clip's startTime for display if shifted
-          const displayClip = isShifted ? { ...clip, startTime: displayStartTime } : clip;
+          let displayClip = isShifted ? { ...clip, startTime: displayStartTime } : clip;
+          const activeMediaPreview = mediaDropPreview;
+          if (activeMediaPreview && activeMediaPreview.splitClipId === clip.id) {
+            displayClip = {
+              ...displayClip,
+              duration: Math.max(0, activeMediaPreview.startTime - clip.startTime),
+              trimOut: clip.trimIn + Math.max(0, activeMediaPreview.startTime - clip.startTime),
+            };
+          }
 
           return (
             <Clip
@@ -202,6 +251,23 @@ const TrackInner: React.FC<TrackProps> = ({ track, pixelsPerSecond, clips, onCli
             />
           );
         })}
+
+      {mediaDropPreview?.splitClipId &&
+        (() => {
+          const splitClip = sortedTrackClips.find((clip) => clip.id === mediaDropPreview!.splitClipId);
+          if (!splitClip) return null;
+          const rightDuration = splitClip.startTime + splitClip.duration - mediaDropPreview!.startTime;
+          return (
+            <div
+              className="pointer-events-none absolute top-1 bottom-1 z-10 rounded border border-accent/60 bg-accent/20"
+              style={{
+                left: `${Math.round((mediaDropPreview.startTime + mediaDropPreview.duration) * pixelsPerSecond)}px`,
+                width: `${Math.max(1, Math.round(rightDuration * pixelsPerSecond))}px`,
+              }}
+              aria-hidden
+            />
+          );
+        })()}
 
       {/* Transitions layer */}
       {track.visible &&

--- a/src/core/history/commands/InsertEditCommand.ts
+++ b/src/core/history/commands/InsertEditCommand.ts
@@ -1,0 +1,115 @@
+import type { Command } from "../Command";
+import { generateCommandId } from "../Command";
+import type { Clip, Track } from "@/types";
+import { generateId } from "@/lib/utils/id";
+
+interface TimelineState {
+  tracks: Track[];
+  clips: Clip[];
+  epoch: number;
+}
+
+/** Stable identities affected by a completed insert edit. */
+export interface InsertEditResult {
+  insertedClipId: string;
+  splitClipId: string | null;
+  shiftedClipIds: string[];
+}
+
+class RestoreClipsCommand implements Command {
+  readonly id = generateCommandId();
+  readonly label = "Restore Insert Edit";
+  readonly timestamp = Date.now();
+  readonly undoable = true;
+  private replaced: Clip[] | null = null;
+
+  constructor(private readonly clips: Clip[]) {}
+
+  apply(state: TimelineState): TimelineState {
+    this.replaced = state.clips.map((clip) => ({ ...clip }));
+    return { ...state, clips: this.clips.map((clip) => ({ ...clip })), epoch: state.epoch + 1 };
+  }
+
+  invert(): Command {
+    if (!this.replaced) throw new Error("Cannot invert before restoring clips");
+    return new RestoreClipsCommand(this.replaced);
+  }
+}
+
+/** Split when necessary, insert media, and ripple only the target track. */
+export class InsertEditCommand implements Command {
+  readonly id = generateCommandId();
+  readonly label = "Insert Media";
+  readonly timestamp = Date.now();
+  readonly undoable = true;
+  private before: Clip[] | null = null;
+  private readonly leftClipId = generateId("clip");
+  private readonly rightClipId = generateId("clip");
+  private result: InsertEditResult | null = null;
+
+  constructor(
+    private readonly insertedClip: Clip,
+    private readonly insertionTime: number,
+    private readonly splitClipId: string | null,
+  ) {}
+
+  apply(state: TimelineState): TimelineState {
+    const targetTrack = state.tracks.find((track) => track.id === this.insertedClip.trackId);
+    const insertedIsAudio = this.insertedClip.kind === "audio";
+    if (!targetTrack || targetTrack.locked || (insertedIsAudio ? targetTrack.type !== "audio" : targetTrack.type !== "video")) {
+      this.result = null;
+      return state;
+    }
+
+    this.before = state.clips.map((clip) => ({ ...clip }));
+    const duration = this.insertedClip.duration;
+    const targetTrackId = this.insertedClip.trackId;
+    const splitClip = this.splitClipId ? state.clips.find((clip) => clip.id === this.splitClipId) : null;
+    const next: Clip[] = [];
+
+    for (const clip of state.clips) {
+      if (splitClip && clip.id === splitClip.id) {
+        const sourceOffset = this.insertionTime - clip.startTime;
+        const sourceSplit = clip.trimIn + sourceOffset;
+        next.push({
+          ...clip,
+          id: this.leftClipId,
+          duration: sourceOffset,
+          trimOut: sourceSplit,
+        });
+        next.push({
+          ...clip,
+          id: this.rightClipId,
+          startTime: this.insertionTime + duration,
+          duration: clip.duration - sourceOffset,
+          trimIn: sourceSplit,
+        });
+        continue;
+      }
+
+      if (clip.trackId === targetTrackId && clip.startTime >= this.insertionTime - 0.0005) {
+        next.push({ ...clip, startTime: clip.startTime + duration });
+      } else {
+        next.push(clip);
+      }
+    }
+
+    next.push({ ...this.insertedClip, startTime: this.insertionTime });
+    this.result = {
+      insertedClipId: this.insertedClip.id,
+      splitClipId: splitClip?.id ?? null,
+      shiftedClipIds: state.clips.filter((clip) => clip.trackId === targetTrackId && clip.id !== splitClip?.id && clip.startTime >= this.insertionTime - 0.0005).map((clip) => clip.id),
+    };
+    return { ...state, clips: next, epoch: state.epoch + 1 };
+  }
+
+  /** Return the identities affected by the most recent successful application. */
+  getResult(): InsertEditResult | null {
+    return this.result;
+  }
+
+  invert(): Command {
+    if (!this.before) throw new Error("Cannot invert InsertEditCommand before apply");
+    return new RestoreClipsCommand(this.before);
+  }
+}

--- a/src/core/history/commands/RippleDeleteRangeCommand.ts
+++ b/src/core/history/commands/RippleDeleteRangeCommand.ts
@@ -1,0 +1,108 @@
+import type { Command } from "../Command";
+import { generateCommandId } from "../Command";
+import type { Clip, Track } from "@/types";
+import type { Gap } from "@/types/gap";
+
+interface TimelineState {
+  tracks: Track[];
+  clips: Clip[];
+  gaps: Gap[];
+  epoch: number;
+}
+
+type TimelineSnapshot = Pick<TimelineState, "tracks" | "clips" | "gaps">;
+
+function cloneSnapshot(state: TimelineState): TimelineSnapshot {
+  return {
+    tracks: state.tracks.map((track) => ({ ...track })),
+    clips: state.clips.map((clip) => ({ ...clip })),
+    gaps: state.gaps.map((gap) => ({ ...gap, metadata: gap.metadata ? { ...gap.metadata } : gap.metadata })),
+  };
+}
+
+class RestoreTimelineSnapshotCommand implements Command {
+  readonly id = generateCommandId();
+  readonly label = "Restore Ripple Delete";
+  readonly timestamp = Date.now();
+  readonly undoable = true;
+  private replaced: TimelineSnapshot | null = null;
+
+  constructor(private readonly snapshot: TimelineSnapshot) {}
+
+  apply(state: TimelineState): TimelineState {
+    this.replaced = cloneSnapshot(state);
+    return {
+      ...state,
+      ...cloneSnapshot({ ...state, ...this.snapshot }),
+      epoch: state.epoch + 1,
+    };
+  }
+
+  invert(): Command {
+    if (!this.replaced) throw new Error("Cannot invert before applying snapshot");
+    return new RestoreTimelineSnapshotCommand(this.replaced);
+  }
+}
+
+/**
+ * Removes one or more clips and closes only their occupied time on each track.
+ * Calculating one shift per survivor avoids the repeated/double shifts produced
+ * by executing one ripple command per selected clip.
+ */
+export class RippleDeleteRangeCommand implements Command {
+  readonly id = generateCommandId();
+  readonly label = "Ripple Delete Clips";
+  readonly timestamp = Date.now();
+  readonly undoable = true;
+  private before: TimelineSnapshot | null = null;
+
+  constructor(private readonly clipIds: string[]) {}
+
+  apply(state: TimelineState): TimelineState {
+    this.before = cloneSnapshot(state);
+    const selected = new Set(this.clipIds);
+    const deleted = state.clips.filter((clip) => selected.has(clip.id));
+    if (deleted.length === 0) return state;
+
+    const deletedByTrack = new Map<string, Clip[]>();
+    for (const clip of deleted) {
+      const track = state.tracks.find((candidate) => candidate.id === clip.trackId);
+      if (track?.locked) continue;
+      const clips = deletedByTrack.get(clip.trackId) ?? [];
+      clips.push(clip);
+      deletedByTrack.set(clip.trackId, clips);
+    }
+    const actuallyDeleted = new Set(Array.from(deletedByTrack.values()).flat().map((clip) => clip.id));
+
+    const clips = state.clips
+      .filter((clip) => !actuallyDeleted.has(clip.id))
+      .map((clip) => {
+        const removed = deletedByTrack.get(clip.trackId);
+        if (!removed) return clip;
+        const lastProtectedBarrier = state.gaps
+          .filter((gap) => gap.trackId === clip.trackId && gap.protected && gap.startTime + gap.duration <= clip.startTime + 0.0005)
+          .reduce((latest, gap) => Math.max(latest, gap.startTime + gap.duration), 0);
+        const shift = removed
+          .filter((deletedClip) => deletedClip.startTime < clip.startTime && deletedClip.startTime >= lastProtectedBarrier - 0.0005)
+          .reduce((sum, deletedClip) => sum + deletedClip.duration, 0);
+        return shift > 0 ? { ...clip, startTime: Math.max(0, clip.startTime - shift) } : clip;
+      });
+
+    const occupiedTrackIds = new Set(clips.map((clip) => clip.trackId));
+    const tracks = state.tracks.filter((track) => occupiedTrackIds.has(track.id) || track.id === state.tracks.find((candidate) => candidate.type === "video")?.id);
+    const deletedTrackIds = new Set(state.tracks.filter((track) => !tracks.some((candidate) => candidate.id === track.id)).map((track) => track.id));
+
+    return {
+      ...state,
+      tracks,
+      clips,
+      gaps: state.gaps.filter((gap) => !deletedTrackIds.has(gap.trackId)),
+      epoch: state.epoch + 1,
+    };
+  }
+
+  invert(): Command {
+    if (!this.before) throw new Error("Cannot invert RippleDeleteRangeCommand before apply");
+    return new RestoreTimelineSnapshotCommand(this.before);
+  }
+}

--- a/src/core/history/commands/__tests__/TimelineFlowCommands.test.ts
+++ b/src/core/history/commands/__tests__/TimelineFlowCommands.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+import type { Clip, Track } from "@/types";
+import { InsertEditCommand } from "../InsertEditCommand";
+import { RippleDeleteRangeCommand } from "../RippleDeleteRangeCommand";
+
+const track: Track = { id: "v1", type: "video", name: "Video", muted: false, locked: false, visible: true, height: 68 };
+const clip = (id: string, startTime: number, duration: number, trimIn = 0): Clip =>
+  ({
+    id,
+    trackId: "v1",
+    mediaId: `media-${id}`,
+    startTime,
+    duration,
+    trimIn,
+    trimOut: trimIn + duration,
+    x: 0,
+    y: 0,
+    width: 1920,
+    height: 1080,
+    opacity: 1,
+    rotation: 0,
+  }) as Clip;
+
+describe("timeline flow commands", () => {
+  it("ripple deletes an adjacent range without double-shifting and restores it", () => {
+    const state = {
+      tracks: [track],
+      clips: [clip("a", 0, 2), clip("b", 2, 2), clip("c", 4, 2), clip("d", 6, 2)],
+      gaps: [],
+      epoch: 0,
+    };
+    const command = new RippleDeleteRangeCommand(["b", "c"]);
+    const deleted = command.apply(state);
+    expect(deleted.clips.map((item) => [item.id, item.startTime])).toEqual([
+      ["a", 0],
+      ["d", 2],
+    ]);
+    expect(command.invert().apply(deleted).clips).toEqual(state.clips);
+  });
+
+  it("does not ripple edits across a protected gap", () => {
+    const state = {
+      tracks: [track],
+      clips: [clip("a", 0, 2), clip("delete", 2, 2), clip("later", 8, 2)],
+      gaps: [{ id: "protected", trackId: "v1", startTime: 4, duration: 4, type: "protected" as const, source: "user-insert" as const, protected: true }],
+      epoch: 0,
+    };
+    const deleted = new RippleDeleteRangeCommand(["delete"]).apply(state);
+    expect(deleted.clips.find((item) => item.id === "later")?.startTime).toBe(8);
+    expect(deleted.gaps).toEqual(state.gaps);
+  });
+
+  it("splits a clip, inserts media, shifts later clips, and restores exact state", () => {
+    const original = clip("source", 0, 10, 5);
+    const later = clip("later", 10, 2);
+    const inserted = clip("inserted", 4, 3);
+    const state = { tracks: [track], clips: [original, later], gaps: [], epoch: 0 };
+    const command = new InsertEditCommand(inserted, 4, original.id);
+    const result = command.apply(state);
+    const pieces = result.clips.filter((item) => item.mediaId === original.mediaId).sort((a, b) => a.startTime - b.startTime);
+    expect(pieces).toHaveLength(2);
+    expect(pieces[0]).toMatchObject({ startTime: 0, duration: 4, trimIn: 5, trimOut: 9 });
+    expect(pieces[1]).toMatchObject({ startTime: 7, duration: 6, trimIn: 9, trimOut: 15 });
+    expect(result.clips.find((item) => item.id === "later")?.startTime).toBe(13);
+    expect(command.invert().apply(result).clips).toEqual(state.clips);
+  });
+
+  it("inserts at an existing cut without creating a redundant split", () => {
+    const state = { tracks: [track], clips: [clip("a", 0, 4), clip("b", 4, 4)], gaps: [], epoch: 0 };
+    const result = new InsertEditCommand(clip("inserted", 4, 2), 4, null).apply(state);
+    expect(result.clips).toHaveLength(3);
+    expect(result.clips.find((item) => item.id === "b")?.startTime).toBe(6);
+  });
+
+  it("defensively rejects insert commands when the target becomes locked", () => {
+    const state = { tracks: [{ ...track, locked: true }], clips: [clip("a", 0, 4)], gaps: [], epoch: 0 };
+    const command = new InsertEditCommand(clip("inserted", 2, 2), 2, "a");
+    expect(command.apply(state)).toBe(state);
+    expect(command.getResult()).toBeNull();
+  });
+});

--- a/src/core/history/commands/index.ts
+++ b/src/core/history/commands/index.ts
@@ -7,9 +7,11 @@
 export { MoveClipCommand } from "./MoveClipCommand";
 export { DeleteClipCommand, AddClipCommand } from "./DeleteClipCommand";
 export { RippleDeleteCommand } from "./RippleDeleteCommand";
+export { RippleDeleteRangeCommand } from "./RippleDeleteRangeCommand";
 export { TrimClipCommand } from "./TrimClipCommand";
 export { SplitClipCommand } from "./SplitClipCommand";
 export { UpdateClipCommand } from "./UpdateClipCommand";
 export { AddTrackCommand, DeleteTrackCommand, ToggleTrackPropertyCommand } from "./TrackCommands";
 export { TransformClipCommand } from "./TransformCommand";
 export { InsertGapCommand, RemoveGapCommand, ResizeGapCommand, ToggleGapProtectionCommand } from "./GapCommands";
+export { InsertEditCommand } from "./InsertEditCommand";

--- a/src/core/interactions/EditingActions.ts
+++ b/src/core/interactions/EditingActions.ts
@@ -24,10 +24,12 @@ import { useHistoryStore } from "@/store/historyStore";
 import { useTimelineStore } from "@/store/timelineStore";
 import { useProjectStore } from "@/store/projectStore";
 import { getPlaybackClock } from "@/hooks/usePlaybackClock";
+import { getActiveSessionOrNull } from "@/core/runtime/ProjectSession";
 import { useUIStore } from "@/store/uiStore";
-import { SplitClipCommand, UpdateClipCommand } from "../history/commands";
+import { DeleteClipCommand, RippleDeleteRangeCommand, SplitClipCommand, UpdateClipCommand } from "../history/commands";
 import type { Clip } from "@/types";
 import { snapToFrameBoundary } from "@/lib/utils/frameTime";
+import { getScrollLeftToRevealTime, getTimelineViewportEndForDuration } from "@/lib/timeline/timelineViewport";
 
 /**
  * Split interaction context.
@@ -58,6 +60,13 @@ export interface TrimAtPlayheadResult {
   error?: string;
 }
 
+/** Result of deleting the current clip selection. */
+export interface DeleteSelectionResult {
+  deletedClipIds: string[];
+  editTime: number;
+  selectedClipId: string | null;
+}
+
 /**
  * Editing Actions - Unified interaction layer.
  *
@@ -65,6 +74,64 @@ export interface TrimAtPlayheadResult {
  * This ensures consistent command execution and history tracking.
  */
 export class EditingActions {
+  /** Delete selected clips with ripple closure, or lift them while preserving time. */
+  static deleteSelection(clipIds: string[], lift = false): DeleteSelectionResult | null {
+    const timeline = useTimelineStore.getState();
+    const selected = timeline.clips.filter((clip) => clipIds.includes(clip.id) && !timeline.tracks.find((track) => track.id === clip.trackId)?.locked);
+    if (selected.length === 0) return null;
+
+    const editTime = Math.min(...selected.map((clip) => clip.startTime));
+    const affectedTrackIds = new Set(selected.map((clip) => clip.trackId));
+    const history = useHistoryStore.getState();
+
+    if (lift) {
+      history.beginTransaction("Lift Delete Clips");
+      selected.forEach((clip) => history.execute(new DeleteClipCommand(clip.id)));
+      history.commitTransaction();
+    } else {
+      history.execute(new RippleDeleteRangeCommand(selected.map((clip) => clip.id)));
+    }
+
+    affectedTrackIds.forEach((trackId) => useTimelineStore.getState().detectAndSyncGaps(trackId));
+
+    const nextState = useTimelineStore.getState();
+    const nextClip =
+      nextState.clips
+        .filter((clip) => affectedTrackIds.has(clip.trackId) && clip.startTime >= editTime - 0.001)
+        .sort((a, b) => a.startTime - b.startTime)[0] ?? null;
+
+    const ui = useUIStore.getState();
+    ui.clearSelection();
+    if (nextClip) ui.selectClip(nextClip.id);
+
+    const session = getActiveSessionOrNull();
+    session?.transportAuthority?.seek(editTime);
+
+    const container =
+      typeof document === "undefined"
+        ? null
+        : (document.getElementById("timeline-tracks-container") as HTMLDivElement | null);
+    if (container) {
+      const currentTimeline = useTimelineStore.getState();
+      const nextScrollLeft = getScrollLeftToRevealTime({
+        time: editTime,
+        currentScrollLeft: container.scrollLeft,
+        containerWidth: container.clientWidth,
+        pixelsPerSecond: currentTimeline.pixelsPerSecond,
+        viewportEndSeconds: getTimelineViewportEndForDuration(currentTimeline.getTimelineEndTime()),
+        hasClips: currentTimeline.clips.length > 0,
+      });
+      container.scrollLeft = nextScrollLeft;
+      currentTimeline.setScrollLeft(nextScrollLeft);
+    }
+
+    return {
+      deletedClipIds: selected.map((clip) => clip.id),
+      editTime,
+      selectedClipId: nextClip?.id ?? null,
+    };
+  }
+
   /**
    * Execute a split operation.
    *

--- a/src/core/interactions/__tests__/EditingActions.test.ts
+++ b/src/core/interactions/__tests__/EditingActions.test.ts
@@ -88,4 +88,39 @@ describe("EditingActions split interactions", () => {
     expect(useTimelineStore.getState().clips).toHaveLength(1);
     expect(useUIStore.getState().selectedClipIds).toEqual([]);
   });
+
+  it("ripple deletes a selected middle range and selects the next clip", () => {
+    useTimelineStore.setState({
+      clips: [
+        makeClip({ id: "left", startTime: 0, duration: 2, trimOut: 2 }),
+        makeClip({ id: "middle-a", startTime: 2, duration: 2, trimIn: 2, trimOut: 4 }),
+        makeClip({ id: "middle-b", startTime: 4, duration: 2, trimIn: 4, trimOut: 6 }),
+        makeClip({ id: "right", startTime: 6, duration: 4, trimIn: 6, trimOut: 10 }),
+      ],
+      gaps: [{ id: "stale-gap", trackId: "track-1", startTime: 2, duration: 4, type: "auto", source: "clip-delete", protected: false }],
+    });
+
+    const result = EditingActions.deleteSelection(["middle-a", "middle-b"]);
+    const state = useTimelineStore.getState();
+    expect(result).toMatchObject({ editTime: 2, selectedClipId: "right" });
+    expect(state.clips.find((clip) => clip.id === "right")?.startTime).toBe(2);
+    expect(state.gaps).toEqual([]);
+    expect(useUIStore.getState().selectedClipIds).toEqual(["right"]);
+
+    useHistoryStore.getState().undo();
+    expect(useTimelineStore.getState().clips.map((clip) => [clip.id, clip.startTime])).toEqual([
+      ["left", 0],
+      ["middle-a", 2],
+      ["middle-b", 4],
+      ["right", 6],
+    ]);
+  });
+
+  it("lift deletes without shifting later clips", () => {
+    useTimelineStore.setState({
+      clips: [makeClip({ id: "left", startTime: 0, duration: 5, trimOut: 5 }), makeClip({ id: "right", startTime: 5, duration: 5, trimIn: 5, trimOut: 10 })],
+    });
+    EditingActions.deleteSelection(["left"], true);
+    expect(useTimelineStore.getState().clips.find((clip) => clip.id === "right")?.startTime).toBe(5);
+  });
 });

--- a/src/core/playback/TransportAuthority.ts
+++ b/src/core/playback/TransportAuthority.ts
@@ -70,6 +70,17 @@ export class TransportAuthority {
     this.activeContext?.play();
   }
 
+  /** Toggle the active context from its live state without a throttled UI snapshot. */
+  togglePlayback(): void {
+    const context = this.activeContext;
+    if (!context) return;
+    if (context.getState() === "playing") {
+      context.pause();
+    } else {
+      context.play();
+    }
+  }
+
   pause(): void {
     this.activeContext?.pause();
   }

--- a/src/core/playback/__tests__/TransportAuthority.test.ts
+++ b/src/core/playback/__tests__/TransportAuthority.test.ts
@@ -112,6 +112,16 @@ describe("TransportAuthority", () => {
       expect(mockProgramContext.pause).toHaveBeenCalled();
     });
 
+    it("toggles from the active context's live state", () => {
+      mockProgramContext.getState = vi.fn(() => "paused" as any);
+      authority.togglePlayback();
+      expect(mockProgramContext.play).toHaveBeenCalledTimes(1);
+
+      mockProgramContext.getState = vi.fn(() => "playing" as any);
+      authority.togglePlayback();
+      expect(mockProgramContext.pause).toHaveBeenCalledTimes(1);
+    });
+
     it("seek delegates to active context", () => {
       authority.seek(5);
       expect(mockProgramContext.seek).toHaveBeenCalledWith(5);

--- a/src/hooks/useAnchoredTimelineZoom.ts
+++ b/src/hooks/useAnchoredTimelineZoom.ts
@@ -3,6 +3,7 @@ import { getPlaybackClock } from "@/hooks/usePlaybackClock";
 import { useTimelineStore } from "@/store/timelineStore";
 import {
   getAnchoredZoomScrollLeft,
+  getFitSequencePixelsPerSecond,
   getTimelineLaneWidth,
   getTimelineViewportEndForDuration,
   zoomToPixelsPerSecond,
@@ -85,9 +86,20 @@ export function useAnchoredTimelineZoom() {
     applyZoomLevel(clampTimelineZoom(state.zoomLevel + direction * TIMELINE_ZOOM_STEP), anchor);
   }, [applyZoomLevel, captureZoomAnchor]);
 
+  const fitSequence = useCallback(() => {
+    const container = getTimelineContainer();
+    if (!container) return;
+    const state = useTimelineStore.getState();
+    const pixelsPerSecond = getFitSequencePixelsPerSecond(container.clientWidth, state.getTimelineEndTime(), state.clips.length > 0);
+    state.setPixelsPerSecond(pixelsPerSecond);
+    container.scrollLeft = 0;
+    state.setScrollLeft(0);
+  }, []);
+
   return {
     captureZoomAnchor,
     applyZoomLevel,
     zoomByStep,
+    fitSequence,
   };
 }

--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -30,16 +30,15 @@ let copiedClipsClipboard: Array<{
 }> = [];
 
 export const useKeyboardShortcuts = () => {
-  const { play, pause, seek, setActiveContext } = useTransportControls();
-  const { state: transportState, time: transportTime, speed } = useTransportSnapshot();
-  const { swapClips, rippleEditEnabled, toggleRippleEdit, addMarker } = useTimelineStore();
+  const { pause, seek, setActiveContext, togglePlayback } = useTransportControls();
+  const { time: transportTime } = useTransportSnapshot();
+  const { swapClips, addMarker } = useTimelineStore();
   const { selectedClipIds, selectClip, selectTrack, previewMode, exitSourceMode, markSourceIn, markSourceOut } = useUIStore();
   const { project } = useProjectStore();
   const { undo, redo } = useHistoryStore();
-  const { zoomByStep } = useAnchoredTimelineZoom();
+  const { zoomByStep, fitSequence } = useAnchoredTimelineZoom();
   const [toastMessage, setToastMessage] = React.useState<string | null>(null);
 
-  const isPlaying = transportState === "playing";
   const frameRate = project?.frameRate ?? 30;
 
   useEffect(() => {
@@ -56,7 +55,7 @@ export const useKeyboardShortcuts = () => {
 
       if (e.code === "Space") {
         e.preventDefault();
-        isPlaying ? pause() : play();
+        if (!e.repeat) togglePlayback();
         return;
       }
 
@@ -221,11 +220,9 @@ export const useKeyboardShortcuts = () => {
       } else if (isMeta && e.key === "-") {
         e.preventDefault();
         zoomByStep(-1);
-      } else if (e.key === "r" && !isMeta) {
+      } else if (e.shiftKey && e.key.toLowerCase() === "z") {
         e.preventDefault();
-        toggleRippleEdit();
-        setToastMessage(rippleEditEnabled ? "Ripple Mode: OFF" : "Ripple Mode: ON");
-        setTimeout(() => setToastMessage(null), 2000);
+        fitSequence();
       } else if (isMeta && e.key.toLowerCase() === "k") {
         e.preventDefault();
         // Ctrl/Cmd+K: Split selected clips (or all if none selected)
@@ -510,7 +507,7 @@ export const useKeyboardShortcuts = () => {
 
     window.addEventListener("keydown", handleKeyDown);
     return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [isPlaying, transportTime, frameRate, selectedClipIds, previewMode, rippleEditEnabled, play, pause, seek, setActiveContext, zoomByStep, selectClip, selectTrack, exitSourceMode, markSourceIn, markSourceOut, swapClips, toggleRippleEdit, addMarker, undo, redo]);
+  }, [transportTime, frameRate, selectedClipIds, previewMode, togglePlayback, pause, seek, setActiveContext, zoomByStep, fitSequence, selectClip, selectTrack, exitSourceMode, markSourceIn, markSourceOut, swapClips, addMarker, undo, redo]);
 
   return { toastMessage };
 };

--- a/src/hooks/usePlaybackClock.ts
+++ b/src/hooks/usePlaybackClock.ts
@@ -92,6 +92,10 @@ export function useTransportControls() {
         getActiveSessionOrNull()?.unlockPreviewAudio();
         authority?.play();
       },
+      togglePlayback: () => {
+        getActiveSessionOrNull()?.unlockPreviewAudio();
+        authority?.togglePlayback();
+      },
       pause: () => authority?.pause(),
       stop: () => authority?.stop(),
       seek: (time: number) => authority?.seek(time),

--- a/src/lib/timeline/__tests__/insertEdit.test.ts
+++ b/src/lib/timeline/__tests__/insertEdit.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import type { Clip, MediaAsset, Track } from "@/types";
+import { resolveInsertEdit } from "../insertEdit";
+
+const videoTrack = { id: "v1", type: "video", locked: false } as Track;
+const videoAsset = { id: "media", type: "video", duration: 5 } as MediaAsset;
+const source = { id: "source", trackId: "v1", startTime: 0, duration: 10 } as Clip;
+
+describe("resolveInsertEdit", () => {
+  it("snaps and identifies a clip that must be split", () => {
+    const result = resolveInsertEdit({ track: videoTrack, asset: videoAsset, clips: [source], requestedTime: 4.02, frameRate: 30 });
+    expect(result.accepted).toBe(true);
+    expect(result.insertionTime).toBe(4.033333333333333);
+    expect(result.splitClipId).toBe("source");
+  });
+
+  it("uses an existing cut without a split", () => {
+    const result = resolveInsertEdit({ track: videoTrack, asset: videoAsset, clips: [source], requestedTime: 10, frameRate: 30 });
+    expect(result.splitClipId).toBeNull();
+  });
+
+  it("rejects locked and incompatible tracks", () => {
+    expect(resolveInsertEdit({ track: { ...videoTrack, locked: true }, asset: videoAsset, clips: [], requestedTime: 0, frameRate: 30 }).accepted).toBe(false);
+    expect(resolveInsertEdit({ track: videoTrack, asset: { ...videoAsset, type: "audio" }, clips: [], requestedTime: 0, frameRate: 30 }).accepted).toBe(false);
+  });
+});

--- a/src/lib/timeline/__tests__/timelineViewport.test.ts
+++ b/src/lib/timeline/__tests__/timelineViewport.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { getFitSequencePixelsPerSecond, getScrollLeftToRevealTime } from "../timelineViewport";
+
+describe("timeline viewport editing helpers", () => {
+  it("fits the full sequence into the lane after subtracting labels", () => {
+    expect(getFitSequencePixelsPerSecond(1160, 100, true)).toBe(10);
+    expect(getFitSequencePixelsPerSecond(1160, 10_000, true)).toBe(0.1);
+  });
+
+  it("clamps extremely long sequence fit to the supported overview floor", () => {
+    expect(getFitSequencePixelsPerSecond(1160, 10_000_000, true)).toBe(0.0001);
+  });
+
+  it("keeps visible edit points still and reveals offscreen edit points", () => {
+    expect(
+      getScrollLeftToRevealTime({
+        time: 7,
+        currentScrollLeft: 500,
+        containerWidth: 1160,
+        pixelsPerSecond: 100,
+        viewportEndSeconds: 100,
+        hasClips: true,
+      }),
+    ).toBe(500);
+
+    expect(
+      getScrollLeftToRevealTime({
+        time: 50,
+        currentScrollLeft: 0,
+        containerWidth: 1160,
+        pixelsPerSecond: 100,
+        viewportEndSeconds: 100,
+        hasClips: true,
+      }),
+    ).toBe(4150);
+  });
+});

--- a/src/lib/timeline/insertEdit.ts
+++ b/src/lib/timeline/insertEdit.ts
@@ -1,0 +1,48 @@
+import type { Clip, MediaAsset, Track } from "@/types";
+import { snapToFrameBoundary } from "@/lib/utils/frameTime";
+
+/** Frame-snapped placement decision shared by insert preview and commit. */
+export interface InsertEditDecision {
+  accepted: boolean;
+  targetTrackId: string;
+  insertionTime: number;
+  splitClipId: string | null;
+  shiftedClipIds: string[];
+  reason?: string;
+}
+
+function isCompatible(track: Track, asset: MediaAsset): boolean {
+  if (asset.type === "audio") return track.type === "audio";
+  return track.type === "video";
+}
+
+/** Resolve whether and how a media asset can be inserted on a timeline track. */
+export function resolveInsertEdit(params: {
+  track: Track;
+  asset: MediaAsset;
+  clips: Clip[];
+  requestedTime: number;
+  frameRate: number;
+}): InsertEditDecision {
+  const { track, asset, clips, frameRate } = params;
+  const insertionTime = Math.max(0, snapToFrameBoundary(params.requestedTime, frameRate));
+
+  if (track.locked) {
+    return { accepted: false, targetTrackId: track.id, insertionTime, splitClipId: null, shiftedClipIds: [], reason: "Track is locked" };
+  }
+  if (!isCompatible(track, asset)) {
+    return { accepted: false, targetTrackId: track.id, insertionTime, splitClipId: null, shiftedClipIds: [], reason: "Media type is incompatible with this track" };
+  }
+
+  const trackClips = clips.filter((clip) => clip.trackId === track.id);
+  const splitClip = trackClips.find((clip) => insertionTime > clip.startTime + 0.0005 && insertionTime < clip.startTime + clip.duration - 0.0005);
+  const shiftedClipIds = trackClips.filter((clip) => clip.id !== splitClip?.id && clip.startTime >= insertionTime - 0.0005).map((clip) => clip.id);
+
+  return {
+    accepted: true,
+    targetTrackId: track.id,
+    insertionTime,
+    splitClipId: splitClip?.id ?? null,
+    shiftedClipIds,
+  };
+}

--- a/src/lib/timeline/timelineUtils.ts
+++ b/src/lib/timeline/timelineUtils.ts
@@ -5,14 +5,17 @@ export { VELOCITY_THRESHOLDS, classifyVelocity } from "../renderEngine/types";
 import type { DragItem, Track, Clip, DensityConfig, DensityLevel } from "../../types";
 import { useTimelineStore } from "../../store/timelineStore";
 import { useProjectStore } from "../../store/projectStore";
+import { useUIStore } from "../../store/uiStore";
 import { useHistoryStore } from "../../store/historyStore";
-import { AddTrackCommand, AddClipCommand, DeleteClipCommand } from "../../core/history/commands";
+import { AddTrackCommand, AddClipCommand, DeleteClipCommand, InsertEditCommand } from "../../core/history/commands";
 import { capitalize } from "../utils";
 import { DensityLevel as DensityLevelEnum } from "../../types";
 import { createClipFromAsset } from "./timelineClip";
 import { autoAdaptSequenceForFirstVisualClip } from "../sequence/sequenceAutoAspect";
 import { DEFAULT_PLACEMENT_POLICY, resolveClipStartTime } from "./placementPolicy";
 import { generateId } from "@/lib/utils/id";
+import { resolveInsertEdit } from "./insertEdit";
+import { getTimelineLaneClientX } from "./timelineViewport";
 
 // Density configurations mapping zoom levels to extraction densities. Each configuration defines the time interval between thumbnails and the zoom range.
 export const DENSITY_CONFIGS: DensityConfig[] = [
@@ -136,13 +139,14 @@ export function handleCreateTrackAndDrop(item: DragItem, monitor: any, insertInd
 
 // Handle dropping media assets onto existing tracks
 export function handleDropOnTrack(item: DragItem, monitor: any, trackId: string) {
-  const { pixelsPerSecond, scrollLeft } = useTimelineStore.getState();
+  const timelineState = useTimelineStore.getState();
+  const { pixelsPerSecond, scrollLeft } = timelineState;
   const { execute } = useHistoryStore.getState();
 
   const offset = monitor.getClientOffset();
   const containerRect = document.getElementById("timeline-tracks-container")?.getBoundingClientRect();
 
-  const dropTime = offset && containerRect ? (offset.x - containerRect.left + scrollLeft) / pixelsPerSecond : 0;
+  const dropTime = offset && containerRect ? (getTimelineLaneClientX(offset.x, containerRect.left, timelineState.clips.length > 0) + scrollLeft) / pixelsPerSecond : 0;
   const startTime = resolveClipStartTime({ intent: "drop", timelineEndTime: 0, dropTime });
 
   if (item.type === "MEDIA_ASSET") {
@@ -169,7 +173,23 @@ export function handleDropOnTrack(item: DragItem, monitor: any, trackId: string)
       height: canvasHeight,
     });
 
-    // Use command to add clip (enables undo/redo)
-    execute(new AddClipCommand(newClip));
+    const track = timelineState.tracks.find((candidate) => candidate.id === trackId);
+    if (!track) return;
+    const decision = resolveInsertEdit({
+      track,
+      asset: item.asset,
+      clips: timelineState.clips,
+      requestedTime: startTime,
+      frameRate: projectState.project?.frameRate ?? 30,
+    });
+    if (!decision.accepted) {
+      useProjectStore.getState().showToast(decision.reason ?? "Cannot insert media here", "error");
+      return;
+    }
+
+    execute(new InsertEditCommand({ ...newClip, startTime: decision.insertionTime }, decision.insertionTime, decision.splitClipId));
+    useUIStore.getState().clearSelection();
+    useUIStore.getState().selectClip(newClip.id);
+    requestAnimationFrame(() => useTimelineStore.getState().detectAndSyncGaps(trackId));
   }
 }

--- a/src/lib/timeline/timelineViewport.ts
+++ b/src/lib/timeline/timelineViewport.ts
@@ -47,3 +47,30 @@ export function getAnchoredZoomScrollLeft(input: {
 export function getTimelineViewportEndForDuration(contentEndSeconds: number): number {
   return getTimelineViewportEnd(contentEndSeconds);
 }
+
+/** Compute the density needed to show the entire sequence in the usable lane. */
+export function getFitSequencePixelsPerSecond(containerWidth: number, duration: number, hasClips: boolean): number {
+  if (duration <= 0) return zoomToPixelsPerSecond(1);
+  return clampTimelinePixelsPerSecond(getTimelineLaneWidth(containerWidth, hasClips) / duration);
+}
+
+/** Return the smallest scroll adjustment that reveals an edit point with context. */
+export function getScrollLeftToRevealTime(input: {
+  time: number;
+  currentScrollLeft: number;
+  containerWidth: number;
+  pixelsPerSecond: number;
+  viewportEndSeconds: number;
+  hasClips: boolean;
+  insetRatio?: number;
+}): number {
+  const laneWidth = getTimelineLaneWidth(input.containerWidth, input.hasClips);
+  const inset = laneWidth * (input.insetRatio ?? 0.15);
+  const editPointPixels = input.time * input.pixelsPerSecond;
+  const visibleLeft = input.currentScrollLeft + inset;
+  const visibleRight = input.currentScrollLeft + laneWidth - inset;
+  let next = input.currentScrollLeft;
+  if (editPointPixels < visibleLeft) next = editPointPixels - inset;
+  if (editPointPixels > visibleRight) next = editPointPixels - laneWidth + inset;
+  return clampTimelineScrollLeft(next, input.containerWidth, input.viewportEndSeconds, input.pixelsPerSecond, input.hasClips);
+}

--- a/src/lib/timeline/timelineZoom.ts
+++ b/src/lib/timeline/timelineZoom.ts
@@ -6,6 +6,8 @@ export const TIMELINE_ZOOM_DEFAULT = DEFAULT_SRP_CONFIG[SpatialTier.L1].min;
 export const BASE_TIMELINE_DENSITY_PPS = 100;
 export const TIMELINE_PPS_PER_ZOOM = BASE_TIMELINE_DENSITY_PPS;
 export const TIMELINE_TIER_SNAP_EPSILON = 0.04;
+/** Timeline-only floor for fitting long sequences below the render tier range. */
+export const TIMELINE_OVERVIEW_ZOOM_MIN = 0.000001;
 
 export const TIMELINE_TIER_LABELS: Record<SpatialTier, string> = {
   [SpatialTier.L0]: "Overview",
@@ -22,7 +24,7 @@ export const TIMELINE_TEMPORAL_LABELS: Record<TemporalTier, string> = {
 };
 
 export function getTimelineZoomMin(config: SrpConfig = DEFAULT_SRP_CONFIG): number {
-  return Math.min(...Object.values(config).map((boundary) => boundary.min));
+  return Math.min(TIMELINE_OVERVIEW_ZOOM_MIN, ...Object.values(config).map((boundary) => boundary.min));
 }
 
 export function getTimelineZoomMax(config: SrpConfig = DEFAULT_SRP_CONFIG): number {


### PR DESCRIPTION
## Summary

- make Space playback toggles read live transport state and ignore key-repeat events
- ripple-close ordinary timeline deletions while preserving lift-delete behind Option/Alt+Delete
- add frame-snapped insert editing for media drops with matching preview and commit placement
- add explicit Fit sequence zoom and keep structural edit points visible without resetting zoom

## Why

Timeline editing currently relies on a throttled playback snapshot, leaves removable gaps after common cut/delete workflows, and treats media drops as simple placement rather than insert edits. Together these behaviors make rapid editorial work feel delayed and require repetitive manual cleanup and scrolling.

This change makes the common path deterministic and immediate while retaining intentional gaps through lift delete and explicit gap operations. Ripple operations remain scoped to the target track, and existing project persistence formats are unchanged.

## User impact

Editors can rapidly alternate playback with Space, remove cut sections without separately deleting generated gaps, insert media directly inside an existing clip, and fit long sequences into the available timeline width. Delete and insert operations remain fully undoable.

## Validation

- `npm test -- --run`: 116 files passed; 1,364 tests passed and 3 skipped
- focused transport, interaction, command, placement, and viewport tests: 28 passed
- `npm run build`
- `cd src-tauri && cargo test`: 77 passed
- native arm64 macOS bundle built and launched successfully

## Notes

- The updater-signing packaging step requires the maintainers' `TAURI_SIGNING_PRIVATE_KEY`; the local application bundle and DMG were generated before that expected credential boundary.
- This is my first contribution and may require completing the project CLA after the bot posts its link.