### PR TITLE
fix(build): add Text, TextStyle, and RenderTexture to mock exports for production build

### DIFF
--- a/src/lib/mocks/pixiMock.ts
+++ b/src/lib/mocks/pixiMock.ts
@@ -35,7 +35,23 @@ export class EmbossFilter extends Filter {}
 export class CrossHatchFilter extends Filter {}
 export class PixelateFilter extends Filter {}
 export class AsciiFilter extends Filter {}
+export class AdjustmentFilter extends Filter {}
 export class VideoSource {}
+
+export class RenderTexture {
+  static create(): RenderTexture {
+    return new RenderTexture();
+  }
+}
+
+export class Text {
+  text = "";
+  style = {};
+  position = { set(): void {} };
+  scale = { set(): void {} };
+}
+
+export class TextStyle {}
 
 export class Container {
   addChild(): void {}


### PR DESCRIPTION
### Summary
- Added `Text`, `TextStyle`, and `RenderTexture` dummy classes to `src/lib/mocks/pixiMock.ts` to satisfy production build tree-shaking analysis in Vite rollup.
- Local `npm run build` passes with 0 errors.
- Automatically created PR as instructed.