### PR TITLE
fix(build): add resolver-level pixi.js mock alias for legacy studio engine dependencies

### DIFF
--- a/src/lib/mocks/pixiMock.ts
+++ b/src/lib/mocks/pixiMock.ts
@@ -1,0 +1,64 @@
+/**
+ * Lightweight mock for legacy Pixi imports in external engine dependencies.
+ * Pixi is no longer used in Clypra.
+ */
+
+export class Filter {}
+
+export class Container {
+  addChild(): void {}
+  removeChild(): void {}
+  destroy(): void {}
+  position = { set(): void {} };
+  scale = { set(): void {} };
+}
+
+export class Graphics extends Container {
+  clear(): this {
+    return this;
+  }
+  rect(): this {
+    return this;
+  }
+  fill(): this {
+    return this;
+  }
+  stroke(): this {
+    return this;
+  }
+  drawRect(): this {
+    return this;
+  }
+  beginFill(): this {
+    return this;
+  }
+  endFill(): this {
+    return this;
+  }
+  lineStyle(): this {
+    return this;
+  }
+}
+
+export class Sprite extends Container {}
+
+export const Texture = {
+  from(): Record<string, unknown> {
+    return {};
+  },
+};
+
+export class Application {
+  stage = new Container();
+  renderer = { resize(): void {} };
+  destroy(): void {}
+}
+
+export default {
+  Filter,
+  Container,
+  Graphics,
+  Sprite,
+  Texture,
+  Application,
+};

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -44,6 +44,7 @@ export default defineConfig(async () => ({
   resolve: {
     alias: {
       "@": path.resolve(__dirname, "./src"),
+      "pixi.js": path.resolve(__dirname, "./src/lib/mocks/pixiMock.ts"),
       ...workspaceAlias,
     },
   },


### PR DESCRIPTION
### Summary
- Added resolver-level alias in `vite.config.ts` mapping `pixi.js` to a lightweight dummy mock in `src/lib/mocks/pixiMock.ts`.
- Resolves CI import-analysis failure in Vitest/Vite without bundling the unused Pixi package.
- Cleaned up sub-branches.