### PR TITLE
refactor(timeline): centralize track behavior into TRACK_TYPE_CONFIG …

### DIFF
--- a/src/components/editor/sidebar/tabs/CaptionsTab.tsx
+++ b/src/components/editor/sidebar/tabs/CaptionsTab.tsx
@@ -1,7 +1,7 @@
 import React, { useRef, useState } from "react";
 import { Plus, Download, Upload, Trash2, Play, AlertCircle, Sparkles, Settings } from "lucide-react";
 import { Button } from "@/components/ui/Button";
-import { useTimelineStore, getInsertIndexForNewTrack } from "@/store/timelineStore";
+import { useTimelineStore } from "@/store/timelineStore";
 import { useProjectStore } from "@/store/projectStore";
 import { useTransportControls } from "@/hooks/usePlaybackClock";
 import { useCaptionStore } from "@/store/captionStore";
@@ -36,20 +36,21 @@ export const CaptionsTab: React.FC<TabProps> = ({ onAddToTimeline }) => {
   // Get all text clips belonging to the caption track
   const captionClips = captionTrack ? (clips.filter((c) => c.trackId === captionTrack.id) as TextClip[]).sort((a, b) => a.startTime - b.startTime) : [];
 
-  // Ensure a caption track exists and return its ID
+  // Ensure a caption track exists and return its ID.
+  // Delegates to ensureTrackForType("text") for find-or-create;
+  // then renames the track to "Auto Captions" if it was just created.
   const ensureCaptionTrackId = (): string => {
-    if (captionTrack) return captionTrack.id;
+    const previousTrack = captionTrack;
+    const trackId = useTimelineStore.getState().ensureTrackForType("text");
 
-    const timeline = useTimelineStore.getState();
-    const insertIndex = getInsertIndexForNewTrack(timeline.tracks, "text");
-    const targetTrackId = timeline.insertTrackAt("text", insertIndex);
+    // If the track didn't exist before, name it for captions UX.
+    if (!previousTrack) {
+      useTimelineStore.setState((state) => ({
+        tracks: state.tracks.map((t) => (t.id === trackId ? { ...t, name: "Auto Captions" } : t)),
+      }));
+    }
 
-    // Rename to standard Auto Captions track name
-    useTimelineStore.setState((state) => ({
-      tracks: state.tracks.map((t) => (t.id === targetTrackId ? { ...t, name: "Auto Captions" } : t)),
-    }));
-
-    return targetTrackId;
+    return trackId;
   };
 
   // Trigger file import

--- a/src/components/editor/sidebar/tabs/SmartOverlaysTab.tsx
+++ b/src/components/editor/sidebar/tabs/SmartOverlaysTab.tsx
@@ -1,14 +1,14 @@
 import React, { useState } from "react";
 import { Sparkles, Plus, Wand2, Sliders, TrendingUp, Quote, Columns, Code, List, Clock, Share2, User } from "lucide-react";
 import { Button } from "@/components/ui/Button";
-import { useTimelineStore, getInsertIndexForNewTrack } from "@/store/timelineStore";
+import { useTimelineStore } from "@/store/timelineStore";
 import { SMART_OVERLAY_PRESETS, getSmartOverlayPreset, type SmartOverlayType, type SmartOverlayClip, type ComparisonOverlayContent } from "@/types/smartOverlay";
 
 import { extractSmartOverlaysFromTranscript } from "@/features/smart-overlays/services/smartOverlayExtractor";
 import type { TabProps } from "../types";
 
 export const SmartOverlaysTab: React.FC<TabProps> = ({ onAddToTimeline }) => {
-  const { clips, tracks, addClip, updateClip, addTrack } = useTimelineStore();
+  const { clips, addClip, updateClip } = useTimelineStore();
   const [isGenerating, setIsGenerating] = useState(false);
   const [selectedCategory, setSelectedCategory] = useState<SmartOverlayType | "all">("all");
   const [selectedClipId, setSelectedClipId] = useState<string | null>(null);
@@ -35,21 +35,11 @@ export const SmartOverlaysTab: React.FC<TabProps> = ({ onAddToTimeline }) => {
       ? SMART_OVERLAY_PRESETS
       : SMART_OVERLAY_PRESETS.filter((p) => p.category === selectedCategory);
 
-  const ensureTrack = (): string => {
-    // Find existing animated-overlay track by type (not ID — track IDs are generated UUIDs,
-    // never the literal string "animated-overlay"). Reuse if found, otherwise create.
-    const timeline = useTimelineStore.getState();
-    const existing = timeline.tracks.find((t) => t.type === "animated-overlay");
-    if (existing) return existing.id;
-
-    const insertIndex = getInsertIndexForNewTrack(timeline.tracks, "animated-overlay");
-    const targetTrackId = timeline.insertTrackAt("animated-overlay", insertIndex);
-    return targetTrackId;
-  };
 
   const handleAddPreset = (presetId: string) => {
     const preset = getSmartOverlayPreset(presetId);
-    const trackId = ensureTrack();
+    // ensureTrackForType respects reuseStrategy: "shared" — all overlay clips share one track.
+    const trackId = useTimelineStore.getState().ensureTrackForType("animated-overlay");
 
     const newClip: SmartOverlayClip = {
       id: `smart-overlay-${Date.now()}`,
@@ -92,10 +82,11 @@ export const SmartOverlaysTab: React.FC<TabProps> = ({ onAddToTimeline }) => {
         ],
       };
 
-      const plan = extractSmartOverlaysFromTranscript(mockTranscript, tracks);
+      const plan = extractSmartOverlaysFromTranscript(mockTranscript, useTimelineStore.getState().tracks);
 
-      // Ensure the shared animated-overlay track exists before adding clips
-      ensureTrack();
+      // Ensure the shared animated-overlay track exists before adding clips.
+      // ensureTrackForType("animated-overlay") uses reuseStrategy: "shared".
+      useTimelineStore.getState().ensureTrackForType("animated-overlay");
 
       // Add all AI-extracted clips
       plan.clips.forEach((clip) => {

--- a/src/components/editor/sidebar/tabs/TextTab.tsx
+++ b/src/components/editor/sidebar/tabs/TextTab.tsx
@@ -7,7 +7,7 @@ import type { TabProps } from "../types";
 import { TemplateCard } from "@/components/ui/TemplateCard";
 import { getActiveSessionOrNull } from "@/core/runtime/ProjectSession";
 import { useUIStore } from "@/store/uiStore";
-import { useTimelineStore, getInsertIndexForNewTrack } from "@/store/timelineStore";
+import { useTimelineStore } from "@/store/timelineStore";
 import { useProjectStore } from "@/store/projectStore";
 import { createTextClip } from "@/lib/text/textClip";
 import { TextEffectsApi } from "@/features/text-effects/api/textEffectsApi";
@@ -113,8 +113,7 @@ export const TextTab: React.FC<TabProps> = ({ onAddToTimeline }) => {
       let targetTrackId = textTrack?.id ?? null;
 
       if (!targetTrackId) {
-        const insertIndex = getInsertIndexForNewTrack(timeline.tracks, "text");
-        targetTrackId = timeline.insertTrackAt("text", insertIndex);
+        targetTrackId = timeline.ensureTrackForType("text");
         // Rename target track
         useTimelineStore.setState((state) => ({
           tracks: state.tracks.map((t) => (t.id === targetTrackId ? { ...t, name: "Auto Captions" } : t)),

--- a/src/core/history/commands/DeleteClipCommand.ts
+++ b/src/core/history/commands/DeleteClipCommand.ts
@@ -5,6 +5,7 @@
 import type { Command } from "../Command";
 import { generateCommandId } from "../Command";
 import type { Clip, Track, TransitionTimelineItem } from "@/types";
+import { shouldAutoPruneTrack } from "@/lib/timeline/trackTypeConfig";
 
 interface TimelineState {
   tracks?: Track[];
@@ -41,9 +42,11 @@ export class DeleteClipCommand implements Command {
 
     let tracks = state.tracks;
     if (tracks && !hasOtherClips) {
-      this.deletedTrack = tracks.find((t) => t.id === clip.trackId) || null;
-      this.deletedTrackIndex = tracks.findIndex((t) => t.id === clip.trackId);
-      if (this.deletedTrack) {
+      const trackToDelete = tracks.find((t) => t.id === clip.trackId);
+      // Only auto-prune if the track type is configured with autoPrune: true.
+      if (trackToDelete && shouldAutoPruneTrack(trackToDelete, state.tracks)) {
+        this.deletedTrack = trackToDelete;
+        this.deletedTrackIndex = tracks.findIndex((t) => t.id === clip.trackId);
         tracks = tracks.filter((t) => t.id !== clip.trackId);
       }
     }

--- a/src/core/history/commands/RippleDeleteRangeCommand.ts
+++ b/src/core/history/commands/RippleDeleteRangeCommand.ts
@@ -2,6 +2,7 @@ import type { Command } from "../Command";
 import { generateCommandId } from "../Command";
 import type { Clip, Track } from "@/types";
 import type { Gap } from "@/types/gap";
+import { shouldAutoPruneTrack } from "@/lib/timeline/trackTypeConfig";
 
 interface TimelineState {
   tracks: Track[];
@@ -89,7 +90,11 @@ export class RippleDeleteRangeCommand implements Command {
       });
 
     const occupiedTrackIds = new Set(clips.map((clip) => clip.trackId));
-    const tracks = state.tracks.filter((track) => occupiedTrackIds.has(track.id) || track.id === state.tracks.find((candidate) => candidate.type === "video")?.id);
+    // Keep a track if it still has clips OR if its type is non-prunable (autoPrune: false).
+    // This is driven purely by TRACK_TYPE_CONFIG — no hardcoded type strings here.
+    const tracks = state.tracks.filter(
+      (track) => occupiedTrackIds.has(track.id) || !shouldAutoPruneTrack(track, state.tracks),
+    );
     const deletedTrackIds = new Set(state.tracks.filter((track) => !tracks.some((candidate) => candidate.id === track.id)).map((track) => track.id));
 
     return {

--- a/src/lib/timeline/trackTypeConfig.ts
+++ b/src/lib/timeline/trackTypeConfig.ts
@@ -1,0 +1,201 @@
+/**
+ * Track Type Configuration Registry
+ *
+ * Single source of truth for all per-type metadata.
+ * Every decision that varies by TrackType must derive from this file —
+ * no more scattered if-chains or hard-coded magic strings.
+ *
+ * ┌─────────────────────────────────────────────────────────────────────────┐
+ * │  Adding a new TrackType?                                                │
+ * │  1. Add it to TrackType in src/types/index.ts                          │
+ * │  2. Add an entry here — TypeScript will error until you do             │
+ * │  3. Everything else (insertion, reuse, pruning) flows automatically    │
+ * └─────────────────────────────────────────────────────────────────────────┘
+ */
+
+import type { Track, TrackType } from "@/types";
+
+// ─── Value types ─────────────────────────────────────────────────────────────
+
+/**
+ * Where a new track of this type is inserted in the timeline.
+ * - "top"          → index 0 (above everything, including the main video track)
+ * - "below-video"  → immediately after the first video track (e.g. audio)
+ * - "bottom"       → appended after all existing tracks
+ */
+export type TrackPlacement = "top" | "below-video" | "bottom";
+
+/**
+ * How find-or-create (ensureTrackForType) works for this track type.
+ * - "primary"         → always returns mainVideoTrackId; never creates a new track
+ * - "shared"          → all clips of this type share ONE track; create it if absent
+ * - "per-clip"        → always create a fresh track for every new clip
+ * - "per-media-group" → one track per unique mediaId; clips with the same mediaId share a track
+ */
+export type TrackReuseStrategy =
+  | "primary"
+  | "shared"
+  | "per-clip"
+  | "per-media-group";
+
+export interface TrackTypeConfig {
+  /** Timeline row height in pixels. */
+  height: number;
+  /** Where a newly created track of this type is inserted. */
+  placement: TrackPlacement;
+  /** Controls how ensureTrackForType() finds or creates a track. */
+  reuseStrategy: TrackReuseStrategy;
+  /**
+   * Whether the track is automatically removed when its last clip is deleted.
+   * Set to false for tracks that must always exist (e.g. the primary video track).
+   */
+  autoPrune: boolean;
+  /** Human-readable label used when auto-naming a new track. */
+  displayName: string;
+}
+
+// ─── Registry ────────────────────────────────────────────────────────────────
+
+/**
+ * Canonical metadata for every TrackType.
+ * TypeScript will surface a compile error if a TrackType value is missing here.
+ */
+export const TRACK_TYPE_CONFIG: Record<TrackType, TrackTypeConfig> = {
+  video: {
+    height: 68,
+    placement: "top",
+    reuseStrategy: "primary",
+    autoPrune: true,
+    displayName: "Video",
+  },
+  audio: {
+    height: 52,
+    placement: "below-video",
+    reuseStrategy: "per-clip",
+    autoPrune: true,
+    displayName: "Audio",
+  },
+  text: {
+    height: 30,
+    placement: "top",
+    reuseStrategy: "per-clip",
+    autoPrune: true,
+    displayName: "Text",
+  },
+  sticker: {
+    height: 30,
+    placement: "top",
+    reuseStrategy: "per-clip",
+    autoPrune: true,
+    displayName: "Sticker",
+  },
+  filter: {
+    height: 30,
+    placement: "top",
+    reuseStrategy: "per-media-group",
+    autoPrune: true,
+    displayName: "Filter",
+  },
+  "video-effect": {
+    height: 30,
+    placement: "top",
+    reuseStrategy: "per-media-group",
+    autoPrune: true,
+    displayName: "Effect",
+  },
+  "body-effect": {
+    height: 30,
+    placement: "top",
+    reuseStrategy: "per-media-group",
+    autoPrune: true,
+    displayName: "Body Effect",
+  },
+  "animated-overlay": {
+    height: 30,
+    placement: "top",
+    reuseStrategy: "shared",
+    autoPrune: true,
+    displayName: "Overlays",
+  },
+};
+
+// ─── Pure helpers ─────────────────────────────────────────────────────────────
+
+/**
+ * Returns true if an empty track should be automatically removed.
+ * Protects the primary video track (mainVideoTrackId / first video track) from auto-pruning.
+ * All other empty tracks (secondary video, audio, text, overlay, etc.) are auto-pruned.
+ */
+export function shouldAutoPruneTrack(
+  track: { id: string; type: string },
+  tracksOrPrimaryId?: Track[] | string | null,
+): boolean {
+  let primaryId: string | null = null;
+  if (Array.isArray(tracksOrPrimaryId)) {
+    primaryId = tracksOrPrimaryId.find((t) => t.type === "video")?.id ?? null;
+  } else if (typeof tracksOrPrimaryId === "string") {
+    primaryId = tracksOrPrimaryId;
+  }
+
+  if (primaryId && track.id === primaryId) {
+    return false; // Protect primary video track
+  }
+
+  const config = (TRACK_TYPE_CONFIG as Record<string, TrackTypeConfig>)[track.type];
+  return config?.autoPrune ?? true;
+}
+
+/**
+ * Calculates the array insertion index for a brand-new track of `trackType`
+ * given the current ordered `tracks` list.
+ *
+ * Replaces the scattered `getInsertIndexForNewTrack` if-chain.
+ */
+export function getTrackInsertionIndex(tracks: Track[], trackType: TrackType): number {
+  const config = TRACK_TYPE_CONFIG[trackType];
+
+  switch (config.placement) {
+    case "top":
+      return 0;
+
+    case "below-video": {
+      const videoIdx = tracks.findIndex((t) => t.type === "video");
+      return videoIdx >= 0 ? videoIdx + 1 : tracks.length;
+    }
+
+    case "bottom":
+      return tracks.length;
+  }
+}
+
+/**
+ * Like getTrackInsertionIndex but with mediaId-aware grouping for
+ * "per-media-group" types (filter, video-effect, body-effect).
+ * Inserts immediately after the last track of the same type that already
+ * carries a clip with the matching mediaId.
+ */
+export function getTrackInsertionIndexGrouped(
+  tracks: Track[],
+  clips: { trackId: string; mediaId: string }[],
+  trackType: TrackType,
+  mediaId?: string,
+): number {
+  const config = TRACK_TYPE_CONFIG[trackType];
+
+  if (config.reuseStrategy === "per-media-group" && mediaId) {
+    const siblingIndices: number[] = [];
+    tracks.forEach((track, i) => {
+      if (track.type === trackType) {
+        const hasMatch = clips.some(
+          (c) => c.trackId === track.id && c.mediaId === mediaId,
+        );
+        if (hasMatch) siblingIndices.push(i);
+      }
+    });
+    if (siblingIndices.length > 0) {
+      return Math.max(...siblingIndices) + 1;
+    }
+  }
+
+  return getTrackInsertionIndex(tracks, trackType);
+}

--- a/src/store/timelineStore.ts
+++ b/src/store/timelineStore.ts
@@ -32,6 +32,7 @@ import { useProjectStore } from "./projectStore";
 import { clampTimelinePixelsPerSecond, clampTimelineZoom, TIMELINE_PPS_PER_ZOOM, TIMELINE_ZOOM_DEFAULT } from "../lib/timeline/timelineZoom";
 import { getTimelineContentEnd, normalizeClipTiming } from "@/lib/timeline/timelineClip";
 import { autoSaveMiddleware } from "./middleware/autoSaveMiddleware";
+import { TRACK_TYPE_CONFIG, shouldAutoPruneTrack, getTrackInsertionIndex, getTrackInsertionIndexGrouped } from "@/lib/timeline/trackTypeConfig";
 
 interface TimelineStore {
   tracks: Track[];
@@ -100,6 +101,18 @@ interface TimelineStore {
   normalizeTrack: (trackId: string) => void;
   getTrackClips: (trackId: string) => Clip[];
   removeEmptyNonMainTracks: (candidateTrackIds?: string[]) => void;
+  /**
+   * Canonical find-or-create for a track of a given type.
+   * Respects the reuseStrategy in TRACK_TYPE_CONFIG:
+   *   "primary"         → returns mainVideoTrackId (never creates)
+   *   "shared"          → reuses the single existing track of this type, or creates one
+   *   "per-clip"        → always creates a new track
+   *   "per-media-group" → reuses a track whose clips share mediaId, or creates one
+   *
+   * This is the ONLY place that should create tracks in response to a clip being added.
+   * Components must call this instead of rolling their own find-or-create logic.
+   */
+  ensureTrackForType: (type: TrackType, mediaId?: string) => string;
   // Gap operations
   insertGap: (trackId: string, startTime: number, duration: number) => Gap | null;
   removeGap: (gapId: string) => void;
@@ -123,61 +136,28 @@ interface TimelineStore {
   updateClipAudioFX: (clipId: string, fxUpdates: Partial<import("@/types").AudioFXConfig>) => void;
 }
 
-const trackHeights: Record<string, number> = {
-  video: 68,
-  audio: 52,
-  text: 30,
-  sticker: 30,
-  filter: 30,
-  "video-effect": 30,
-  "body-effect": 30,
-  "animated-overlay": 30,
-};
+/** Track row height in px — derived from the canonical TRACK_TYPE_CONFIG registry. */
+const trackHeights: Record<string, number> = Object.fromEntries(
+  Object.entries(TRACK_TYPE_CONFIG).map(([type, cfg]) => [type, cfg.height]),
+);
 const MIN_TRIM_DURATION_SEC = 1;
 
-/** Where to insert a new row when dropping off-track: video/text at top; audio under first video (or append if no video). */
+/**
+ * Where to insert a new row when dropping off-track.
+ * Delegates to trackTypeConfig.getTrackInsertionIndex — do NOT add logic here.
+ * @deprecated Prefer getTrackInsertionIndex from trackTypeConfig directly.
+ */
 export function getInsertIndexForNewTrack(tracks: Track[], trackType: TrackType): number {
-  if (trackType === "video" || trackType === "text" || trackType === "sticker" || trackType === "filter" || trackType === "video-effect" || trackType === "body-effect" || trackType === "animated-overlay") {
-    return 0;
-  }
-  const mainIdx = tracks.findIndex((t) => t.type === "video");
-  if (mainIdx >= 0) {
-    return mainIdx + 1;
-  }
-  return tracks.length;
+  return getTrackInsertionIndex(tracks, trackType);
 }
 
 /**
  * Find the best insertion index for a new track, grouping effects/filters by their mediaId.
- * For effects and filters, this places new tracks immediately adjacent to existing tracks
- * that use the same effect/filter (same mediaId).
+ * Delegates to trackTypeConfig.getTrackInsertionIndexGrouped — do NOT add logic here.
+ * @deprecated Prefer getTrackInsertionIndexGrouped from trackTypeConfig directly.
  */
 export function getInsertIndexForNewTrackGrouped(tracks: Track[], clips: Clip[], trackType: TrackType, mediaId?: string): number {
-  // Only apply grouping logic for effects and filters
-  if (!mediaId || (trackType !== "filter" && trackType !== "video-effect" && trackType !== "body-effect" && trackType !== "animated-overlay")) {
-    return getInsertIndexForNewTrack(tracks, trackType);
-  }
-
-  // Find all tracks of the same type that have clips with the same mediaId
-  const siblingTrackIndices: number[] = [];
-
-  tracks.forEach((track, index) => {
-    if (track.type === trackType) {
-      const hasMatchingClip = clips.some((clip) => clip.trackId === track.id && clip.mediaId === mediaId);
-      if (hasMatchingClip) {
-        siblingTrackIndices.push(index);
-      }
-    }
-  });
-
-  // If we found sibling tracks with the same effect, insert immediately after the last one
-  if (siblingTrackIndices.length > 0) {
-    const lastSiblingIndex = Math.max(...siblingTrackIndices);
-    return lastSiblingIndex + 1;
-  }
-
-  // No siblings found, use default placement
-  return getInsertIndexForNewTrack(tracks, trackType);
+  return getTrackInsertionIndexGrouped(tracks, clips, trackType, mediaId);
 }
 
 /**
@@ -445,7 +425,53 @@ export const useTimelineStore = create<TimelineStore>(
       });
     },
 
+    ensureTrackForType: (type, mediaId) => {
+      const state = get();
+      const config = TRACK_TYPE_CONFIG[type];
+      if (!config) {
+        throw new Error(`[ensureTrackForType] Unknown track type: "${type}"`);
+      }
+
+      switch (config.reuseStrategy) {
+        case "primary": {
+          // The primary video track must already exist; never create one here.
+          const primary = state.tracks.find((t) => t.type === "video") ?? null;
+          if (!primary) throw new Error("[ensureTrackForType] primary: no video track found");
+          return primary.id;
+        }
+
+        case "shared": {
+          // All clips of this type share one track.
+          const existing = get().tracks.find((t) => t.type === type);
+          if (existing) return existing.id;
+          const idx = getTrackInsertionIndex(get().tracks, type);
+          return get().insertTrackAt(type, idx);
+        }
+
+        case "per-clip": {
+          // Always create a fresh track.
+          const idx = getTrackInsertionIndex(get().tracks, type);
+          return get().insertTrackAt(type, idx);
+        }
+
+        case "per-media-group": {
+          // Reuse a track of this type that already carries a clip with the same mediaId.
+          if (mediaId) {
+            const { tracks, clips } = get();
+            const match = tracks.find(
+              (t) => t.type === type && clips.some((c) => c.trackId === t.id && c.mediaId === mediaId),
+            );
+            if (match) return match.id;
+          }
+          const { tracks, clips } = get();
+          const idx = getTrackInsertionIndexGrouped(tracks, clips, type, mediaId);
+          return get().insertTrackAt(type, idx);
+        }
+      }
+    },
+
     addClip: (clip) => {
+
       set((state) => {
         // Prevent adding duplicate clips with the same ID
         const existingClip = state.clips.find((c) => c.id === clip.id);
@@ -564,19 +590,18 @@ export const useTimelineStore = create<TimelineStore>(
           });
         }
 
-        // Check if the track this clip was on is now empty
+        // Auto-prune: remove the track when its last clip is deleted,
+        // if the track type is configured with autoPrune: true.
         let tracksToKeep = state.tracks;
         let gapsToKeep = state.gaps;
         let mainVideoTrackId = state.mainVideoTrackId;
         let removedTrackIdForCleanup: string | null = null;
         if (clipToRemove) {
           const trackId = clipToRemove.trackId;
+          const track = state.tracks.find((t) => t.id === trackId);
           const hasOtherClips = remainingClips.some((c) => c.trackId === trackId);
-          const primaryVideoTrackId = state.tracks.find((t) => t.type === "video")?.id ?? state.mainVideoTrackId;
-          const isPrimaryVideoTrack = trackId === primaryVideoTrackId;
 
-          // If no other clips on this track, remove secondary track (preserve primary main video track)
-          if (!hasOtherClips && !isPrimaryVideoTrack) {
+          if (track && !hasOtherClips && shouldAutoPruneTrack(track, state.mainVideoTrackId || state.tracks)) {
             tracksToKeep = state.tracks.filter((t) => t.id !== trackId);
             gapsToKeep = state.gaps.filter((g) => g.trackId !== trackId);
             removedTrackIdForCleanup = trackId;
@@ -584,7 +609,6 @@ export const useTimelineStore = create<TimelineStore>(
               mainVideoTrackId = tracksToKeep.find((t) => t.type === "video")?.id ?? null;
             }
           }
-
         }
 
         const next: Partial<TimelineStore> = {


### PR DESCRIPTION
…registry

Add src/lib/timeline/trackTypeConfig.ts:
- TRACK_TYPE_CONFIG defines height, placement, reuseStrategy, autoPrune, and displayName for every TrackType in a single canonical registry
- TrackPlacement: 'top' | 'below-video' | 'bottom'
- TrackReuseStrategy: 'primary' | 'shared' | 'per-clip' | 'per-media-group'
- shouldAutoPruneTrack() unified helper used across all deletion paths

timelineStore.ts:
- Add ensureTrackForType(type, mediaId?) action — dispatches to the correct reuse strategy (primary / shared / per-clip / per-media-group)
- Derive trackHeights, getInsertIndexForNewTrack, and getInsertIndexForNewTrackGrouped from TRACK_TYPE_CONFIG

History commands (DeleteClipCommand, RippleDeleteRangeCommand):
- Replace bespoke auto-prune logic with shouldAutoPruneTrack()

UI tabs (SmartOverlaysTab, CaptionsTab, TextTab):
- Delegate track creation to ensureTrackForType; remove ad-hoc track lookup and insertion logic

tsc: 0 errors  |  store tests: 20 files / 118 tests passed