### PR TITLE
fix(updater): point auto-update endpoint to latest.json

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -65,7 +65,7 @@
   "plugins": {
     "updater": {
       "endpoints": [
-        "https://github.com/AIEraDev/clypra/releases/latest/download/updater.json"
+        "https://github.com/AIEraDev/clypra/releases/latest/download/latest.json"
       ],
       "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDdCOUZCOEM1RDBDN0NBOUIKUldTYnlzZlF4YmlmZXpMSUI4ZGJveW1xVFRIeDMza25NMlg0R2xmdFJNaTVLTHBmdVlYejFFc2oK"
     }


### PR DESCRIPTION
Tauri action generates `latest.json` by default. The old config was pointing at `updater.json` which was 404 on the CDN — silently preventing in-app auto-updates.\n\nThe v1.3.0 release has been patched by manually uploading `updater.json` so existing production users are already receiving the update prompt. This commit ensures all future releases work automatically.