### PR TITLE
ci(golden): configure Lavapipe Vulkan ICD environment in preview-golden workflow

### DIFF
--- a/.github/workflows/preview-golden.yml
+++ b/.github/workflows/preview-golden.yml
@@ -39,6 +39,8 @@ jobs:
             libclang-dev pkg-config libwebkit2gtk-4.1-dev build-essential \
             libssl-dev libxdo-dev libayatana-appindicator3-dev librsvg2-dev \
             libvulkan1 mesa-vulkan-drivers vulkan-tools libegl1-mesa-dev libgl1-mesa-dri
+          echo "VK_ICD_FILENAMES=/usr/share/vulkan/icd.d/lvp_icd.x86_64.json" >> "$GITHUB_ENV"
+          echo "LIBGL_ALWAYS_SOFTWARE=1" >> "$GITHUB_ENV"
 
       - name: Install macOS dependencies
         if: runner.os == 'macOS'


### PR DESCRIPTION
### Summary
- Configured `VK_ICD_FILENAMES` and `LIBGL_ALWAYS_SOFTWARE` on Linux in `.github/workflows/preview-golden.yml` so wgpu accurately discovers the Mesa Lavapipe software rasterizer in headless Linux runners.
- Automatically created PR as instructed.