### PR TITLE
fix(windows): resolve blank video preview on Windows WebView2

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -34,7 +34,7 @@ pub fn run() {
         if std::env::var("WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS").is_err() {
             std::env::set_var(
                 "WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS",
-                "--use-angle=d3d11 --enable-gpu-rasterization --ignore-gpu-blocklist --enable-zero-copy",
+                "--use-angle=d3d11 --enable-gpu-rasterization --ignore-gpu-blocklist --enable-zero-copy --allow-file-access-from-files",
             );
         }
     }

--- a/src/core/resources/VideoElementPool.ts
+++ b/src/core/resources/VideoElementPool.ts
@@ -135,6 +135,7 @@ export class VideoElementPool {
         const video = document.createElement("video");
         video.preload = "auto";
         video.crossOrigin = "anonymous";
+        video.setAttribute("playsinline", "");
         video.muted = true; // Muted for export (no audio in frame extraction)
 
         // Style and add to DOM to ensure the browser composites the frames


### PR DESCRIPTION
- Add --allow-file-access-from-files to WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS so Edge Chromium grants cross-origin read access to local video assets loaded via Tauri's asset protocol
- Set playsinline attribute on video elements in VideoElementPool alongside crossOrigin=anonymous to prevent WebGL frame extraction from being tainted or blocked on Windows Chromium

TypeScript: 0 errors  |  Rust cargo test: 81/81 passed