### PR TITLE
Fix release workflow for Node 24

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -124,7 +124,7 @@ jobs:
 
       # ── Release ────────────────────────────────────────────────────────────
       - name: Build & Publish Release
-        uses: tauri-apps/tauri-action@v0.5
+        uses: tauri-apps/tauri-action@action-v1.0.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}


### PR DESCRIPTION
## Summary
- update tauri-apps/tauri-action from v0.5 to action-v1.0.0
- restore the tagged release workflow on current GitHub-hosted Node 24 runners

## Context
The v1.4.0 tag workflow passed frontend and Rust tests but the old action exited immediately during the publish step with an unsettled top-level-await warning. The current action declares Node 24 support.