### PR TITLE
fix(cli): enable InstanceFlags::all(), multi-stage adapter fallback, and VK_DRIVER_FILES for Linux software Vulkan

### DIFF
--- a/.github/workflows/native-golden.yml
+++ b/.github/workflows/native-golden.yml
@@ -104,6 +104,7 @@ jobs:
           sudo apt-get install -y --no-install-recommends \
             libvulkan1 mesa-vulkan-drivers vulkan-tools libasound2-dev
           echo "VK_ICD_FILENAMES=/usr/share/vulkan/icd.d/lvp_icd.x86_64.json" >> "$GITHUB_ENV"
+          echo "VK_DRIVER_FILES=/usr/share/vulkan/icd.d/lvp_icd.x86_64.json" >> "$GITHUB_ENV"
           echo "LIBGL_ALWAYS_SOFTWARE=1" >> "$GITHUB_ENV"
 
       # ── WASM platform setup ───────────────────────────────────────────────
@@ -113,8 +114,9 @@ jobs:
           # Lavapipe for the native-CLI reference render on this runner
           sudo apt-get update -qq
           sudo apt-get install -y --no-install-recommends \
-            libvulkan1 mesa-vulkan-drivers vulkan-tools
+            libvulkan1 mesa-vulkan-drivers vulkan-tools libasound2-dev
           echo "VK_ICD_FILENAMES=/usr/share/vulkan/icd.d/lvp_icd.x86_64.json" >> "$GITHUB_ENV"
+          echo "VK_DRIVER_FILES=/usr/share/vulkan/icd.d/lvp_icd.x86_64.json" >> "$GITHUB_ENV"
           echo "LIBGL_ALWAYS_SOFTWARE=1" >> "$GITHUB_ENV"
           # wasm-pack
           curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh

--- a/crates/clypra-native-cli/src/main.rs
+++ b/crates/clypra-native-cli/src/main.rs
@@ -387,6 +387,7 @@ fn run_render(args: &[String]) -> Result<(), String> {
     let gpu = runtime.block_on(async {
         let instance = wgpu::Instance::new(&wgpu::InstanceDescriptor {
             backends: wgpu::Backends::all(),
+            flags: wgpu::InstanceFlags::all(),
             ..Default::default()
         });
         GpuContext::select_best_gpu(&instance, None).await

--- a/src-tauri/src/wgpu_compositor/adapter_selector.rs
+++ b/src-tauri/src/wgpu_compositor/adapter_selector.rs
@@ -127,7 +127,7 @@ impl GpuContext {
                 &wgpu::DeviceDescriptor {
                     label: Some("Native Wgpu Device"),
                     required_features,
-                    required_limits: wgpu::Limits::default(),
+                    required_limits: best_adapter.limits(),
                     memory_hints: wgpu::MemoryHints::Performance,
                 },
                 None,

--- a/src-tauri/src/wgpu_compositor/adapter_selector.rs
+++ b/src-tauri/src/wgpu_compositor/adapter_selector.rs
@@ -68,15 +68,29 @@ impl GpuContext {
                     .await
                 {
                     adapter
+                } else if let Some(adapter) = instance
+                    .request_adapter(&wgpu::RequestAdapterOptions {
+                        power_preference:       wgpu::PowerPreference::LowPower,
+                        compatible_surface,
+                        force_fallback_adapter: false,
+                    })
+                    .await
+                {
+                    adapter
+                } else if let Some(adapter) = instance
+                    .request_adapter(&wgpu::RequestAdapterOptions {
+                        power_preference:       wgpu::PowerPreference::None,
+                        compatible_surface,
+                        force_fallback_adapter: true,
+                    })
+                    .await
+                {
+                    adapter
                 } else {
-                    // Graceful degradation: Fallback to software rasterizer (WARP / Lavapipe / SwiftShader)
                     instance
-                        .request_adapter(&wgpu::RequestAdapterOptions {
-                            power_preference:       wgpu::PowerPreference::None,
-                            compatible_surface,
-                            force_fallback_adapter: true,
-                        })
-                        .await
+                        .enumerate_adapters(wgpu::Backends::all())
+                        .into_iter()
+                        .next()
                         .ok_or_else(|| {
                             "No compatible graphics adapters or software rasterizers found.".to_string()
                         })?

--- a/src-tauri/src/wgpu_compositor/yuv_ring_buffer.rs
+++ b/src-tauri/src/wgpu_compositor/yuv_ring_buffer.rs
@@ -522,7 +522,7 @@ mod tests {
                     &wgpu::DeviceDescriptor {
                         label: Some("Test YUV HDR Device"),
                         required_features,
-                        required_limits: wgpu::Limits::default(),
+                        required_limits: adapter.limits(),
                         memory_hints: wgpu::MemoryHints::Performance,
                     },
                     None,


### PR DESCRIPTION
### Summary
- Enabled `wgpu::InstanceFlags::all()` in `clypra-native-cli/src/main.rs` to allow software Vulkan rasterizers (Mesa Lavapipe) to be discovered and accepted on Linux headless CI.
- Expanded adapter selection fallback chain in `adapter_selector.rs`.
- Exported `VK_DRIVER_FILES` in `native-golden.yml`.
- Automatically created PR as instructed.