### PR TITLE
fix(wgpu): use adapter.limits() in GpuContext and Yuv ring buffer tests for robust headless software rasterization

### DIFF
--- a/src-tauri/src/wgpu_compositor/adapter_selector.rs
+++ b/src-tauri/src/wgpu_compositor/adapter_selector.rs
@@ -127,7 +127,7 @@ impl GpuContext {
                 &wgpu::DeviceDescriptor {
                     label: Some("Native Wgpu Device"),
                     required_features,
-                    required_limits: wgpu::Limits::default(),
+                    required_limits: best_adapter.limits(),
                     memory_hints: wgpu::MemoryHints::Performance,
                 },
                 None,

--- a/src-tauri/src/wgpu_compositor/yuv_ring_buffer.rs
+++ b/src-tauri/src/wgpu_compositor/yuv_ring_buffer.rs
@@ -522,7 +522,7 @@ mod tests {
                     &wgpu::DeviceDescriptor {
                         label: Some("Test YUV HDR Device"),
                         required_features,
-                        required_limits: wgpu::Limits::default(),
+                        required_limits: adapter.limits(),
                         memory_hints: wgpu::MemoryHints::Performance,
                     },
                     None,


### PR DESCRIPTION
### Summary
- Updated `src-tauri/src/wgpu_compositor/adapter_selector.rs` to use `best_adapter.limits()` so software rasterizers (like Lavapipe/WARP) in headless environments initialize the GPU context within valid driver bounds.
- Updated `src-tauri/src/wgpu_compositor/yuv_ring_buffer.rs` unit test device descriptor to use `adapter.limits()`.
- Automatically created PR as instructed.