### PR TITLE
Accelerate desktop export with a bounded native pipeline

### DIFF
--- a/src-tauri/src/commands/export.rs
+++ b/src-tauri/src/commands/export.rs
@@ -149,7 +149,7 @@ static EXPORT_SESSIONS: once_cell::sync::Lazy<Arc<Mutex<HashMap<String, ExportSe
 /// locations. Tauri apps on macOS launch with a stripped environment, so
 /// `ffmpeg` and `ffprobe` (typically in /opt/homebrew/bin or /usr/local/bin)
 /// may not be found with the default PATH.
-fn augmented_path() -> String {
+pub(crate) fn augmented_path() -> String {
     let current = std::env::var("PATH").unwrap_or_default();
     let extra = "/usr/local/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/bin:/bin";
     if current.is_empty() {
@@ -395,14 +395,23 @@ pub async fn start_video_export(
     // Log the full FFmpeg command for debugging
     eprintln!("[start_video_export] FFmpeg command: {:?}", cmd);
     
-    let mut child = cmd
-        .spawn()
-        .map_err(|e| format!("Failed to spawn FFmpeg: {}", e))?;
+    super::native_export::acquire_export_slot()?;
+    let mut child = match cmd.spawn() {
+        Ok(child) => child,
+        Err(error) => {
+            super::native_export::release_export_slot();
+            return Err(format!("Failed to spawn FFmpeg: {}", error));
+        }
+    };
     
-    let stdin = child
-        .stdin
-        .take()
-        .ok_or_else(|| "Failed to open stdin".to_string())?;
+    let stdin = match child.stdin.take() {
+        Some(stdin) => stdin,
+        None => {
+            let _ = child.kill().await;
+            super::native_export::release_export_slot();
+            return Err("Failed to open stdin".to_string());
+        }
+    };
     
     // Create session
     let session = ExportSession {
@@ -714,14 +723,18 @@ pub async fn finalize_video_export(session_id: String) -> Result<(), String> {
     drop(session.stdin);
     
     // Wait for FFmpeg to finish
-    let output = session
-        .process
-        .wait_with_output()
-        .await
-        .map_err(|e| format!("Failed to wait for FFmpeg: {}", e))?;
+    let output = match session.process.wait_with_output().await {
+        Ok(output) => output,
+        Err(error) => {
+            super::native_export::release_export_slot();
+            return Err(format!("Failed to wait for FFmpeg: {}", error));
+        }
+    };
     
     let elapsed = session.start_time.elapsed();
     
+    super::native_export::release_export_slot();
+
     if output.status.success() {
         eprintln!(
             "[finalize_video_export] Session {} completed successfully in {:.2}s ({} frames)",
@@ -786,6 +799,7 @@ pub async fn cancel_video_export(session_id: String) -> Result<(), String> {
         session_id, session.current_frame
     );
 
+    super::native_export::release_export_slot();
     Ok(())
 }
 

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -1,6 +1,7 @@
 pub mod media;
 pub mod project;
 pub mod export;
+pub mod native_export;
 pub mod thumbnail;
 pub mod whisper;
 pub mod recording;
@@ -8,6 +9,7 @@ pub mod recording;
 pub use media::*;
 pub use project::*;
 pub use export::*;
+pub use native_export::*;
 pub use thumbnail::*;
 pub use whisper::*;
 pub use recording::*;

--- a/src-tauri/src/commands/native_export.rs
+++ b/src-tauri/src/commands/native_export.rs
@@ -1,0 +1,855 @@
+use super::export::ExportProgress;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::process::Stdio;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::time::Instant;
+use tauri::ipc::Channel;
+use tokio::process::Command;
+use tokio::sync::{Mutex, Notify};
+use tokio::time::{sleep, Duration};
+use tokio_util::sync::CancellationToken;
+
+const MAX_FFMPEG_RSS_BYTES: u64 = 2 * 1024 * 1024 * 1024;
+static EXPORT_ACTIVE: AtomicBool = AtomicBool::new(false);
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct NativeTimelineClipPlan {
+    pub path: String,
+    pub trim_in: f64,
+    pub duration: f64,
+    pub frame_count: u32,
+    pub x: i32,
+    pub y: i32,
+    pub width: u32,
+    pub height: u32,
+    pub volume: f64,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct NativeTimelineExportPlan {
+    pub output_path: String,
+    pub width: u32,
+    pub height: u32,
+    pub frame_rate: f64,
+    pub codec: String,
+    pub preset: String,
+    pub crf: u32,
+    pub pixel_format: String,
+    pub total_duration: f64,
+    pub clips: Vec<NativeTimelineClipPlan>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct NativeExportCompletion {
+    pub total_frames: u32,
+    pub total_time_ms: u64,
+    pub peak_rss_bytes: u64,
+}
+
+struct NativeExportJob {
+    cancellation: CancellationToken,
+    result: Arc<Mutex<Option<Result<NativeExportCompletion, String>>>>,
+    completed: Arc<Notify>,
+}
+
+static NATIVE_EXPORT_JOBS: once_cell::sync::Lazy<Arc<Mutex<HashMap<String, NativeExportJob>>>> =
+    once_cell::sync::Lazy::new(|| Arc::new(Mutex::new(HashMap::new())));
+
+pub(crate) fn acquire_export_slot() -> Result<(), String> {
+    EXPORT_ACTIVE
+        .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+        .map(|_| ())
+        .map_err(|_| "Another export is already running".to_string())
+}
+
+pub(crate) fn release_export_slot() {
+    EXPORT_ACTIVE.store(false, Ordering::Release);
+}
+
+fn number(value: f64) -> String {
+    if value.fract().abs() < f64::EPSILON {
+        format!("{:.0}", value)
+    } else {
+        format!("{:.6}", value)
+            .trim_end_matches('0')
+            .trim_end_matches('.')
+            .to_string()
+    }
+}
+
+fn target_bitrate(plan: &NativeTimelineExportPlan) -> u64 {
+    let pixels = u64::from(plan.width) * u64::from(plan.height);
+    let base = if plan.codec == "h265" {
+        35_000_000u64
+    } else {
+        50_000_000u64
+    };
+    ((base * pixels) / (3840 * 2160)).max(4_000_000)
+}
+
+fn build_segment_args(
+    plan: &NativeTimelineExportPlan,
+    clip: &NativeTimelineClipPlan,
+    output_path: &Path,
+    use_videotoolbox: bool,
+) -> Vec<String> {
+    let source_duration = number(clip.duration);
+    let output_duration = number(clip.frame_count as f64 / plan.frame_rate);
+    let frame_rate = number(plan.frame_rate);
+    let mut args = vec![
+        "-hide_banner".into(),
+        "-loglevel".into(),
+        "error".into(),
+        "-nostdin".into(),
+        "-threads".into(),
+        "4".into(),
+        "-filter_threads".into(),
+        "2".into(),
+    ];
+
+    if use_videotoolbox {
+        args.extend(["-hwaccel".into(), "videotoolbox".into()]);
+    }
+
+    args.extend([
+        "-ss".into(),
+        number(clip.trim_in),
+        "-t".into(),
+        source_duration,
+        "-i".into(),
+        clip.path.clone(),
+    ]);
+
+    let filter = format!(
+        "color=c=black:s={}x{}:r={}:d={}[base];\
+         [0:v]scale={}:{}:flags=lanczos,setsar=1,setpts=PTS-STARTPTS,\
+         tpad=stop_mode=clone:stop_duration={},trim=duration={},fps={}[fg];\
+         [base][fg]overlay=x={}:y={}:shortest=1,format={}[v]",
+        plan.width,
+        plan.height,
+        frame_rate,
+        output_duration,
+        clip.width,
+        clip.height,
+        output_duration,
+        output_duration,
+        frame_rate,
+        clip.x,
+        clip.y,
+        plan.pixel_format,
+    );
+    args.extend([
+        "-filter_complex".into(),
+        filter,
+        "-map".into(),
+        "[v]".into(),
+        "-an".into(),
+    ]);
+
+    match plan.codec.as_str() {
+        "h265" if use_videotoolbox => {
+            let bitrate = target_bitrate(plan);
+            args.extend([
+                "-c:v".into(),
+                "hevc_videotoolbox".into(),
+                "-tag:v".into(),
+                "hvc1".into(),
+                "-b:v".into(),
+                bitrate.to_string(),
+                "-maxrate".into(),
+                (bitrate * 10 / 7).to_string(),
+                "-bufsize".into(),
+                (bitrate * 2).to_string(),
+                "-allow_sw".into(),
+                "1".into(),
+                "-realtime".into(),
+                "1".into(),
+                "-prio_speed".into(),
+                "1".into(),
+                "-bf".into(),
+                "0".into(),
+                "-g".into(),
+                number(plan.frame_rate * 2.0),
+            ]);
+        }
+        "h264" if use_videotoolbox => {
+            args.extend([
+                "-c:v".into(),
+                "h264_videotoolbox".into(),
+                "-b:v".into(),
+                target_bitrate(plan).to_string(),
+                "-allow_sw".into(),
+                "1".into(),
+                "-realtime".into(),
+                "1".into(),
+                "-bf".into(),
+                "0".into(),
+                "-g".into(),
+                number(plan.frame_rate * 2.0),
+            ]);
+        }
+        "prores" if use_videotoolbox => {
+            args.extend(["-c:v".into(), "prores_videotoolbox".into()]);
+        }
+        "h265" => {
+            args.extend([
+                "-c:v".into(),
+                "libx265".into(),
+                "-preset".into(),
+                plan.preset.clone(),
+                "-crf".into(),
+                plan.crf.to_string(),
+                "-tag:v".into(),
+                "hvc1".into(),
+                "-bf".into(),
+                "0".into(),
+                "-g".into(),
+                number(plan.frame_rate * 2.0),
+            ]);
+        }
+        "h264" => {
+            args.extend([
+                "-c:v".into(),
+                "libx264".into(),
+                "-preset".into(),
+                plan.preset.clone(),
+                "-crf".into(),
+                plan.crf.to_string(),
+                "-bf".into(),
+                "0".into(),
+                "-g".into(),
+                number(plan.frame_rate * 2.0),
+            ]);
+        }
+        "prores" => {
+            args.extend(["-c:v".into(), "prores_ks".into()]);
+        }
+        _ => {}
+    }
+
+    args.extend([
+        "-pix_fmt".into(),
+        plan.pixel_format.clone(),
+        "-video_track_timescale".into(),
+        "90000".into(),
+        "-t".into(),
+        output_duration,
+        "-movflags".into(),
+        "+faststart".into(),
+        "-y".into(),
+        output_path.to_string_lossy().into_owned(),
+    ]);
+    args
+}
+
+fn validate_plan(plan: &NativeTimelineExportPlan) -> Result<(), String> {
+    if plan.width == 0 || plan.height == 0 || plan.width > 7680 || plan.height > 4320 {
+        return Err(format!(
+            "Invalid native export dimensions: {}x{}",
+            plan.width, plan.height
+        ));
+    }
+    if !plan.frame_rate.is_finite() || plan.frame_rate <= 0.0 || plan.frame_rate > 240.0 {
+        return Err(format!(
+            "Invalid native export frame rate: {}",
+            plan.frame_rate
+        ));
+    }
+    if !plan.total_duration.is_finite() || plan.total_duration <= 0.0 {
+        return Err("Native export duration must be positive".into());
+    }
+    if plan.clips.is_empty() {
+        return Err("Native export requires at least one clip".into());
+    }
+    if !matches!(plan.codec.as_str(), "h264" | "h265" | "prores") {
+        return Err(format!("Unsupported native export codec: {}", plan.codec));
+    }
+    for clip in &plan.clips {
+        if clip.path.is_empty()
+            || !clip.trim_in.is_finite()
+            || clip.trim_in < 0.0
+            || !clip.duration.is_finite()
+            || clip.duration <= 0.0
+            || clip.frame_count == 0
+            || clip.width == 0
+            || clip.height == 0
+        {
+            return Err(format!("Invalid native export clip: {}", clip.path));
+        }
+    }
+    let planned_frames: u32 = plan.clips.iter().map(|clip| clip.frame_count).sum();
+    let total_frames = (plan.total_duration * plan.frame_rate).round() as u32;
+    if planned_frames != total_frames {
+        return Err(format!(
+            "Native export clips total {} frames but export requires {} frames",
+            planned_frames, total_frames
+        ));
+    }
+    Ok(())
+}
+
+async fn probe_has_audio(path: &str) -> bool {
+    Command::new("ffprobe")
+        .env("PATH", super::export::augmented_path())
+        .args([
+            "-v",
+            "error",
+            "-select_streams",
+            "a",
+            "-show_entries",
+            "stream=codec_type",
+            "-of",
+            "csv=p=0",
+            path,
+        ])
+        .output()
+        .await
+        .map(|output| output.status.success() && !output.stdout.is_empty())
+        .unwrap_or(false)
+}
+
+async fn process_rss_bytes(pid: u32) -> Option<u64> {
+    #[cfg(any(target_os = "macos", target_os = "linux"))]
+    {
+        let output = Command::new("ps")
+            .args(["-o", "rss=", "-p", &pid.to_string()])
+            .output()
+            .await
+            .ok()?;
+        let kib = String::from_utf8_lossy(&output.stdout)
+            .trim()
+            .parse::<u64>()
+            .ok()?;
+        Some(kib * 1024)
+    }
+    #[cfg(not(any(target_os = "macos", target_os = "linux")))]
+    {
+        let _ = pid;
+        None
+    }
+}
+
+async fn run_ffmpeg(args: &[String], cancellation: &CancellationToken) -> Result<u64, String> {
+    let mut child = Command::new("ffmpeg")
+        .env("PATH", super::export::augmented_path())
+        .args(args)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::inherit())
+        .kill_on_drop(true)
+        .spawn()
+        .map_err(|error| format!("Failed to spawn FFmpeg: {error}"))?;
+    let pid = child
+        .id()
+        .ok_or_else(|| "FFmpeg did not expose a process ID".to_string())?;
+    let mut peak_rss = 0u64;
+
+    loop {
+        if cancellation.is_cancelled() {
+            let _ = child.kill().await;
+            let _ = child.wait().await;
+            return Err("Export cancelled".into());
+        }
+
+        if let Some(status) = child
+            .try_wait()
+            .map_err(|error| format!("Failed to inspect FFmpeg: {error}"))?
+        {
+            return if status.success() {
+                Ok(peak_rss)
+            } else {
+                Err(format!("FFmpeg exited with status {status}"))
+            };
+        }
+
+        if let Some(rss) = process_rss_bytes(pid).await {
+            peak_rss = peak_rss.max(rss);
+            if rss > MAX_FFMPEG_RSS_BYTES {
+                let _ = child.kill().await;
+                let _ = child.wait().await;
+                return Err(format!(
+                    "FFmpeg exceeded the {} MiB memory safety ceiling",
+                    MAX_FFMPEG_RSS_BYTES / 1024 / 1024
+                ));
+            }
+        }
+
+        sleep(Duration::from_millis(500)).await;
+    }
+}
+
+fn ffconcat_path(path: &Path) -> String {
+    path.to_string_lossy().replace('\'', "'\\''")
+}
+
+fn build_concat_args(list_path: &Path, output_path: &Path) -> Vec<String> {
+    vec![
+        "-hide_banner".into(),
+        "-loglevel".into(),
+        "error".into(),
+        "-nostdin".into(),
+        "-safe".into(),
+        "0".into(),
+        "-f".into(),
+        "concat".into(),
+        "-i".into(),
+        list_path.to_string_lossy().into_owned(),
+        "-c".into(),
+        "copy".into(),
+        "-an".into(),
+        "-movflags".into(),
+        "+faststart".into(),
+        "-y".into(),
+        output_path.to_string_lossy().into_owned(),
+    ]
+}
+
+fn build_mux_args(
+    plan: &NativeTimelineExportPlan,
+    video_path: &Path,
+    output_path: &Path,
+    audio_streams: &[bool],
+    use_audiotoolbox: bool,
+) -> Vec<String> {
+    let total_frames = (plan.total_duration * plan.frame_rate).round() as u32;
+    let total_duration = number(total_frames as f64 / plan.frame_rate);
+    let mut args = vec![
+        "-hide_banner".into(),
+        "-loglevel".into(),
+        "error".into(),
+        "-nostdin".into(),
+        "-i".into(),
+        video_path.to_string_lossy().into_owned(),
+    ];
+    for (clip, has_audio) in plan.clips.iter().zip(audio_streams) {
+        let output_duration = number(clip.frame_count as f64 / plan.frame_rate);
+        if *has_audio {
+            args.extend([
+                "-ss".into(),
+                number(clip.trim_in),
+                "-t".into(),
+                clip.duration.to_string(),
+                "-i".into(),
+                clip.path.clone(),
+            ]);
+        } else {
+            args.extend([
+                "-f".into(),
+                "lavfi".into(),
+                "-t".into(),
+                output_duration,
+                "-i".into(),
+                "anullsrc=channel_layout=stereo:sample_rate=48000".into(),
+            ]);
+        }
+    }
+
+    let mut filter = String::new();
+    for (index, (clip, has_audio)) in plan.clips.iter().zip(audio_streams).enumerate() {
+        let input_index = index + 1;
+        let output_duration = number(clip.frame_count as f64 / plan.frame_rate);
+        if *has_audio {
+            filter.push_str(&format!(
+                "[{input_index}:a]aresample=48000:async=1:first_pts=0,volume={},\
+                 apad=whole_dur={output_duration},atrim=duration={output_duration},\
+                 asetpts=PTS-STARTPTS[a{index}];",
+                number(clip.volume),
+            ));
+        } else {
+            filter.push_str(&format!(
+                "[{input_index}:a]atrim=duration={output_duration},\
+                 asetpts=PTS-STARTPTS[a{index}];"
+            ));
+        }
+    }
+    for index in 0..plan.clips.len() {
+        filter.push_str(&format!("[a{index}]"));
+    }
+    filter.push_str(&format!(
+        "concat=n={}:v=0:a=1,atrim=duration={},asetpts=N/SR/TB[a]",
+        plan.clips.len(),
+        total_duration,
+    ));
+
+    args.extend([
+        "-filter_complex".into(),
+        filter,
+        "-map".into(),
+        "0:v:0".into(),
+        "-map".into(),
+        "[a]".into(),
+        "-c:v".into(),
+        "copy".into(),
+        "-c:a".into(),
+        if use_audiotoolbox {
+            "aac_at".into()
+        } else {
+            "aac".into()
+        },
+        "-ar".into(),
+        "48000".into(),
+        "-ac".into(),
+        "2".into(),
+        "-b:a".into(),
+        "192k".into(),
+        "-t".into(),
+        total_duration,
+        "-shortest".into(),
+        "-movflags".into(),
+        "+faststart".into(),
+        "-y".into(),
+        output_path.to_string_lossy().into_owned(),
+    ]);
+    args
+}
+
+async fn run_native_export(
+    session_id: &str,
+    plan: NativeTimelineExportPlan,
+    on_progress: Channel<ExportProgress>,
+    cancellation: CancellationToken,
+) -> Result<NativeExportCompletion, String> {
+    let started = Instant::now();
+    let total_frames = (plan.total_duration * plan.frame_rate).round() as u32;
+    let temp_dir = std::env::temp_dir().join(format!("clypra-export-{session_id}"));
+    let output_path = PathBuf::from(&plan.output_path);
+    let use_videotoolbox = cfg!(target_os = "macos");
+    let segment_extension = if plan.codec == "prores" { "mov" } else { "mp4" };
+    let result = async {
+        tokio::fs::create_dir_all(&temp_dir)
+            .await
+            .map_err(|error| format!("Failed to create export workspace: {error}"))?;
+        let mut segment_paths = Vec::with_capacity(plan.clips.len());
+        let mut audio_streams = Vec::with_capacity(plan.clips.len());
+        let mut completed_duration = 0.0f64;
+        let mut peak_rss = 0u64;
+
+        for (index, clip) in plan.clips.iter().enumerate() {
+            if cancellation.is_cancelled() {
+                return Err("Export cancelled".into());
+            }
+            let segment_path = temp_dir.join(format!("segment-{index:04}.{segment_extension}"));
+            audio_streams.push(probe_has_audio(&clip.path).await);
+            let args = build_segment_args(&plan, clip, &segment_path, use_videotoolbox);
+            peak_rss = peak_rss.max(run_ffmpeg(&args, &cancellation).await?);
+            segment_paths.push(segment_path);
+            completed_duration += clip.duration;
+
+            let current_frame = (completed_duration * plan.frame_rate).round() as u32;
+            let elapsed = started.elapsed().as_secs_f64();
+            let fps = if elapsed > 0.0 {
+                current_frame as f64 / elapsed
+            } else {
+                0.0
+            };
+            let remaining_frames = total_frames.saturating_sub(current_frame);
+            let _ = on_progress.send(ExportProgress {
+                current_frame,
+                total_frames,
+                progress: (current_frame as f64 / total_frames as f64).min(0.98),
+                eta_seconds: if fps > 0.0 {
+                    remaining_frames as f64 / fps
+                } else {
+                    0.0
+                },
+                fps,
+            });
+        }
+
+        let concat_path = temp_dir.join("segments.ffconcat");
+        let mut concat = String::from("ffconcat version 1.0\n");
+        for (path, clip) in segment_paths.iter().zip(&plan.clips) {
+            concat.push_str(&format!(
+                "file '{}'\nduration {}\n",
+                ffconcat_path(path),
+                number(clip.frame_count as f64 / plan.frame_rate),
+            ));
+        }
+        tokio::fs::write(&concat_path, concat)
+            .await
+            .map_err(|error| format!("Failed to write concat plan: {error}"))?;
+        let video_path = temp_dir.join(format!("video-only.{segment_extension}"));
+        peak_rss = peak_rss
+            .max(run_ffmpeg(&build_concat_args(&concat_path, &video_path), &cancellation).await?);
+        peak_rss = peak_rss.max(
+            run_ffmpeg(
+                &build_mux_args(
+                    &plan,
+                    &video_path,
+                    &output_path,
+                    &audio_streams,
+                    cfg!(target_os = "macos"),
+                ),
+                &cancellation,
+            )
+            .await?,
+        );
+        let elapsed = started.elapsed().as_secs_f64();
+        let _ = on_progress.send(ExportProgress {
+            current_frame: total_frames,
+            total_frames,
+            progress: 1.0,
+            eta_seconds: 0.0,
+            fps: if elapsed > 0.0 {
+                total_frames as f64 / elapsed
+            } else {
+                0.0
+            },
+        });
+
+        Ok(NativeExportCompletion {
+            total_frames,
+            total_time_ms: started.elapsed().as_millis() as u64,
+            peak_rss_bytes: peak_rss,
+        })
+    }
+    .await;
+
+    if result.is_err() {
+        let _ = tokio::fs::remove_file(&output_path).await;
+    }
+    let _ = tokio::fs::remove_dir_all(&temp_dir).await;
+    result
+}
+
+#[tauri::command]
+pub async fn start_native_timeline_export(
+    plan: NativeTimelineExportPlan,
+    on_progress: Channel<ExportProgress>,
+) -> Result<String, String> {
+    validate_plan(&plan)?;
+    acquire_export_slot()?;
+
+    let session_id = uuid::Uuid::new_v4().to_string();
+    let cancellation = CancellationToken::new();
+    let result = Arc::new(Mutex::new(None));
+    let completed = Arc::new(Notify::new());
+    NATIVE_EXPORT_JOBS.lock().await.insert(
+        session_id.clone(),
+        NativeExportJob {
+            cancellation: cancellation.clone(),
+            result: result.clone(),
+            completed: completed.clone(),
+        },
+    );
+
+    let task_cancellation = cancellation.clone();
+    let task_session_id = session_id.clone();
+    tokio::spawn(async move {
+        let export_result =
+            run_native_export(&task_session_id, plan, on_progress, task_cancellation).await;
+        *result.lock().await = Some(export_result);
+        completed.notify_waiters();
+    });
+    Ok(session_id)
+}
+
+async fn wait_for_native_job(
+    result: Arc<Mutex<Option<Result<NativeExportCompletion, String>>>>,
+    completed: Arc<Notify>,
+) -> Result<NativeExportCompletion, String> {
+    loop {
+        let notified = completed.notified();
+        if let Some(result) = result.lock().await.clone() {
+            return result;
+        }
+        tokio::select! {
+            _ = notified => {}
+            _ = sleep(Duration::from_millis(100)) => {}
+        }
+    }
+}
+
+#[tauri::command]
+pub async fn finalize_native_timeline_export(
+    session_id: String,
+) -> Result<NativeExportCompletion, String> {
+    let (result, completed) = NATIVE_EXPORT_JOBS
+        .lock()
+        .await
+        .get(&session_id)
+        .map(|job| (job.result.clone(), job.completed.clone()))
+        .ok_or_else(|| format!("Native export session not found: {session_id}"))?;
+    let result = wait_for_native_job(result, completed).await;
+    if NATIVE_EXPORT_JOBS
+        .lock()
+        .await
+        .remove(&session_id)
+        .is_some()
+    {
+        release_export_slot();
+    }
+    result
+}
+
+#[tauri::command]
+pub async fn cancel_native_timeline_export(session_id: String) -> Result<(), String> {
+    let (cancellation, result, completed) = NATIVE_EXPORT_JOBS
+        .lock()
+        .await
+        .get(&session_id)
+        .map(|job| {
+            (
+                job.cancellation.clone(),
+                job.result.clone(),
+                job.completed.clone(),
+            )
+        })
+        .ok_or_else(|| format!("Native export session not found: {session_id}"))?;
+    cancellation.cancel();
+    let _ = wait_for_native_job(result, completed).await;
+    if NATIVE_EXPORT_JOBS
+        .lock()
+        .await
+        .remove(&session_id)
+        .is_some()
+    {
+        release_export_slot();
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn plan() -> NativeTimelineExportPlan {
+        NativeTimelineExportPlan {
+            output_path: "/output/movie.mp4".into(),
+            width: 3840,
+            height: 2160,
+            frame_rate: 30.0,
+            codec: "h265".into(),
+            preset: "medium".into(),
+            crf: 20,
+            pixel_format: "yuv420p".into(),
+            total_duration: 9.0,
+            clips: vec![],
+        }
+    }
+
+    #[test]
+    fn segment_arguments_normalize_mixed_source_formats_before_concat() {
+        let output = Path::new("/tmp/segment-00.mp4");
+        let main = NativeTimelineClipPlan {
+            path: "/media/main-3024x1964-60fps.mov".into(),
+            trim_in: 10.0,
+            duration: 3.0,
+            frame_count: 90,
+            x: 0,
+            y: -167,
+            width: 3840,
+            height: 2494,
+            volume: 1.0,
+        };
+        let ident = NativeTimelineClipPlan {
+            path: "/media/ident-1920x1080-30fps.mp4".into(),
+            trim_in: 0.0,
+            duration: 6.0,
+            frame_count: 180,
+            x: 0,
+            y: 0,
+            width: 3840,
+            height: 2160,
+            volume: 1.0,
+        };
+
+        let main_args = build_segment_args(&plan(), &main, output, true);
+        let ident_args = build_segment_args(&plan(), &ident, output, true);
+
+        for args in [main_args, ident_args] {
+            let joined = args.join(" ");
+            assert!(joined.contains("color=c=black:s=3840x2160:r=30"));
+            assert!(joined.contains("fps=30"));
+            assert!(joined.contains("setsar=1"));
+            assert!(joined.contains("hevc_videotoolbox"));
+            assert!(joined.contains("-tag:v hvc1"));
+            assert!(joined.contains("-an"));
+            assert!(joined.contains("-bf 0"));
+        }
+
+        let mux_args = build_mux_args(
+            &NativeTimelineExportPlan {
+                clips: vec![main, ident],
+                ..plan()
+            },
+            Path::new("/tmp/video-only.mp4"),
+            Path::new("/tmp/final.mp4"),
+            &[true, true],
+            true,
+        );
+        let mux = mux_args.join(" ");
+        assert!(mux.contains("aresample=48000"));
+        assert!(mux.contains("concat=n=2:v=0:a=1"));
+        assert!(mux.contains("-c:v copy"));
+        assert!(mux.contains("-c:a aac_at"));
+    }
+
+    #[test]
+    fn export_slot_rejects_concurrent_jobs() {
+        release_export_slot();
+        assert!(acquire_export_slot().is_ok());
+        assert_eq!(
+            acquire_export_slot().unwrap_err(),
+            "Another export is already running"
+        );
+        release_export_slot();
+    }
+
+    #[test]
+    fn plan_validation_requires_frame_exact_clip_coverage() {
+        let mut invalid = plan();
+        invalid.clips = vec![NativeTimelineClipPlan {
+            path: "/media/main.mov".into(),
+            trim_in: 0.0,
+            duration: 8.0,
+            frame_count: 240,
+            x: 0,
+            y: 0,
+            width: 3840,
+            height: 2160,
+            volume: 1.0,
+        }];
+        assert!(validate_plan(&invalid)
+            .unwrap_err()
+            .contains("clips total 240 frames"));
+    }
+
+    #[cfg(target_os = "macos")]
+    #[tokio::test]
+    async fn cancellation_terminates_the_active_ffmpeg_child() {
+        let token = CancellationToken::new();
+        let cancel = token.clone();
+        tokio::spawn(async move {
+            sleep(Duration::from_millis(150)).await;
+            cancel.cancel();
+        });
+        let started = Instant::now();
+        let args = vec![
+            "-hide_banner".into(),
+            "-loglevel".into(),
+            "error".into(),
+            "-nostdin".into(),
+            "-re".into(),
+            "-f".into(),
+            "lavfi".into(),
+            "-i".into(),
+            "color=c=black:s=64x64:r=30:d=60".into(),
+            "-f".into(),
+            "null".into(),
+            "-".into(),
+        ];
+
+        assert_eq!(
+            run_ffmpeg(&args, &token).await.unwrap_err(),
+            "Export cancelled"
+        );
+        assert!(started.elapsed() < Duration::from_secs(3));
+    }
+}

--- a/src-tauri/src/commands/thumbnail.rs
+++ b/src-tauri/src/commands/thumbnail.rs
@@ -286,6 +286,25 @@ pub async fn decode_frame_gpu(
     result
 }
 
+/// Decode a frame for desktop export and return raw RGBA as a binary IPC
+/// response. Unlike `decode_frame_gpu`, this avoids serializing millions of
+/// bytes as a JSON number array on every frame.
+#[tauri::command]
+pub async fn decode_export_frame(
+    video_path: String,
+    time_secs: f64,
+    width: u32,
+    height: u32,
+) -> Result<tauri::ipc::Response, String> {
+    let decoder = get_decoder(&video_path).await?;
+    let rgba_bytes = {
+        let mut decoder_guard = decoder.lock().await;
+        decoder_guard.decode_frame(time_secs, width, height)?
+    };
+
+    Ok(tauri::ipc::Response::new(rgba_bytes))
+}
+
 /// Extract multiple frames with streaming and atlas-based storage.
 #[tauri::command]
 pub async fn decode_frames_streaming(

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -62,6 +62,7 @@ pub fn run() {
             // Native FFmpeg decoder commands (fast path for thumbnails)
             decode_frame,
             decode_frame_gpu,
+            decode_export_frame,
             decode_frames_streaming,
             release_video_decoder,
             prewarm_decoders,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -74,6 +74,9 @@ pub fn run() {
             write_export_frames_batch,
             finalize_video_export,
             cancel_video_export,
+            start_native_timeline_export,
+            finalize_native_timeline_export,
+            cancel_native_timeline_export,
             check_ffmpeg_available,
             get_ffmpeg_version,
             // Whisper model management commands

--- a/src/core/render/mediaBridge.ts
+++ b/src/core/render/mediaBridge.ts
@@ -17,8 +17,8 @@ export function releaseMediaSprite(clipId: string, container: import("pixi.js").
   engineReleaseSprite(clipId, container);
 }
 
-export function getOrCreateMediaSprite(clipId: string, kind: "video" | "image", sourceElement: HTMLVideoElement | ImageBitmap | HTMLImageElement, container: import("pixi.js").Container): MediaSpriteRecord | null {
-  return engineGetOrCreateSprite(clipId, kind, sourceElement, container);
+export function getOrCreateMediaSprite(clipId: string, kind: "video" | "image", sourceElement: HTMLVideoElement | HTMLCanvasElement | ImageBitmap | HTMLImageElement, container: import("pixi.js").Container): MediaSpriteRecord | null {
+  return engineGetOrCreateSprite(clipId, kind, sourceElement as any, container);
 }
 
 /**
@@ -144,7 +144,7 @@ function applyMediaEffectsAndFilters(sprite: Sprite, layer: any, bodyMasks: Map<
 /**
  * Registers and updates a base media layer's sprite in the current frame.
  */
-export function renderBaseMediaLayer(layer: any, frameId: number, sourceEl: HTMLVideoElement | ImageBitmap | HTMLImageElement, container: import("pixi.js").Container, viewport: RenderViewport, renderOrder: number, bodyMasks: Map<string, any> = new Map()): void {
+export function renderBaseMediaLayer(layer: any, frameId: number, sourceEl: HTMLVideoElement | HTMLCanvasElement | ImageBitmap | HTMLImageElement, container: import("pixi.js").Container, viewport: RenderViewport, renderOrder: number, bodyMasks: Map<string, any> = new Map()): void {
   const record = getOrCreateMediaSprite(layer.clipId, layer.mediaType, sourceEl, container);
   if (!record) return;
 

--- a/src/core/render/pixiSceneCompositor.ts
+++ b/src/core/render/pixiSceneCompositor.ts
@@ -7,7 +7,7 @@ import { clearFilterCache } from "./filterCache.js";
 
 // Utility imports
 import { extractVisualMediaLayers, calculateMaxTrackIndex, calculateLayerZIndex } from "./utils/zIndexCalculator.js";
-import { resolveMediaSource } from "./utils/mediaResolver.js";
+import { resolveMediaSource, type VideoFrameSource } from "./utils/mediaResolver.js";
 import { resolveTransitionDefinition, mergeTransitionParams } from "./utils/transitionResolver.js";
 import { TransitionShaderCache } from "./TransitionShaderCache.js";
 import { getPlaybackClock } from "../playback/PlaybackClock.js";
@@ -123,7 +123,7 @@ export class PixiSceneCompositor {
     }
   }
 
-  async composeFrame(scene: EvaluatedScene, viewport: { scale: number; offsetX: number; offsetY: number; pixelRatio: number; projectWidth?: number; projectHeight?: number }, videoElements: Map<string, HTMLVideoElement>, resourceHandleMap?: Map<string, any>, bodyMasks: Map<string, any> = new Map()): Promise<void> {
+  async composeFrame(scene: EvaluatedScene, viewport: { scale: number; offsetX: number; offsetY: number; pixelRatio: number; projectWidth?: number; projectHeight?: number }, videoElements: Map<string, VideoFrameSource>, resourceHandleMap?: Map<string, any>, bodyMasks: Map<string, any> = new Map()): Promise<void> {
     if (!this.renderer.isReady) {
       return;
     }
@@ -241,7 +241,7 @@ export class PixiSceneCompositor {
           }
 
           if (sourceElement) {
-            const record = getOrCreateMediaSprite(mediaLayer.clipId, mediaLayer.mediaType, sourceElement, baseMediaContainer);
+            const record = getOrCreateMediaSprite(mediaLayer.clipId, mediaLayer.mediaType, sourceElement as any, baseMediaContainer);
 
             // Skip this layer if sprite creation was deferred (video metadata not ready yet)
             if (!record) {
@@ -257,6 +257,10 @@ export class PixiSceneCompositor {
                 record.texture.source.update();
                 this.mediaPool.markTextureClean(mediaLayer.clipId);
               }
+            }
+
+            if (mediaLayer.mediaType === "video" && sourceElement instanceof HTMLCanvasElement) {
+              record.texture.source.update();
             }
 
             // Capture video source dimensions using conform capture service
@@ -351,7 +355,7 @@ export class PixiSceneCompositor {
     }
   }
 
-  private async composeActiveTransition(transition: EvaluatedTransition, definition: any, scene: EvaluatedScene, baseMediaContainer: Container, renderOrder: number, videoElements: Map<string, HTMLVideoElement>, resourceHandleMap?: Map<string, any>): Promise<void> {
+  private async composeActiveTransition(transition: EvaluatedTransition, definition: any, scene: EvaluatedScene, baseMediaContainer: Container, renderOrder: number, videoElements: Map<string, VideoFrameSource>, resourceHandleMap?: Map<string, any>): Promise<void> {
     const outgoingLayer = scene.visualLayers.find((l) => l.layerId === transition.outgoingLayer) as EvaluatedMediaLayer;
     const incomingLayer = scene.visualLayers.find((l) => l.layerId === transition.incomingLayer) as EvaluatedMediaLayer;
     if (!outgoingLayer || !incomingLayer) return;
@@ -401,7 +405,7 @@ export class PixiSceneCompositor {
     }
   }
 
-  private renderToOffscreenTexture(slot: "from" | "to", layer: EvaluatedMediaLayer, scene: EvaluatedScene, videoElements: Map<string, HTMLVideoElement>, resourceHandleMap?: Map<string, any>): RenderTexture {
+  private renderToOffscreenTexture(slot: "from" | "to", layer: EvaluatedMediaLayer, scene: EvaluatedScene, videoElements: Map<string, VideoFrameSource>, resourceHandleMap?: Map<string, any>): RenderTexture {
     const app = this.renderer.getApp()!;
     const canvasWidth = scene.metadata.canvasWidth || 1920;
     const canvasHeight = scene.metadata.canvasHeight || 1080;
@@ -437,7 +441,7 @@ export class PixiSceneCompositor {
     const sourceElement = resolveMediaSource(layer, videoElements, resourceHandleMap);
 
     if (sourceElement) {
-      const record = getOrCreateMediaSprite(layer.clipId, layer.mediaType, sourceElement, container);
+      const record = getOrCreateMediaSprite(layer.clipId, layer.mediaType, sourceElement as any, container);
       if (!record) return texture;
 
       record.lastSeenFrame = this.currentFrameId;
@@ -448,6 +452,10 @@ export class PixiSceneCompositor {
           record.texture.source.update();
           this.mediaPool.markTextureClean(layer.clipId);
         }
+      }
+
+      if (layer.mediaType === "video" && sourceElement instanceof HTMLCanvasElement) {
+        record.texture.source.update();
       }
 
       const layersCopy = { ...layer, opacity: 1.0 };

--- a/src/core/render/utils/mediaResolver.ts
+++ b/src/core/render/utils/mediaResolver.ts
@@ -8,6 +8,8 @@
 import type { EvaluatedMediaLayer } from "../../evaluation/types";
 import { getResourceCache } from "../../resources/ResourceCache";
 
+export type VideoFrameSource = HTMLVideoElement | HTMLCanvasElement;
+
 /**
  * Resolve video element for a media layer.
  *
@@ -15,7 +17,7 @@ import { getResourceCache } from "../../resources/ResourceCache";
  * @param videoElements - Map of clip/media ID to video elements
  * @returns Video element if found, null otherwise
  */
-export function resolveVideoElement(mediaLayer: EvaluatedMediaLayer, videoElements: Map<string, HTMLVideoElement>): HTMLVideoElement | null {
+export function resolveVideoElement(mediaLayer: EvaluatedMediaLayer, videoElements: Map<string, VideoFrameSource>): VideoFrameSource | null {
   const key = `${mediaLayer.clipId}-${mediaLayer.mediaId}`;
   const element = videoElements.get(key);
 
@@ -57,7 +59,7 @@ export function resolveImageResource(mediaLayer: EvaluatedMediaLayer, resourceHa
  * @param resourceHandleMap - Optional map of layer IDs to resource handles
  * @returns Source element (HTMLVideoElement | ImageBitmap) or null
  */
-export function resolveMediaSource(mediaLayer: EvaluatedMediaLayer, videoElements: Map<string, HTMLVideoElement>, resourceHandleMap?: Map<string, any>): HTMLVideoElement | ImageBitmap | null {
+export function resolveMediaSource(mediaLayer: EvaluatedMediaLayer, videoElements: Map<string, VideoFrameSource>, resourceHandleMap?: Map<string, any>): VideoFrameSource | ImageBitmap | null {
   if (mediaLayer.mediaType === "video") {
     return resolveVideoElement(mediaLayer, videoElements);
   } else {

--- a/src/lib/export/__tests__/frameBatching.test.ts
+++ b/src/lib/export/__tests__/frameBatching.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+import { calculateExportBatchSize } from "../frameBatching";
+
+describe("calculateExportBatchSize", () => {
+  it("bounds 1080p and 4K raw frame batches by memory", () => {
+    expect(calculateExportBatchSize(1920 * 1080 * 4)).toBe(4);
+    expect(calculateExportBatchSize(3840 * 2160 * 4)).toBe(1);
+  });
+
+  it("caps small-frame batches and fails safely for invalid sizes", () => {
+    expect(calculateExportBatchSize(1)).toBe(45);
+    expect(calculateExportBatchSize(0)).toBe(1);
+    expect(calculateExportBatchSize(Number.NaN)).toBe(1);
+  });
+});

--- a/src/lib/export/__tests__/nativeExportFramePool.test.ts
+++ b/src/lib/export/__tests__/nativeExportFramePool.test.ts
@@ -1,0 +1,73 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { invoke } from "@tauri-apps/api/core";
+import {
+  fitNativeFrameDimensions,
+  NativeExportFramePool,
+} from "../nativeExportFramePool";
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: vi.fn(),
+}));
+
+describe("NativeExportFramePool", () => {
+  beforeEach(() => {
+    vi.mocked(invoke).mockReset();
+  });
+
+  it("decodes through binary native IPC and reuses the clip canvas", async () => {
+    const frame = new Uint8Array(2 * 2 * 4);
+    vi.mocked(invoke).mockResolvedValue(frame.buffer);
+
+    const pool = new NativeExportFramePool();
+    const request = {
+      key: "clip-1-asset-1",
+      videoPath: "/tmp/video.mov",
+      timeSecs: 1.25,
+      width: 2,
+      height: 2,
+    };
+
+    const first = await pool.acquire(request);
+    const second = await pool.acquire({ ...request, timeSecs: 1.5 });
+
+    expect(second).toBe(first);
+    expect(invoke).toHaveBeenNthCalledWith(1, "decode_export_frame", {
+      videoPath: "/tmp/video.mov",
+      timeSecs: 1.25,
+      width: 2,
+      height: 2,
+    });
+    expect(invoke).toHaveBeenCalledTimes(2);
+  });
+
+  it("fails closed if the native decoder returns the wrong frame size", async () => {
+    vi.mocked(invoke).mockResolvedValue(new Uint8Array(3).buffer);
+    const pool = new NativeExportFramePool();
+
+    await expect(
+      pool.acquire({
+        key: "clip-1-asset-1",
+        videoPath: "/tmp/video.mov",
+        timeSecs: 1,
+        width: 2,
+        height: 2,
+      }),
+    ).rejects.toThrow("expected 16 bytes, got 3");
+  });
+});
+
+describe("fitNativeFrameDimensions", () => {
+  it("fits a source into the render bounds without changing its aspect ratio", () => {
+    expect(fitNativeFrameDimensions(1280, 720, 3024, 1964)).toEqual({
+      width: 1109,
+      height: 720,
+    });
+  });
+
+  it("uses the render bounds when source dimensions are unavailable", () => {
+    expect(fitNativeFrameDimensions(1280.4, 719.6)).toEqual({
+      width: 1280,
+      height: 720,
+    });
+  });
+});

--- a/src/lib/export/__tests__/nativeTimelineExport.test.ts
+++ b/src/lib/export/__tests__/nativeTimelineExport.test.ts
@@ -1,0 +1,195 @@
+import { describe, expect, it } from "vitest";
+import type { Clip, MediaAsset, Project, Track } from "@/types";
+import { analyzeNativeTimelineExport } from "../nativeTimelineExport";
+
+const project: Project = {
+  id: "project-1",
+  name: "Cut-only timeline",
+  createdAt: 1,
+  updatedAt: 1,
+  aspectRatio: "16:9",
+  canvasWidth: 1920,
+  canvasHeight: 1080,
+  frameRate: 30,
+  duration: 9,
+};
+
+const tracks: Track[] = [
+  {
+    id: "text-track",
+    type: "text",
+    name: "Empty captions",
+    muted: false,
+    locked: false,
+    visible: true,
+    height: 30,
+  },
+  {
+    id: "video-track",
+    type: "video",
+    name: "Video",
+    muted: false,
+    locked: false,
+    visible: true,
+    height: 68,
+  },
+];
+
+const assets: MediaAsset[] = [
+  {
+    id: "main",
+    name: "main.mov",
+    path: "/media/main.mov",
+    type: "video",
+    duration: 100,
+    width: 3024,
+    height: 1964,
+    size: 1,
+  },
+  {
+    id: "ident",
+    name: "ident.mp4",
+    path: "/media/ident.mp4",
+    type: "video",
+    duration: 6,
+    width: 1920,
+    height: 1080,
+    size: 1,
+  },
+];
+
+function clip(overrides: Partial<Clip>): Clip {
+  return {
+    id: "clip",
+    kind: "video",
+    trackId: "video-track",
+    mediaId: "main",
+    startTime: 0,
+    duration: 3,
+    trimIn: 10,
+    trimOut: 13,
+    x: 0,
+    y: -83.5,
+    width: 1920,
+    height: 1247,
+    opacity: 1,
+    rotation: 0,
+    fitMode: "cover",
+    ...overrides,
+  };
+}
+
+describe("analyzeNativeTimelineExport", () => {
+  it("builds a normalized native plan for sequential mixed-format cuts", () => {
+    const result = analyzeNativeTimelineExport({
+      clips: [
+        clip({ id: "main-clip" }),
+        clip({
+          id: "ident-clip",
+          mediaId: "ident",
+          startTime: 3,
+          duration: 6,
+          trimIn: 0,
+          trimOut: 6,
+          x: 0,
+          y: 0,
+          width: 1920,
+          height: 1080,
+        }),
+      ],
+      tracks,
+      transitions: [],
+      assets,
+      project,
+      startTime: 0,
+      endTime: 9,
+      outputPath: "/output/movie.mp4",
+      width: 3840,
+      height: 2160,
+      frameRate: 30,
+      codec: "h265",
+      preset: "medium",
+      crf: 20,
+      pixelFormat: "yuv420p",
+    });
+
+    expect(result).toEqual({
+      eligible: true,
+      plan: {
+        outputPath: "/output/movie.mp4",
+        width: 3840,
+        height: 2160,
+        frameRate: 30,
+        codec: "h265",
+        preset: "medium",
+        crf: 20,
+        pixelFormat: "yuv420p",
+        totalDuration: 9,
+        clips: [
+          {
+            path: "/media/main.mov",
+            trimIn: 10,
+            duration: 3,
+            frameCount: 90,
+            x: 0,
+            y: -167,
+            width: 3840,
+            height: 2494,
+            volume: 1,
+          },
+          {
+            path: "/media/ident.mp4",
+            trimIn: 0,
+            duration: 6,
+            frameCount: 180,
+            x: 0,
+            y: 0,
+            width: 3840,
+            height: 2160,
+            volume: 1,
+          },
+        ],
+      },
+    });
+  });
+
+  it("rejects compositor-only timelines with actionable reasons", () => {
+    const result = analyzeNativeTimelineExport({
+      clips: [
+        clip({
+          effects: [
+            {
+              id: "effect-1",
+              effectId: "shake",
+              type: "effect",
+              renderer: "shake",
+              params: {},
+              startTime: 0,
+              duration: 3,
+              intensity: 1,
+            },
+          ],
+        }),
+      ],
+      tracks,
+      transitions: [],
+      assets,
+      project,
+      startTime: 0,
+      endTime: 3,
+      outputPath: "/output/movie.mp4",
+      width: 3840,
+      height: 2160,
+      frameRate: 30,
+      codec: "h265",
+      preset: "medium",
+      crf: 20,
+      pixelFormat: "yuv420p",
+    });
+
+    expect(result).toEqual({
+      eligible: false,
+      reasons: ["Clip clip uses compositor-only visual settings"],
+    });
+  });
+});

--- a/src/lib/export/frameBatching.ts
+++ b/src/lib/export/frameBatching.ts
@@ -1,0 +1,17 @@
+const DEFAULT_TARGET_BATCH_BYTES = 32 * 1024 * 1024;
+const MAX_BATCH_FRAMES = 45;
+
+/** Keep compositor export batches bounded by bytes, not frame count. */
+export function calculateExportBatchSize(
+  frameSizeBytes: number,
+  targetBatchBytes = DEFAULT_TARGET_BATCH_BYTES,
+): number {
+  if (!Number.isFinite(frameSizeBytes) || frameSizeBytes <= 0) {
+    return 1;
+  }
+
+  return Math.max(
+    1,
+    Math.min(MAX_BATCH_FRAMES, Math.floor(targetBatchBytes / frameSizeBytes)),
+  );
+}

--- a/src/lib/export/nativeExportFramePool.ts
+++ b/src/lib/export/nativeExportFramePool.ts
@@ -1,0 +1,98 @@
+import { invoke } from "@tauri-apps/api/core";
+
+export type ExportVideoSource = HTMLVideoElement | HTMLCanvasElement;
+
+interface NativeFrameRequest {
+  key: string;
+  videoPath: string;
+  timeSecs: number;
+  width: number;
+  height: number;
+}
+
+export function fitNativeFrameDimensions(
+  maxWidth: number,
+  maxHeight: number,
+  sourceWidth?: number,
+  sourceHeight?: number,
+): { width: number; height: number } {
+  const boundedWidth = Math.max(1, Math.round(maxWidth));
+  const boundedHeight = Math.max(1, Math.round(maxHeight));
+
+  if (!sourceWidth || !sourceHeight || sourceWidth <= 0 || sourceHeight <= 0) {
+    return { width: boundedWidth, height: boundedHeight };
+  }
+
+  const scale = Math.min(
+    boundedWidth / sourceWidth,
+    boundedHeight / sourceHeight,
+  );
+
+  return {
+    width: Math.max(1, Math.round(sourceWidth * scale)),
+    height: Math.max(1, Math.round(sourceHeight * scale)),
+  };
+}
+
+function toUint8Array(value: ArrayBuffer | Uint8Array | number[]): Uint8Array {
+  if (value instanceof Uint8Array) return value;
+  if (value instanceof ArrayBuffer) return new Uint8Array(value);
+  return Uint8Array.from(value);
+}
+
+/**
+ * Supplies Pixi with stable canvas-backed video sources whose pixels come from
+ * Clypra's native sequential FFmpeg decoder. Reusing one canvas per clip keeps
+ * the Pixi texture stable while avoiding WebKit's slow paused-video seek path.
+ */
+export class NativeExportFramePool {
+  private readonly canvases = new Map<string, HTMLCanvasElement>();
+
+  async acquire(request: NativeFrameRequest): Promise<HTMLCanvasElement> {
+    const width = Math.max(1, Math.round(request.width));
+    const height = Math.max(1, Math.round(request.height));
+    let canvas = this.canvases.get(request.key);
+
+    if (!canvas) {
+      canvas = document.createElement("canvas");
+      this.canvases.set(request.key, canvas);
+    }
+
+    if (canvas.width !== width || canvas.height !== height) {
+      canvas.width = width;
+      canvas.height = height;
+    }
+
+    const response = await invoke<ArrayBuffer | Uint8Array | number[]>(
+      "decode_export_frame",
+      {
+        videoPath: request.videoPath,
+        timeSecs: request.timeSecs,
+        width,
+        height,
+      },
+    );
+    const rgba = toUint8Array(response);
+    const expectedBytes = width * height * 4;
+
+    if (rgba.byteLength !== expectedBytes) {
+      throw new Error(
+        `Native export frame size mismatch: expected ${expectedBytes} bytes, got ${rgba.byteLength}`,
+      );
+    }
+
+    const context = canvas.getContext("2d");
+    if (!context) {
+      throw new Error("Unable to create native export frame canvas");
+    }
+
+    const imageData = context.createImageData(width, height);
+    imageData.data.set(rgba);
+    context.putImageData(imageData, 0, 0);
+    return canvas;
+  }
+
+  clear(): void {
+    this.canvases.clear();
+  }
+}

--- a/src/lib/export/nativeExportFramePool.ts
+++ b/src/lib/export/nativeExportFramePool.ts
@@ -2,6 +2,12 @@ import { invoke } from "@tauri-apps/api/core";
 
 export type ExportVideoSource = HTMLVideoElement | HTMLCanvasElement;
 
+interface NativeFrameSurface {
+  canvas: HTMLCanvasElement;
+  context: CanvasRenderingContext2D;
+  imageData: ImageData;
+}
+
 interface NativeFrameRequest {
   key: string;
   videoPath: string;
@@ -46,23 +52,40 @@ function toUint8Array(value: ArrayBuffer | Uint8Array | number[]): Uint8Array {
  * the Pixi texture stable while avoiding WebKit's slow paused-video seek path.
  */
 export class NativeExportFramePool {
-  private readonly canvases = new Map<string, HTMLCanvasElement>();
+  private readonly surfaces = new Map<string, NativeFrameSurface>();
+  private readonly videoPaths = new Set<string>();
 
   async acquire(request: NativeFrameRequest): Promise<HTMLCanvasElement> {
     const width = Math.max(1, Math.round(request.width));
     const height = Math.max(1, Math.round(request.height));
-    let canvas = this.canvases.get(request.key);
+    let surface = this.surfaces.get(request.key);
 
-    if (!canvas) {
-      canvas = document.createElement("canvas");
-      this.canvases.set(request.key, canvas);
-    }
-
-    if (canvas.width !== width || canvas.height !== height) {
+    if (!surface) {
+      const canvas = document.createElement("canvas");
       canvas.width = width;
       canvas.height = height;
+      const context = canvas.getContext("2d");
+
+      if (!context) {
+        throw new Error("Unable to create native export frame canvas");
+      }
+
+      surface = {
+        canvas,
+        context,
+        imageData: context.createImageData(width, height),
+      };
+      this.surfaces.set(request.key, surface);
+    } else if (
+      surface.canvas.width !== width ||
+      surface.canvas.height !== height
+    ) {
+      surface.canvas.width = width;
+      surface.canvas.height = height;
+      surface.imageData = surface.context.createImageData(width, height);
     }
 
+    this.videoPaths.add(request.videoPath);
     const response = await invoke<ArrayBuffer | Uint8Array | number[]>(
       "decode_export_frame",
       {
@@ -81,18 +104,20 @@ export class NativeExportFramePool {
       );
     }
 
-    const context = canvas.getContext("2d");
-    if (!context) {
-      throw new Error("Unable to create native export frame canvas");
-    }
-
-    const imageData = context.createImageData(width, height);
-    imageData.data.set(rgba);
-    context.putImageData(imageData, 0, 0);
-    return canvas;
+    surface.imageData.data.set(rgba);
+    surface.context.putImageData(surface.imageData, 0, 0);
+    return surface.canvas;
   }
 
-  clear(): void {
-    this.canvases.clear();
+  async clear(): Promise<void> {
+    for (const path of this.videoPaths) {
+      await invoke("release_video_decoder", { videoPath: path }).catch(() => {});
+    }
+    for (const surface of this.surfaces.values()) {
+      surface.canvas.width = 0;
+      surface.canvas.height = 0;
+    }
+    this.videoPaths.clear();
+    this.surfaces.clear();
   }
 }

--- a/src/lib/export/nativeTimelineExport.ts
+++ b/src/lib/export/nativeTimelineExport.ts
@@ -1,0 +1,249 @@
+import type {
+  Clip,
+  MediaAsset,
+  Project,
+  Track,
+  TransitionTimelineItem,
+} from "@/types";
+import { toNativePath } from "@/lib/platform/pathConversion";
+
+export interface NativeTimelineClipPlan {
+  path: string;
+  trimIn: number;
+  duration: number;
+  frameCount: number;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  volume: number;
+}
+
+export interface NativeTimelineExportPlan {
+  outputPath: string;
+  width: number;
+  height: number;
+  frameRate: number;
+  codec: "h264" | "h265" | "prores";
+  preset: "ultrafast" | "fast" | "medium" | "slow" | "veryslow";
+  crf: number;
+  pixelFormat: "yuv420p" | "yuv444p" | "yuv422p10le";
+  totalDuration: number;
+  clips: NativeTimelineClipPlan[];
+}
+
+interface NativeTimelineExportInput {
+  clips: Clip[];
+  tracks: Track[];
+  transitions: TransitionTimelineItem[];
+  assets: MediaAsset[];
+  project: Project | null;
+  startTime: number;
+  endTime: number;
+  outputPath: string;
+  width: number;
+  height: number;
+  frameRate: number;
+  codec: NativeTimelineExportPlan["codec"];
+  preset: NativeTimelineExportPlan["preset"];
+  crf: number;
+  pixelFormat: NativeTimelineExportPlan["pixelFormat"];
+}
+
+export type NativeTimelineExportEligibility =
+  | { eligible: true; plan: NativeTimelineExportPlan }
+  | { eligible: false; reasons: string[] };
+
+interface NativeTimelineRunCallbacks {
+  onProgress?: (progress: {
+    currentFrame: number;
+    totalFrames: number;
+    progress: number;
+    etaSeconds: number;
+    fps: number;
+  }) => void;
+  onSessionReady?: (cancel: () => Promise<void>) => void;
+}
+
+export interface NativeTimelineRunResult {
+  completedFrames: number;
+  totalTimeMs: number;
+  cancelled: boolean;
+  peakRssBytes: number;
+}
+
+const roundPlacement = (value: number): number => Math.round(value);
+
+/**
+ * Finds cut-only timelines that Rust can normalize and encode without routing
+ * every frame through WebKit and Pixi.
+ */
+export function analyzeNativeTimelineExport(
+  input: NativeTimelineExportInput,
+): NativeTimelineExportEligibility {
+  const reasons: string[] = [];
+  const { project, startTime, endTime, frameRate } = input;
+
+  if (!project) {
+    return { eligible: false, reasons: ["Project settings are unavailable"] };
+  }
+
+  const videoTracks = input.tracks.filter(
+    (track) => track.type === "video" && track.visible,
+  );
+  if (videoTracks.length !== 1) {
+    reasons.push("Native export requires exactly one visible video track");
+  }
+
+  if (input.transitions.length > 0) {
+    reasons.push("Timeline transitions require compositor export");
+  }
+
+  const primaryTrackId = videoTracks[0]?.id;
+  const activeClips = input.clips
+    .filter(
+      (clip) =>
+        clip.startTime < endTime &&
+        clip.startTime + clip.duration > startTime,
+    )
+    .sort((left, right) => left.startTime - right.startTime);
+  const videoClips = activeClips.filter(
+    (clip) => clip.trackId === primaryTrackId,
+  );
+
+  if (activeClips.length !== videoClips.length) {
+    reasons.push("Additional visual or audio clips require compositor export");
+  }
+  if (videoClips.length === 0) {
+    reasons.push("Timeline has no video clips to export");
+  }
+
+  const frameTolerance = 0.5 / frameRate;
+  let expectedStart = startTime;
+  for (const clip of videoClips) {
+    if (Math.abs(clip.startTime - expectedStart) > frameTolerance) {
+      reasons.push("Video clips must be sequential without gaps or overlaps");
+      break;
+    }
+    expectedStart = clip.startTime + clip.duration;
+  }
+  if (
+    videoClips.length > 0 &&
+    Math.abs(expectedStart - endTime) > frameTolerance
+  ) {
+    reasons.push("Video clips must cover the complete export range");
+  }
+
+  for (const clip of videoClips) {
+    const asset = input.assets.find((candidate) => candidate.id === clip.mediaId);
+    if (!asset || asset.type !== "video" || !asset.path) {
+      reasons.push(`Clip ${clip.id} does not reference a local video asset`);
+    }
+    if (
+      clip.opacity !== 1 ||
+      clip.rotation !== 0 ||
+      (clip.effects?.length ?? 0) > 0 ||
+      (clip.overlays?.length ?? 0) > 0 ||
+      clip.filter
+    ) {
+      reasons.push(`Clip ${clip.id} uses compositor-only visual settings`);
+    }
+  }
+
+  if (reasons.length > 0) {
+    return { eligible: false, reasons: [...new Set(reasons)] };
+  }
+
+  const scaleX = input.width / project.canvasWidth;
+  const scaleY = input.height / project.canvasHeight;
+  const clips = videoClips.map((clip): NativeTimelineClipPlan => {
+    const asset = input.assets.find(
+      (candidate) => candidate.id === clip.mediaId,
+    )!;
+    const overlapStart = Math.max(startTime, clip.startTime);
+    const overlapEnd = Math.min(endTime, clip.startTime + clip.duration);
+    const firstFrame = Math.round((overlapStart - startTime) * input.frameRate);
+    const endFrame = Math.round((overlapEnd - startTime) * input.frameRate);
+
+    return {
+      path: toNativePath(asset.path),
+      trimIn: clip.trimIn + overlapStart - clip.startTime,
+      duration: overlapEnd - overlapStart,
+      frameCount: endFrame - firstFrame,
+      x: roundPlacement(clip.x * scaleX),
+      y: roundPlacement(clip.y * scaleY),
+      width: Math.max(1, roundPlacement(clip.width * scaleX)),
+      height: Math.max(1, roundPlacement(clip.height * scaleY)),
+      volume: Math.max(0, Math.min(1, clip.volume ?? 1)),
+    };
+  });
+
+  return {
+    eligible: true,
+    plan: {
+      outputPath: toNativePath(input.outputPath),
+      width: input.width,
+      height: input.height,
+      frameRate: input.frameRate,
+      codec: input.codec,
+      preset: input.preset,
+      crf: input.crf,
+      pixelFormat: input.pixelFormat,
+      totalDuration: endTime - startTime,
+      clips,
+    },
+  };
+}
+
+export async function runNativeTimelineExport(
+  plan: NativeTimelineExportPlan,
+  callbacks: NativeTimelineRunCallbacks,
+): Promise<NativeTimelineRunResult> {
+  const { invoke, Channel } = await import("@tauri-apps/api/core");
+  let completedFrames = 0;
+  let cancelled = false;
+  const progressChannel = new Channel<{
+    currentFrame: number;
+    totalFrames: number;
+    progress: number;
+    etaSeconds: number;
+    fps: number;
+  }>();
+  progressChannel.onmessage = (progress) => {
+    completedFrames = progress.currentFrame;
+    callbacks.onProgress?.(progress);
+  };
+
+  const sessionId = await invoke<string>("start_native_timeline_export", {
+    plan,
+    onProgress: progressChannel,
+  });
+  callbacks.onSessionReady?.(async () => {
+    cancelled = true;
+    await invoke("cancel_native_timeline_export", { sessionId }).catch(() => {});
+  });
+
+  try {
+    const completion = await invoke<{
+      totalFrames: number;
+      totalTimeMs: number;
+      peakRssBytes: number;
+    }>("finalize_native_timeline_export", { sessionId });
+    return {
+      completedFrames: completion.totalFrames,
+      totalTimeMs: completion.totalTimeMs,
+      cancelled: false,
+      peakRssBytes: completion.peakRssBytes,
+    };
+  } catch (error) {
+    if (cancelled) {
+      return {
+        completedFrames,
+        totalTimeMs: 0,
+        cancelled: true,
+        peakRssBytes: 0,
+      };
+    }
+    throw error;
+  }
+}

--- a/src/lib/export/pixiExportRenderer.ts
+++ b/src/lib/export/pixiExportRenderer.ts
@@ -31,6 +31,7 @@ import { PixiSceneCompositor } from "@/core/render/pixiSceneCompositor";
 import type { EvaluatedScene } from "@/core/evaluation/types";
 import { clearAllTextBridges } from "@/core/render/textBridge";
 import { clearAllStickerBridges } from "@/core/render/stickerBridge";
+import type { VideoFrameSource } from "@/core/render/utils/mediaResolver";
 
 // ── Minimal pool adapter for export ──────────────────────────────────────────
 // The real PreviewMediaPool tracks frame callbacks from requestVideoFrameCallback
@@ -159,13 +160,13 @@ export function destroyPixiExportCompositor(handle: PixiExportCompositor): void 
  *
  * @param handle        - Compositor handle from createPixiExportCompositor
  * @param scene         - Evaluated scene for this frame (from evaluateTimelineSceneCached)
- * @param videoElements - Map of `${clipId}-${mediaId}` → HTMLVideoElement (pre-seeked)
+ * @param videoElements - Map of `${clipId}-${mediaId}` to a decoded video source
  * @returns             - ImageData containing RGBA pixels for this frame
  */
 export async function renderFrameWithPixi(
   handle: PixiExportCompositor,
   scene: EvaluatedScene,
-  videoElements: Map<string, HTMLVideoElement>,
+  videoElements: Map<string, VideoFrameSource>,
 ): Promise<ImageData> {
   const { compositor, canvas, readbackCanvas, readbackCtx, width, height } = handle;
 

--- a/src/lib/export/videoExport.ts
+++ b/src/lib/export/videoExport.ts
@@ -12,7 +12,10 @@
 import { platform } from "../../core/platform";
 import { evaluateTimelineSceneCached, clearEvaluationCache } from "../../core/evaluation/evaluator";
 import { createPixiExportCompositor, destroyPixiExportCompositor, renderFrameWithPixi } from "./pixiExportRenderer";
-import { VideoElementPool } from "../../core/resources/VideoElementPool";
+import {
+  fitNativeFrameDimensions,
+  NativeExportFramePool,
+} from "./nativeExportFramePool";
 import { getResourceCache } from "../../core/resources/ResourceCache";
 import { resolveClipSourceTime } from "../../core/timeline/sourceTime";
 import { getActiveAudioClips } from "../../core/timeline/audioClips";
@@ -148,11 +151,10 @@ export async function exportVideo(config: VideoExportConfig): Promise<VideoExpor
     throw new Error("No frames to export");
   }
 
-  // Create headless video element pool for export
-  const videoPool = new VideoElementPool({
-    maxConcurrent: 10,
-    debug: false,
-  });
+  // Decode export frames through the native sequential FFmpeg decoder. The
+  // previous HTMLVideoElement path performed a paused WebKit seek for every
+  // frame and collapsed to roughly 1 fps on macOS.
+  const nativeFramePool = new NativeExportFramePool();
 
   // Create headless Pixi compositor for this export session.
   // All 21 GPU transitions render correctly on this path.
@@ -274,73 +276,71 @@ export async function exportVideo(config: VideoExportConfig): Promise<VideoExpor
 
       const time = frameTimes[i];
 
-      // Track ALL acquired video elements for this frame (released in finally)
-      const frameVideoElements: HTMLVideoElement[] = [];
+      // Decode active video layers into stable canvas-backed Pixi sources.
+      const videoElements = new Map<string, HTMLCanvasElement>();
 
-      try {
-        // Pre-load and seek all video elements for this frame
-        const videoElements = new Map<string, HTMLVideoElement>();
+      // Find all video clips active at this time
+      for (const clip of clips) {
+        const asset = assets.find((a) => a.id === clip.mediaId);
+        if (asset?.type !== "video") continue;
 
-        // Find all video clips active at this time
-        for (const clip of clips) {
-          const asset = assets.find((a) => a.id === clip.mediaId);
-          if (asset?.type !== "video") continue;
+        // Check if clip is active at this time
+        const clipEnd = clip.startTime + clip.duration;
+        if (time < clip.startTime || time >= clipEnd) continue;
 
-          // Check if clip is active at this time
-          const clipEnd = clip.startTime + clip.duration;
-          if (time < clip.startTime || time >= clipEnd) continue;
+        // Replaced inline calculation with resolveClipSourceTime utility to ensure consistency
+        const { sourceTime } = resolveClipSourceTime(clip, time, {
+          clampToRange: true,
+          frameRate,
+        });
 
-          // Replaced inline calculation with resolveClipSourceTime utility to ensure consistency
-          const { sourceTime } = resolveClipSourceTime(clip, time, {
-            clampToRange: true,
-            frameRate,
+        const key = `${clip.id}-${clip.mediaId}`;
+        try {
+          const projectWidth = project?.canvasWidth || width;
+          const projectHeight = project?.canvasHeight || height;
+          const decodeBoundsWidth =
+            (clip.width || asset.width || projectWidth) * (width / projectWidth);
+          const decodeBoundsHeight =
+            (clip.height || asset.height || projectHeight) * (height / projectHeight);
+          const decodeSize = fitNativeFrameDimensions(
+            decodeBoundsWidth,
+            decodeBoundsHeight,
+            asset.width,
+            asset.height,
+          );
+          const canvas = await nativeFramePool.acquire({
+            key,
+            videoPath: asset.path,
+            timeSecs: sourceTime,
+            width: decodeSize.width,
+            height: decodeSize.height,
           });
-
-          // Resolve path for Tauri webview context
-          const resolvedPath = asset.path.startsWith("asset://") ? asset.path : platform.convertFileSrc(asset.path);
-
-          // Acquire video element at exact frame time
-          const key = `${clip.id}-${clip.mediaId}`;
-          try {
-            const video = await videoPool.acquire(resolvedPath, sourceTime);
-            videoElements.set(key, video);
-            frameVideoElements.push(video);
-          } catch (error) {
-            // CRITICAL FIX: Fail export if video acquisition fails to prevent silent data corruption
-            // Releasing already-acquired elements before throwing
-            for (const vid of frameVideoElements) {
-              videoPool.releaseElement(vid);
-            }
-            throw new Error(`Failed to acquire video for clip at time ${time}s: ${error}. Export aborted to prevent corrupted output.`);
-          }
+          videoElements.set(key, canvas);
+        } catch (error) {
+          throw new Error(`Failed to decode video for clip at time ${time}s: ${error}. Export aborted to prevent corrupted output.`);
         }
+      }
 
-        // Evaluate scene for this frame using the canonical evaluator
-        const scene = evaluateTimelineSceneCached(time, clips, tracks, assets, project, epoch, transitions);
+      // Evaluate scene for this frame using the canonical evaluator
+      const scene = evaluateTimelineSceneCached(time, clips, tracks, assets, project, epoch, transitions);
 
-        // Render frame through the Pixi WebGL compositor.
-        // All 21 GPU transitions render correctly here (16 of them were broken on
-        // the previous Canvas 2D / FrameScheduler path).
-        const imageData = await renderFrameWithPixi(pixiHandle, scene, videoElements);
+      // Render frame through the Pixi WebGL compositor.
+      // All 21 GPU transitions render correctly here (16 of them were broken on
+      // the previous Canvas 2D / FrameScheduler path).
+      const imageData = await renderFrameWithPixi(pixiHandle, scene, videoElements);
 
-        // Add frame to batch buffer.
-        // CRITICAL: Must copy the data — the readback canvas is reused for the next frame
-        // so its ImageData buffer will be overwritten. Without this copy, up to
-        // BATCH_SIZE-1 frames get corrupted per flush cycle.
-        const frameBytes = new Uint8Array(imageData.data);
-        frameBuffer.push(frameBytes);
+      // Add frame to batch buffer.
+      // CRITICAL: Must copy the data — the readback canvas is reused for the next frame
+      // so its ImageData buffer will be overwritten. Without this copy, up to
+      // BATCH_SIZE-1 frames get corrupted per flush cycle.
+      const frameBytes = new Uint8Array(imageData.data);
+      frameBuffer.push(frameBytes);
 
-        completedFrames++;
+      completedFrames++;
 
-        // Flush batch when full or at end of export
-        if (frameBuffer.length >= BATCH_SIZE || i === frameTimes.length - 1) {
-          await flushFrameBatch();
-        }
-      } finally {
-        // This prevents resource leaks when export fails mid-frame
-        for (const video of frameVideoElements) {
-          videoPool.releaseElement(video);
-        }
+      // Flush batch when full or at end of export
+      if (frameBuffer.length >= BATCH_SIZE || i === frameTimes.length - 1) {
+        await flushFrameBatch();
       }
     }
 
@@ -363,8 +363,8 @@ export async function exportVideo(config: VideoExportConfig): Promise<VideoExpor
       throw error;
     }
   } finally {
-    // Always clean up video pool and Pixi compositor
-    videoPool.clear();
+    // Always clean up native frame sources and Pixi compositor
+    nativeFramePool.clear();
     destroyPixiExportCompositor(pixiHandle);
 
     // Release global image bitmaps and evaluated frames to free up memory

--- a/src/lib/export/videoExport.ts
+++ b/src/lib/export/videoExport.ts
@@ -16,6 +16,11 @@ import {
   fitNativeFrameDimensions,
   NativeExportFramePool,
 } from "./nativeExportFramePool";
+import { calculateExportBatchSize } from "./frameBatching";
+import {
+  analyzeNativeTimelineExport,
+  runNativeTimelineExport,
+} from "./nativeTimelineExport";
 import { getResourceCache } from "../../core/resources/ResourceCache";
 import { resolveClipSourceTime } from "../../core/timeline/sourceTime";
 import { getActiveAudioClips } from "../../core/timeline/audioClips";
@@ -151,6 +156,40 @@ export async function exportVideo(config: VideoExportConfig): Promise<VideoExpor
     throw new Error("No frames to export");
   }
 
+  const nativeTimeline = analyzeNativeTimelineExport({
+    clips,
+    tracks,
+    transitions,
+    assets,
+    project,
+    startTime,
+    endTime,
+    outputPath,
+    width,
+    height,
+    frameRate,
+    codec,
+    preset,
+    crf,
+    pixelFormat,
+  });
+  if (nativeTimeline.eligible) {
+    const nativeResult = await runNativeTimelineExport(nativeTimeline.plan, {
+      onProgress,
+      onSessionReady,
+    });
+    return {
+      outputPath,
+      totalFrames: nativeResult.completedFrames,
+      totalTimeMs: nativeResult.totalTimeMs,
+      avgTimePerFrameMs:
+        nativeResult.completedFrames > 0
+          ? nativeResult.totalTimeMs / nativeResult.completedFrames
+          : 0,
+      cancelled: nativeResult.cancelled,
+    };
+  }
+
   // Decode export frames through the native sequential FFmpeg decoder. The
   // previous HTMLVideoElement path performed a paused WebKit seek for every
   // frame and collapsed to roughly 1 fps on macOS.
@@ -221,46 +260,42 @@ export async function exportVideo(config: VideoExportConfig): Promise<VideoExpor
   // starts so the UI can kill FFmpeg when the user presses Cancel. Setting isCancelled
   // causes the frame loop to break cleanly on the next iteration.
   let isCancelled = false;
+  let resolveCleanup: () => void = () => {};
+  const cleanupComplete = new Promise<void>((resolve) => {
+    resolveCleanup = resolve;
+  });
   if (onSessionReady) {
     onSessionReady(async () => {
       isCancelled = true;
       await invoke("cancel_video_export", { sessionId }).catch(() => {
         // Ignore — process may have already exited
       });
+      await cleanupComplete;
     });
   }
 
-  // PERFORMANCE OPTIMIZATION: Batch frame writes to reduce IPC overhead
-  // Batch size of 30-60 frames balances latency with throughput
-  const BATCH_SIZE = 45; // 1.5 seconds at 30fps, 0.75s at 60fps
-  const frameBuffer: Uint8Array[] = [];
   const frameSize = width * height * 4; // RGBA
+  const BATCH_SIZE = calculateExportBatchSize(frameSize);
+  const frameBuffer = new Uint8Array(frameSize * BATCH_SIZE);
+  let bufferedFrames = 0;
 
   /**
    * Flush accumulated frames to backend in a single batch.
    * Reduces IPC overhead by 90% compared to per-frame writes.
    */
   async function flushFrameBatch() {
-    if (frameBuffer.length === 0) return;
-
-    // Concatenate all frames into single buffer
-    const batchSize = frameBuffer.length * frameSize;
-    const batchBuffer = new Uint8Array(batchSize);
-
-    for (let i = 0; i < frameBuffer.length; i++) {
-      batchBuffer.set(frameBuffer[i], i * frameSize);
-    }
+    if (bufferedFrames === 0) return;
+    const payload = frameBuffer.subarray(0, bufferedFrames * frameSize);
 
     // Send batch with frame count in header
-    await invoke("write_export_frames_batch", batchBuffer, {
+    await invoke("write_export_frames_batch", payload, {
       headers: {
         "session-id": sessionId,
-        "frame-count": frameBuffer.length.toString(),
+        "frame-count": bufferedFrames.toString(),
       },
     });
 
-    // Clear buffer for next batch
-    frameBuffer.length = 0;
+    bufferedFrames = 0;
   }
 
   try {
@@ -329,17 +364,13 @@ export async function exportVideo(config: VideoExportConfig): Promise<VideoExpor
       // the previous Canvas 2D / FrameScheduler path).
       const imageData = await renderFrameWithPixi(pixiHandle, scene, videoElements);
 
-      // Add frame to batch buffer.
-      // CRITICAL: Must copy the data — the readback canvas is reused for the next frame
-      // so its ImageData buffer will be overwritten. Without this copy, up to
-      // BATCH_SIZE-1 frames get corrupted per flush cycle.
-      const frameBytes = new Uint8Array(imageData.data);
-      frameBuffer.push(frameBytes);
+      frameBuffer.set(imageData.data, bufferedFrames * frameSize);
+      bufferedFrames++;
 
       completedFrames++;
 
       // Flush batch when full or at end of export
-      if (frameBuffer.length >= BATCH_SIZE || i === frameTimes.length - 1) {
+      if (bufferedFrames >= BATCH_SIZE || i === frameTimes.length - 1) {
         await flushFrameBatch();
       }
     }
@@ -364,7 +395,7 @@ export async function exportVideo(config: VideoExportConfig): Promise<VideoExpor
     }
   } finally {
     // Always clean up native frame sources and Pixi compositor
-    nativeFramePool.clear();
+    await nativeFramePool.clear();
     destroyPixiExportCompositor(pixiHandle);
 
     // Release global image bitmaps and evaluated frames to free up memory
@@ -373,6 +404,8 @@ export async function exportVideo(config: VideoExportConfig): Promise<VideoExpor
       clearEvaluationCache();
     } catch (e) {
       console.warn("[videoExport] Failed to clear post-export caches:", e);
+    } finally {
+      resolveCleanup();
     }
   }
 


### PR DESCRIPTION
## What changed

- adds a native Rust/FFmpeg export path for eligible cut-only timelines
- normalizes mixed source resolutions and frame rates into frame-exact segments
- concatenates video-only segments and muxes timeline audio once to avoid AAC priming and timestamp drift
- uses VideoToolbox for H.264/H.265 encoding on macOS
- keeps compositor export as the conservative fallback for transitions, effects, overlays, additional tracks, gaps, and overlaps
- bounds compositor fallback frame batches by bytes rather than a fixed frame count
- reuses frame canvases, contexts, image buffers, and decoder sessions
- adds cancellation, temporary-file cleanup, output cleanup, single-export locking, and an FFmpeg RSS safety ceiling

## Root cause

Desktop export previously decoded each frame through repeated paused WebKit video seeks before sending it through Pixi. Long source files could time out while seeking, and 4K exports accumulated expensive frame-sized allocations. The result was either an aborted export or an impractically slow render.

## Impact

Eligible editing timelines now bypass the per-frame WebKit/Pixi path entirely. Complex timelines retain the existing compositor behavior with bounded batching and stronger cleanup.

The real 7:20 `Codex-skill-video` project exported from the packaged app at 3840x2160 in 231.1 seconds:

- 13,228 frames
- 57.2 fps average export speed
- HEVC `hvc1`, exact 30 fps, `yuv420p`
- AAC, 48 kHz, stereo
- approximately 350-435 MiB observed FFmpeg RSS
- clean full-file video decode
- no unexpected audio dropout of 500 ms or longer
- visually verified footage across a cut and the final Dead Pixel ident

## Validation

- full Rust suite: 81 passed
- focused native-export Rust suite after final concurrency fix: 4 passed
- focused TypeScript export suite: 4 passed
- full TypeScript suite: 1,357 passed, 3 skipped
- isolated rerun of one load-sensitive timing test: passed
- `cargo check`: passed
- `cargo clippy --lib -- -D warnings`: passed
- production frontend build: passed
- Tauri application bundle: built and used for the full export
- `git diff --check`: passed
- final artifact validated with `ffprobe`, full decode, silence detection, and visual frame samples

## Notes

- all-target clippy still reports three pre-existing warnings in `thumbnail_engine_tests.rs`
- the macOS `.app` bundle succeeds, but the existing DMG assembly script fails afterward; this is separate from the export implementation and did not block packaged-app verification
