### PR TITLE
fix(ci): fix Rust Clippy warnings breaking CI

### DIFF
--- a/src-tauri/src/audio/decoder.rs
+++ b/src-tauri/src/audio/decoder.rs
@@ -15,8 +15,7 @@ static AUDIO_DECODE_SEMAPHORE: Lazy<Arc<Semaphore>> = Lazy::new(|| {
     let permits = std::thread::available_parallelism()
         .map(|p| p.get())
         .unwrap_or(4)
-        .min(8)
-        .max(2);
+        .clamp(2, 8);
     Arc::new(Semaphore::new(permits))
 });
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -281,11 +281,11 @@ pub fn run() {
             run_wgpu_smoke_test,
             run_native_document_wgpu_export,
         ])
-        .on_window_event(|window, event| {
+        .on_window_event(|_window, event| {
             if let tauri::WindowEvent::CloseRequested { .. } = event {
                 #[cfg(target_os = "macos")]
                 {
-                    window.app_handle().exit(0);
+                    _window.app_handle().exit(0);
                 }
             }
         })


### PR DESCRIPTION
## Summary

Two Clippy errors were failing the **CI / Test Rust Backend** job under `-D warnings`:

### 1. `unused-variables` — `src/lib.rs:284`
The `window` parameter in the `on_window_event` closure was unused on non-macOS targets.

**Fix:** renamed to `_window` to signal intentional non-use.

### 2. `clippy::manual_clamp` — `src/audio/decoder.rs:15`
The semaphore permit count used `.min(8).max(2)` which Clippy flags as a manual clamp pattern.

**Fix:** replaced with `.clamp(2, 8)`.

## Testing
- `cargo check` passes cleanly with no errors or warnings.