### PR TITLE
fix(build): add pixi-filters alias and comprehensive mock exports

### DIFF
--- a/src/lib/mocks/pixiMock.ts
+++ b/src/lib/mocks/pixiMock.ts
@@ -4,6 +4,38 @@
  */
 
 export class Filter {}
+export class GodrayFilter extends Filter {}
+export class ColorGradientFilter extends Filter {}
+export class ColorOverlayFilter extends Filter {}
+export class HslAdjustmentFilter extends Filter {}
+export class AlphaFilter extends Filter {}
+export class ColorMatrixFilter extends Filter {}
+export class GlowFilter extends Filter {}
+export class RGBSplitFilter extends Filter {}
+export class GlitchFilter extends Filter {}
+export class CRTFilter extends Filter {}
+export class NoiseFilter extends Filter {}
+export class TiltShiftFilter extends Filter {}
+export class MotionBlurFilter extends Filter {}
+export class BlurFilter extends Filter {}
+export class KawaseBlurFilter extends Filter {}
+export class ZoomBlurFilter extends Filter {}
+export class RadialBlurFilter extends Filter {}
+export class DropShadowFilter extends Filter {}
+export class OldFilmFilter extends Filter {}
+export class ShockwaveFilter extends Filter {}
+export class BulgePinchFilter extends Filter {}
+export class TwistFilter extends Filter {}
+export class ReflectionFilter extends Filter {}
+export class DisplacementFilter extends Filter {}
+export class OutlineFilter extends Filter {}
+export class GrayscaleFilter extends Filter {}
+export class DotFilter extends Filter {}
+export class EmbossFilter extends Filter {}
+export class CrossHatchFilter extends Filter {}
+export class PixelateFilter extends Filter {}
+export class AsciiFilter extends Filter {}
+export class VideoSource {}
 
 export class Container {
   addChild(): void {}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -45,6 +45,7 @@ export default defineConfig(async () => ({
     alias: {
       "@": path.resolve(__dirname, "./src"),
       "pixi.js": path.resolve(__dirname, "./src/lib/mocks/pixiMock.ts"),
+      "pixi-filters": path.resolve(__dirname, "./src/lib/mocks/pixiMock.ts"),
       ...workspaceAlias,
     },
   },


### PR DESCRIPTION
### Summary
- Added `pixi-filters` alias in `vite.config.ts` mapping to `pixiMock.ts`.
- Exported all filter classes in `src/lib/mocks/pixiMock.ts` to satisfy legacy external studio engine imports without Pixi runtime.
- Automatically created PR as instructed.