### PR TITLE
refactor(types): unify all type exports under src/types/index.ts

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -585,3 +585,8 @@ export interface ClipMarker {
   name: string;
   color: string;
 }
+
+export * from "./export";
+export * from "./gap";
+export * from "./serialization";
+


### PR DESCRIPTION
Re-export export.ts, gap.ts, and serialization.ts from the types barrel so all domain types, export params, timeline gaps, and serialization schemas are importable from @/types.

TypeScript: 0 errors  |  Vitest types: 3/3 passed  |  Rust: 0 warnings