### PR TITLE
fix(golden): request adapter.limits() for robust headless GPU initialization

### DIFF
--- a/src-tauri/tests/native_preview_golden_tests.rs
+++ b/src-tauri/tests/native_preview_golden_tests.rs
@@ -75,7 +75,7 @@ impl HeadlessGpuContext {
                 &wgpu::DeviceDescriptor {
                     label: Some("Native Preview Golden Test Device"),
                     required_features: wgpu::Features::empty(),
-                    required_limits: wgpu::Limits::default(),
+                    required_limits: adapter.limits(),
                     memory_hints: wgpu::MemoryHints::Performance,
                 },
                 None,


### PR DESCRIPTION
### Summary
- Passed `adapter.limits()` in `native_preview_golden_tests.rs` so headless runners using software adapters (like Mesa Lavapipe) initialize the device within available capabilities.
- Automatically created PR as instructed.