### PR TITLE
fix(wasm): use adapter.limits() in wasm-renderer and capture browser console in headless Chrome

### DIFF
--- a/.github/workflows/native-golden.yml
+++ b/.github/workflows/native-golden.yml
@@ -224,11 +224,12 @@ jobs:
           }).listen(PORT);
           const browser = await puppeteer.launch({
             args: ["--no-sandbox","--disable-setuid-sandbox","--enable-unsafe-webgpu",
-                   "--enable-features=Vulkan,UseSkiaRenderer","--use-angle=vulkan"],
+                   "--use-gl=angle","--use-angle=swiftshader","--enable-features=Vulkan,UseSkiaRenderer"],
             headless: true,
           });
           const page = await browser.newPage();
-          page.on("pageerror", e => process.stderr.write(`[error] ${e}\n`));
+          page.on("console", msg => console.log(`[browser-console] ${msg.type()}: ${msg.text()}`));
+          page.on("pageerror", e => console.error(`[browser-pageerror] ${e}`));
           await page.setContent(`<!DOCTYPE html><html><body><script type="module">
             import init, { create_renderer } from "http://localhost:${PORT}/pkg/clypra_render_wasm.js";
             async function run() {

--- a/crates/clypra-render-wasm/src/lib.rs
+++ b/crates/clypra-render-wasm/src/lib.rs
@@ -366,7 +366,7 @@ async fn init_gpu() -> Result<GpuContext, String> {
             &wgpu::DeviceDescriptor {
                 label:              Some("clypra-render-wasm device"),
                 required_features:  wgpu::Features::empty(),
-                required_limits:    wgpu::Limits::downlevel_webgl2_defaults(),
+                required_limits:    adapter.limits(),
                 memory_hints:       wgpu::MemoryHints::Performance,
             },
             None,


### PR DESCRIPTION
### Summary
- Configured `adapter.limits()` in `crates/clypra-render-wasm/src/lib.rs` for device creation.
- Updated `wasm-render.mjs` flags in `.github/workflows/native-golden.yml` and attached page console listeners.
- Automatically created PR as instructed.