### PR TITLE
release: v1.4.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [1.4.4] - 2026-08-25
+
+### ⚡ Program Preview Performance
+
+- **Smoother native Program Preview playback and scrubbing** — removed high-frequency decoder console I/O from the frame path and kept native-surface diagnostics from blocking presentation.
+- **Native-surface playback telemetry** — added optional timings for decoder wait/decode, YUV conversion/upload, composition, surface acquisition, and present submission.
+- **RGBA readback telemetry** — separated compositor time from GPU readback/map time for paused seeking and scrubbing.
+- **Mode-aware preview statistics** — performance data is partitioned across playback, lookahead, seek, scrub, frame-step, and prefetch with P50/P95/P99 stage percentiles.
+- **Frontend preview tracing** — added bounded dispatch, IPC, and canvas-paint measurements keyed by request ID, generation, and frame index.
+- **Accurate cache metrics** — native-surface staging frames are no longer counted as RGBA frame-cache hits.
+
 ## [1.4.3] - 2026-08-25
 
 ### ✂️ Timeline Editing

--- a/crates/clypra-native-core/src/lib.rs
+++ b/crates/clypra-native-core/src/lib.rs
@@ -43,7 +43,10 @@ pub mod native_core {
         ProjectSnapshot, QualityTier, RasterLayerSnapshot, TransitionSnapshot, VideoLayerSnapshot,
         DEFAULT_TIME_SCALE, NATIVE_CORE_CONTRACT_VERSION,
     };
-    pub use crate::performance::{NativeFrameServiceStats, PerformanceBudget, PerformanceSample};
+    pub use crate::performance::{
+        ModeStats, NativeFrameServiceStats, PerformanceBudget, PerformanceSample, PreviewMode,
+        StagePercentiles,
+    };
     pub use crate::service::NativeFrameService;
     pub use crate::session::PlaybackSession;
     pub use crate::surface::{
@@ -60,7 +63,10 @@ pub use contracts::{
     NATIVE_CORE_CONTRACT_VERSION,
 };
 pub use golden::{compare_rgba8, GoldenDiff};
-pub use performance::{NativeFrameServiceStats, PerformanceBudget, PerformanceSample};
+pub use performance::{
+    ModeStats, NativeFrameServiceStats, PerformanceBudget, PerformanceSample, PreviewMode,
+    StagePercentiles,
+};
 pub use service::NativeFrameService;
 pub use session::PlaybackSession;
 pub use surface::{

--- a/docs/native-architecture.md
+++ b/docs/native-architecture.md
@@ -1,5 +1,11 @@
 # Native Media Architecture
 
+Program Preview performance changes must follow the
+[Program Preview Performance Runbook](program-preview-performance-runbook.md)
+and the [Native Performance Contract](performance-contract.md). These documents
+are the durable guardrails for path separation, stale-frame handling, telemetry,
+and release validation.
+
 Status: migration branch `codex/native-architecture-migration`.
 
 ## Authority

--- a/docs/performance-contract.md
+++ b/docs/performance-contract.md
@@ -1,5 +1,8 @@
 # Native Performance Contract
 
+For the investigation history, path-specific failure modes, and safe-change
+checklist, read [Program Preview Performance Runbook](program-preview-performance-runbook.md).
+
 ## Baseline
 
 The current smooth editing path is the performance baseline. A native change
@@ -53,9 +56,28 @@ never replace the visible target.
 ## Measurement
 
 The native frame service records request count, cache hit/miss count, cache
-bytes, transferred bytes, and the latest end-to-end sample. Phase-specific
-decode, compose, and readback timers must be added before native playback is
-enabled. The diagnostics command is `get_native_frame_service_stats`.
+bytes, transferred bytes, and the latest end-to-end sample. It also keeps a
+five-second, mode-partitioned window for `playback`, `playback-lookahead`,
+`seek`, `scrub`, `frame-step`, and `prefetch`.
+
+Native samples expose optional stage timings. The readback path records decode,
+decoder-mutex wait, conversion/upload, composition, and RGBA readback. The
+retained native-surface path records decode, decoder-mutex wait, conversion /
+upload, composition, surface acquisition, and CPU submit/present. A stage that
+does not exist on a path is `null`, not zero. Percentiles filter out nulls and
+report the number of samples that actually contained that stage.
+
+The diagnostics command is `get_native_frame_service_stats`. Frontend-only
+dispatch, IPC, and canvas-paint spans are kept in a bounded in-memory ring
+buffer by `nativePerfCollector`; they use the same request ID, generation, and
+frame index for offline joining. Rust `Instant` values and browser
+`performance.now()` values must never be aligned as shared timestamps.
+
+Native-surface telemetry records with a non-blocking service-mutex attempt so
+diagnostics cannot add a presentation wait. A sample can therefore be omitted
+if a stats read is holding the service mutex. Per-frame decode logging is gated
+through the existing trace event path; the default path does not print a
+decoder line for every frame.
 
 Every benchmark report must include:
 

--- a/docs/program-preview-performance-runbook.md
+++ b/docs/program-preview-performance-runbook.md
@@ -1,0 +1,269 @@
+# Program Preview Performance Runbook
+
+Status: required guidance for every native Program Preview performance change.
+
+This document records the failures found during the Program Preview investigation
+and the rules that prevent repeating them. It applies only to the Program Preview
+pipeline: timeline input, transport, native decode, YUV conversion, composition,
+surface/readback, and final presentation.
+
+## Scope and source of truth
+
+The canonical implementation is split across these files:
+
+- React request and presentation paths:
+  `src/components/editor/preview/NativeProgramPreview.tsx`
+- Request scheduling and obsolete-request handling:
+  `src/components/editor/preview/nativePreviewScheduler.ts`
+- Timeline transport and seek identity:
+  `src/core/playback/TransportAuthority.ts`,
+  `src/core/playback/seekController.ts`, and
+  `src/core/playback/PlaybackClock.ts`
+- Native commands and queue:
+  `src-tauri/src/commands/native_preview.rs`
+- Native performance contract and aggregation:
+  `src-tauri/src/native_core/performance.rs` and
+  `src-tauri/src/native_core/service.rs`
+- Native compositor and RGBA readback:
+  `src-tauri/src/wgpu_compositor/multi_track_composer.rs`
+- Contract documentation:
+  `docs/performance-contract.md`
+
+Extend these existing contracts. Do not create a second `PerformanceSample`,
+stats command, request-ID type, mode parser, or telemetry ring buffer without an
+architecture decision and a migration plan.
+
+## The two real preview paths
+
+Playback and paused interaction are not one performance path:
+
+```text
+Timeline input
+  -> TransportAuthority
+  -> SeekController (requestId + generation + mode)
+  -> PlaybackClock / NativeProgramPreview render loop
+       |
+       | playback / lookahead
+       v
+  queue_native_frame
+    -> decoder + decoder mutex
+    -> bounded decoded-frame queue
+  present_native_frame
+    -> NV12/YUV conversion and upload
+    -> native compositor
+    -> native surface acquire
+    -> queue submit / surface present
+    -> retained native surface
+
+       |
+       | paused seek / scrub / frame step
+       v
+  render_native_frame
+    -> RGBA frame cache
+    -> decoder + decoder mutex
+    -> NV12/YUV conversion and upload
+    -> compositor
+    -> GPU copy and RGBA readback/map
+    -> IPC response
+    -> canvas ImageData / putImageData
+```
+
+The direct native-surface path must remain the continuous playback path. The
+RGBA bridge is a paused-frame fallback and diagnostic path, not a playback
+target.
+
+## Failure modes and permanent fixes
+
+### 1. High-frequency logging was inside the frame path
+
+The decoder printed one `eprintln!` for every preview frame. Console I/O is not
+free and can contend with decode, async scheduling, and the desktop runtime.
+That made the observed preview less smooth and polluted any timing collected
+around the path.
+
+Permanent rule:
+
+- No `println!`, `eprintln!`, or `console.log` per preview frame in normal mode.
+- High-volume events must go through the existing gated trace mechanism.
+- Diagnostic logging must be disabled for benchmark runs unless the benchmark
+  explicitly measures logging overhead.
+
+### 2. Playback, seeking, and scrubbing were easy to conflate
+
+Playback can use a retained native surface and a decoded lookahead queue.
+Paused seeking and scrubbing can require decode, composition, GPU readback, IPC,
+and canvas paint. A single average across those paths hides the actual cost.
+
+Permanent rule:
+
+- Every sample has an explicit mode: `Playback`, `PlaybackLookahead`, `Seek`,
+  `Scrub`, `FrameStep`, or `Prefetch`.
+- Do not infer mode by parsing a request ID.
+- Do not compare playback surface timings with paused readback timings as one
+  population.
+
+### 3. Obsolete work was not the same as cancelled work
+
+A newer seek can make an older request obsolete even when FFmpeg or GPU work
+cannot stop immediately. Ignoring a result after it finishes is not equivalent
+to cancelling the work, and both facts must be visible in diagnostics.
+
+Permanent rule:
+
+- `SeekController` generations identify the current intent.
+- Scheduler abort signals cancel work where the underlying operation supports it.
+- Native generation checks prevent old decoded frames entering the queue or
+  surface presentation path.
+- Record `stale`, `cancelled`, and `dropped` separately.
+
+### 4. A stale frame must never become the visible target
+
+Keeping the last valid frame visible during a seek is valid visual continuity.
+Treating that frame as the newly requested frame is not. The exact request key,
+project revision, frame index, and generation must still match after every
+`await` before committing a paused frame.
+
+Permanent rule:
+
+- Stale responses may be discarded or retained only as non-visible cache data.
+- Seek completion requires the exact current target.
+- A failed request preserves the last valid frame and records the failure.
+
+### 5. `lastSample` was mistaken for an average
+
+`lastSample` is one sample. It is not a mean, median, or percentile. A latest
+sample overlay can look healthy while the preceding requests were slow.
+
+Permanent rule:
+
+- Label latest values as latest.
+- Use the existing five-second window and P50/P95/P99 values for claims about
+  performance.
+- Percentile `sampleCount` counts only samples that contain that optional stage.
+
+### 6. Seek telemetry mixed unrelated requests
+
+Pooling all samples into a seek statistic lets playback, lookahead, cache hits,
+and prefetch change the reported seek latency.
+
+Permanent rule:
+
+- Seek summaries include only `Seek`, `Scrub`, and `FrameStep` samples.
+- Playback and lookahead have separate mode buckets.
+- Cold/warm cache state, quality, output size, and media characteristics are
+  included in every benchmark report.
+
+### 7. Direct native-surface playback was missing from detailed statistics
+
+The retained surface path can be the visible playback path while the detailed
+RGBA frame-service stats describe only readback frames. That makes the overlay
+look incomplete exactly when the important path is active.
+
+Permanent rule:
+
+- Surface playback records decode, conversion/upload, composition, surface
+  acquisition, submit/present, total time, and queue staging wait.
+- Surface staging is not an RGBA frame-cache hit.
+- `window_cache_hit_rate` remains scoped to the RGBA cache population.
+
+### 8. Missing stages were represented as zero
+
+A native-surface frame has no canvas paint or RGBA readback. A readback frame has
+no surface acquisition or native submit. Recording zero makes an absent stage
+look like a measured zero and corrupts percentiles.
+
+Permanent rule:
+
+- Path-specific stage fields are `Option`/nullable.
+- `None` means the stage did not exist or was not measured.
+- Zero is used only when zero work was actually measured.
+
+### 9. Rust and browser clocks cannot be aligned directly
+
+Rust `Instant` and browser `performance.now()` have no defined shared epoch.
+Joining them as one timestamp stream creates false queue and presentation
+latencies.
+
+Permanent rule:
+
+- Record durations locally in each process.
+- Correlate reports by string `requestId`, generation, and frame index.
+- Never subtract a Rust timestamp from a browser timestamp.
+
+### 10. Instrumentation must not become the bottleneck
+
+Telemetry that waits on the frame-service mutex or logs synchronously can change
+the behavior it is intended to measure.
+
+Permanent rule:
+
+- Frontend telemetry is disabled by default and stored in a bounded ring buffer.
+- Native-surface sample recording uses a non-blocking service-mutex attempt.
+- A missed diagnostic sample is preferable to delaying frame presentation.
+- Never stream one JSON log line per frame during a benchmark.
+
+## Required investigation procedure
+
+Before changing React scheduling, UI rendering, or native policy:
+
+1. Confirm the actual repository types and call sites. Read the canonical files
+   above; do not write speculative standalone modules against guessed fields.
+2. Trace one frozen playback, seek, and scrub scenario end to end.
+3. Capture the mode, request ID, generation, frame index, queue state, stale/
+   cancelled/dropped outcome, and each applicable native/frontend duration.
+4. Compare P50/P95/P99 by mode and path. Do not rank a bottleneck from symptoms
+   or from code structure alone.
+5. Change the smallest diagnostic surface that distinguishes the leading
+   candidates.
+6. Re-run the same scenario with logging disabled and enabled separately if
+   logging is suspected.
+7. Only after native timings identify the cost should UI or React work be
+   considered.
+
+## Benchmark record
+
+Every meaningful preview performance change must attach a table like this to the
+investigation or release notes:
+
+| Scenario | Path | Mode | Warm/cold | P50 total | P95 total | P95 decode | P95 compose | P95 readback | P95 surface acquire | Drops/stale |
+| --- | --- | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | --- |
+| Playback | Native surface | Playback |  |  |  |  |  | N/A |  |  |
+| Seek | RGBA readback | Seek |  |  |  |  |  |  | N/A |  |
+| Scrub | RGBA readback | Scrub |  |  |  |  |  |  | N/A |  |
+
+Record OS, GPU adapter, backend, driver, DPR, source codec/dimensions, CFR/VFR
+status, color metadata, project dimensions, quality, and whether the native
+surface was ready. A benchmark without those details is not a regression
+baseline.
+
+## Safe change and release checklist
+
+- [ ] `git status` and the existing diff were inspected before editing.
+- [ ] Only files in the traced preview path were changed.
+- [ ] Existing request IDs remain strings and existing wire spellings remain
+      compatible (`frameStep` is normalized at the boundary).
+- [ ] No duplicate performance type or diagnostics command was added.
+- [ ] Playback, seek, scrub, frame-step, and prefetch remain separate modes.
+- [ ] Optional stages remain nullable and are excluded from unrelated
+      percentiles.
+- [ ] Direct native-surface frames are represented in performance statistics.
+- [ ] Cache-hit statistics exclude surface staging frames.
+- [ ] High-volume logging is gated or disabled for benchmarks.
+- [ ] Stale results cannot present or complete a newer seek.
+- [ ] `cargo check --lib`, Rust tests, and `npm run typecheck` pass.
+- [ ] The same fixed benchmark scenarios were repeated after the change.
+- [ ] No optimization is claimed until the native timings identify the cost.
+
+## Current implementation references
+
+The current instrumentation is implemented in:
+
+- `src-tauri/src/native_core/performance.rs`
+- `src-tauri/src/native_core/service.rs`
+- `src-tauri/src/commands/native_preview.rs`
+- `src-tauri/src/wgpu_compositor/multi_track_composer.rs`
+- `src/core/playback/nativePerfTelemetry.ts`
+- `src/components/editor/preview/NativeProgramPreview.tsx`
+
+The contract and budgets remain in
+[`docs/performance-contract.md`](performance-contract.md).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clypra",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "description": "A modern, open-source video editor built with Tauri, React, and TypeScript",
   "author": "Clypra Contributors",
   "license": "MIT",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -606,7 +606,7 @@ dependencies = [
 
 [[package]]
 name = "clypra"
-version = "1.4.2"
+version = "1.4.3"
 dependencies = [
  "base64 0.22.1",
  "bytemuck",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clypra"
-version = "1.4.3"
+version = "1.4.4"
 description = "A modern, open-source video editor with native performance and GPU-accelerated preview"
 authors = ["Clypra Contributors"]
 edition = "2021"

--- a/src-tauri/src/commands/native_preview.rs
+++ b/src-tauri/src/commands/native_preview.rs
@@ -1,6 +1,7 @@
 use crate::native_core::{
     BodyEffectSnapshot, ColorGradeSnapshot, FramePacket, FrameRequest, FrameTime, NativeFrameService, NativeFrameServiceStats,
-    NativeSurfacePresentation, PerformanceSample, PixelFormat, NATIVE_CORE_CONTRACT_VERSION,
+    NativeSurfacePresentation, PerformanceSample, PixelFormat, PreviewMode,
+    NATIVE_CORE_CONTRACT_VERSION,
     TransitionSnapshot,
 };
 use crate::native_audio::NativeAudioClock;
@@ -23,6 +24,19 @@ use tauri::Manager;
 
 type DecodedNativeVideoFrame = (Vec<u8>, Vec<u8>, u32, u32, VideoColorMetadata);
 static NATIVE_SURFACE_PRESENTATION_SEQUENCE: AtomicU64 = AtomicU64::new(1);
+
+#[derive(Debug, Default, Clone, Copy)]
+struct NativeDecodeTimings {
+    decode_time_us: u32,
+    decoder_mutex_wait_us: u64,
+}
+
+struct QueuedNativeFrame {
+    decoded_frames: Vec<DecodedNativeVideoFrame>,
+    decode_timings: NativeDecodeTimings,
+    queued_at: Instant,
+    scheduler_wait_us: u64,
+}
 
 fn native_presentation_timing(
     app: &tauri::AppHandle,
@@ -87,6 +101,64 @@ fn record_successful_readback_metrics(app: &tauri::AppHandle, request: &FrameReq
     );
 }
 
+fn record_native_surface_sample(
+    app: &tauri::AppHandle,
+    request: &FrameRequest,
+    started_at: Instant,
+    decode_timings: NativeDecodeTimings,
+    queue_hit: bool,
+    scheduler_wait_us: u64,
+    conversion_upload_us: Option<u64>,
+    compose_us: Option<u64>,
+    surface_acquire_us: Option<u64>,
+    submit_present_us: Option<u64>,
+    dropped: bool,
+    stale: bool,
+) {
+    let Some(service) = app.try_state::<tokio::sync::Mutex<NativeFrameService>>() else {
+        return;
+    };
+    // Diagnostics must never make the presentation future wait on the frame
+    // service mutex. A busy stats reader may therefore miss a sample.
+    let Ok(mut service) = service.try_lock() else {
+        return;
+    };
+    service.record_sample(PerformanceSample {
+        request_id: request.request_id.clone(),
+        frame_index: request.frame_time.frame_index,
+        decode_time_us: decode_timings.decode_time_us,
+        compose_time_us: compose_us.unwrap_or(0).min(u32::MAX as u64) as u32,
+        readback_time_us: 0,
+        total_time_us: started_at.elapsed().as_micros().min(u32::MAX as u128) as u32,
+        bytes_transferred: 0,
+        // A queued decode is a playback staging hit, not a NativeFrameService
+        // cache hit. Keep cache-rate telemetry scoped to the RGBA cache.
+        cache_hit: false,
+        generation: request.generation,
+        mode: PreviewMode::from_request_mode(request.mode.as_deref()),
+        quality: Some(format!("{:?}", request.quality)),
+        strategy: Some(if queue_hit { "SURFACE_WARM" } else { "SURFACE_COLD" }.to_string()),
+        cancelled: false,
+        stale,
+        dropped,
+        seek_time_us: decode_timings.decode_time_us,
+        conversion_time_us: conversion_upload_us.unwrap_or(0).min(u32::MAX as u64) as u32,
+        upload_time_us: conversion_upload_us.unwrap_or(0).min(u32::MAX as u64) as u32,
+        present_time_us: submit_present_us.unwrap_or(0).min(u32::MAX as u64) as u32,
+        decode_us: Some(u64::from(decode_timings.decode_time_us)),
+        conversion_upload_us,
+        compose_us,
+        readback_us: None,
+        present_us: submit_present_us,
+        scheduler_wait_us: Some(scheduler_wait_us),
+        ipc_wait_us: None,
+        decoder_mutex_wait_us: Some(decode_timings.decoder_mutex_wait_us),
+        gpu_queue_wait_us: None,
+        surface_acquire_us,
+        submit_present_us,
+    });
+}
+
 /// Bounded native decode-ahead storage for continuous preview playback.
 ///
 /// The queue owns decoded NV12 planes, not GPU textures. Decoding can happen
@@ -94,7 +166,7 @@ fn record_successful_readback_metrics(app: &tauri::AppHandle, request: &FrameReq
 /// consumes the entry and performs only color conversion/compositing/surface
 /// submission.
 pub struct NativePreviewFrameQueue {
-    entries: HashMap<String, Vec<DecodedNativeVideoFrame>>,
+    entries: HashMap<String, QueuedNativeFrame>,
     order: VecDeque<String>,
     pending: std::collections::HashSet<String>,
     max_entries: usize,
@@ -132,10 +204,10 @@ impl NativePreviewFrameQueue {
         true
     }
 
-    fn complete(&mut self, key: String, decoded: Vec<DecodedNativeVideoFrame>) {
+    fn complete(&mut self, key: String, frame: QueuedNativeFrame) {
         self.pending.remove(&key);
         self.order.retain(|entry| entry != &key);
-        self.entries.insert(key.clone(), decoded);
+        self.entries.insert(key.clone(), frame);
         self.order.push_back(key);
         while self.entries.len() > self.max_entries {
             let Some(oldest) = self.order.pop_front() else {
@@ -149,7 +221,7 @@ impl NativePreviewFrameQueue {
         self.pending.remove(key);
     }
 
-    fn take(&mut self, key: &str) -> Option<Vec<DecodedNativeVideoFrame>> {
+    fn take(&mut self, key: &str) -> Option<QueuedNativeFrame> {
         let decoded = self.entries.remove(key)?;
         self.order.retain(|entry| entry != key);
         Some(decoded)
@@ -1101,6 +1173,8 @@ struct NativeRenderStageTimings {
     decode_time_us: u32,
     conversion_time_us: u32,
     compose_time_us: u32,
+    readback_time_us: u32,
+    decoder_mutex_wait_us: u64,
 }
 
 async fn render_native_video_project_frame_bytes(
@@ -1129,9 +1203,8 @@ async fn render_native_video_project_frame_bytes_timed(
 
     // Decode before taking the GPU session lock so a slow seek cannot block
     // another already-decoded preview frame from submitting work.
-    let decode_started = Instant::now();
-    let decoded_frames = decode_native_video_layers(&request, None).await?;
-    let decode_time_us = decode_started.elapsed().as_micros().min(u32::MAX as u128) as u32;
+    let (decoded_frames, decode_timings) = decode_native_video_layers(&request, None).await?;
+    let decode_time_us = decode_timings.decode_time_us;
 
     let mut session = state.lock().await;
     let conversion_started = Instant::now();
@@ -1226,8 +1299,7 @@ async fn render_native_video_project_frame_bytes_timed(
         b: request.clear_color[2].clamp(0.0, 1.0) as f64,
         a: request.clear_color[3].clamp(0.0, 1.0) as f64,
     };
-    let compose_started = Instant::now();
-    let rgba = if let Some(transition) = request.transition.as_ref() {
+    let (rgba, compose_time_us, readback_time_us) = if let Some(transition) = request.transition.as_ref() {
         let (from_layer, to_layer) = build_transition_sources(&request, &layers)?;
         let from_texture = create_transition_source_texture(
             &session.gpu.device,
@@ -1259,8 +1331,8 @@ async fn render_native_video_project_frame_bytes_timed(
             std::slice::from_ref(&to_layer),
             Some(clear_color),
         )?;
-        compositor
-            .render_transition_to_rgba_bytes(
+        let (rgba, compositor_compose_us, readback_us) = compositor
+            .render_transition_to_rgba_bytes_timed(
                 &session.gpu.device,
                 &session.gpu.queue,
                 request.canvas_width,
@@ -1269,10 +1341,11 @@ async fn render_native_video_project_frame_bytes_timed(
                 &to_view,
                 &transition_uniforms(transition),
             )
-            .await?
+            .await?;
+        (rgba, compositor_compose_us, readback_us)
     } else {
         compositor
-            .render_to_rgba_bytes_with_size(
+            .render_to_rgba_bytes_with_size_timed(
                 &session.gpu.device,
                 &session.gpu.queue,
                 request.canvas_width,
@@ -1282,21 +1355,30 @@ async fn render_native_video_project_frame_bytes_timed(
             )
             .await?
     };
-
-    let compose_time_us = compose_started.elapsed().as_micros().min(u32::MAX as u128) as u32;
-    Ok((rgba, NativeRenderStageTimings { decode_time_us, conversion_time_us, compose_time_us }))
+    Ok((rgba, NativeRenderStageTimings {
+        decode_time_us,
+        conversion_time_us,
+        compose_time_us: compose_time_us.min(u32::MAX as u64) as u32,
+        readback_time_us: readback_time_us.min(u32::MAX as u64) as u32,
+        decoder_mutex_wait_us: decode_timings.decoder_mutex_wait_us,
+    }))
 }
 
 async fn decode_native_video_layers(
     request: &NativeVideoProjectFrameRequest,
     cancellation: Option<(Arc<AtomicU64>, u64)>,
-) -> Result<Vec<DecodedNativeVideoFrame>, String> {
+) -> Result<(Vec<DecodedNativeVideoFrame>, NativeDecodeTimings), String> {
     let mut decoded_frames = Vec::with_capacity(request.layers.len());
+    let mut timings = NativeDecodeTimings::default();
     for layer in &request.layers {
-        let t0 = std::time::Instant::now();
         let decoder = get_preview_decoder(&layer.video_path).await?;
+        let mutex_started = Instant::now();
         let (y_plane, uv_plane, width, height, color) = {
             let mut guard = decoder.lock().await;
+            timings.decoder_mutex_wait_us = timings
+                .decoder_mutex_wait_us
+                .saturating_add(mutex_started.elapsed().as_micros() as u64);
+            let decode_started = Instant::now();
             let stream_color = guard.metadata().color;
             let cancel = cancellation.clone();
             let (y_plane, uv_plane, width, height, frame_color) = guard
@@ -1308,30 +1390,28 @@ async fn decode_native_video_layers(
                         })
                         .unwrap_or(false)
                 })?;
-            (
+            let decoded = (
                 y_plane,
                 uv_plane,
                 width,
                 height,
                 merge_color_metadata(frame_color, &stream_color),
-            )
+            );
+            timings.decode_time_us = timings.decode_time_us.saturating_add(
+                decode_started.elapsed().as_micros().min(u32::MAX as u128) as u32,
+            );
+            decoded
         };
-        let elapsed = t0.elapsed();
-        let file_name = std::path::Path::new(&layer.video_path)
-            .file_name()
-            .and_then(|n| n.to_str())
-            .unwrap_or(&layer.video_path);
-        eprintln!(
-            "🎬 [preview_decode] Decoded frame @ {:.3}s for {} in {:.2}ms ({}x{})",
-            layer.time_secs,
-            file_name,
-            elapsed.as_secs_f64() * 1000.0,
-            width,
-            height
+        crate::sync_metrics::trace_event(
+            "preview_decode",
+            format_args!(
+                "time_secs={:.3} width={} height={}",
+                layer.time_secs, width, height
+            ),
         );
         decoded_frames.push((y_plane, uv_plane, width, height, color));
     }
-    Ok(decoded_frames)
+    Ok((decoded_frames, timings))
 }
 
 /// Decode a frame into the bounded native playback queue without presenting
@@ -1343,6 +1423,7 @@ pub async fn queue_native_frame(
     app: tauri::AppHandle,
     request: FrameRequest,
 ) -> Result<(), String> {
+    let command_started = Instant::now();
     request.validate().map_err(|error| error.to_string())?;
     let key = request.cache_key().map_err(|error| error.to_string())?;
     let legacy_request = to_video_project_request(&request)?;
@@ -1355,8 +1436,11 @@ pub async fn queue_native_frame(
         .clone();
     let generation = request.generation.unwrap_or(0);
     let cancellation_generation;
+    let scheduler_wait_started = Instant::now();
+    let scheduler_wait_us;
     {
         let mut queue_state = queue.lock().await;
+        scheduler_wait_us = scheduler_wait_started.elapsed().as_micros() as u64;
         queue_state.observe_generation(generation);
         if !queue_state.is_generation_current(generation) {
             return Ok(());
@@ -1369,10 +1453,18 @@ pub async fn queue_native_frame(
 
     let cancellation = Some((cancellation_generation, generation));
     match decode_native_video_layers(&legacy_request, cancellation).await {
-        Ok(decoded_frames) => {
+        Ok((decoded_frames, decode_timings)) => {
             let mut queue_state = queue.lock().await;
             if queue_state.is_generation_current(generation) {
-                queue_state.complete(key, decoded_frames);
+                queue_state.complete(
+                    key,
+                    QueuedNativeFrame {
+                        decoded_frames,
+                        decode_timings,
+                        queued_at: command_started,
+                        scheduler_wait_us,
+                    },
+                );
             } else {
                 queue_state.fail(&key);
             }
@@ -1453,6 +1545,7 @@ pub async fn present_native_frame(
     app: tauri::AppHandle,
     request: FrameRequest,
 ) -> Result<NativeSurfacePresentation, String> {
+    let presentation_started = Instant::now();
     let presentation_sequence =
         NATIVE_SURFACE_PRESENTATION_SEQUENCE.fetch_add(1, Ordering::Relaxed);
     if request.contract_version != NATIVE_CORE_CONTRACT_VERSION {
@@ -1470,19 +1563,50 @@ pub async fn present_native_frame(
     let legacy_request = to_video_project_request(&request)?;
     validate_video_project_request(&legacy_request)?;
     let queued_key = request.cache_key().map_err(|error| error.to_string())?;
-    let queued_frames = if let Some(queue) =
+    let queued_frame = if let Some(queue) =
         app.try_state::<Arc<tokio::sync::Mutex<NativePreviewFrameQueue>>>()
     {
         queue.inner().clone().lock().await.take(&queued_key)
     } else {
         None
     };
-    let decoded_frames = match queued_frames {
-        Some(decoded_frames) => decoded_frames,
-        None => decode_native_video_layers(&legacy_request, None).await?,
-    };
+    let (decoded_frames, decode_timings, scheduler_wait_us, request_started_at, queue_hit) =
+        match queued_frame {
+            Some(frame) => (
+                frame.decoded_frames,
+                frame.decode_timings,
+                frame.scheduler_wait_us,
+                frame.queued_at,
+                true,
+            ),
+            None => {
+                let (decoded_frames, decode_timings) =
+                    decode_native_video_layers(&legacy_request, None).await?;
+                (
+                    decoded_frames,
+                    decode_timings,
+                    0,
+                    presentation_started,
+                    false,
+                )
+            }
+        };
     if let Some(queue) = app.try_state::<Arc<tokio::sync::Mutex<NativePreviewFrameQueue>>>() {
         if !queue.inner().clone().lock().await.is_generation_current(generation) {
+            record_native_surface_sample(
+                &app,
+                &request,
+                request_started_at,
+                decode_timings,
+                queue_hit,
+                scheduler_wait_us,
+                None,
+                None,
+                None,
+                None,
+                false,
+                true,
+            );
             return Err("Native preview frame request is stale".to_string());
         }
     }
@@ -1514,6 +1638,22 @@ pub async fn present_native_frame(
     );
     if !surface.accept_presentation(presentation_sequence) {
         SYNC_METRICS.record_dropped_frame();
+        drop(surface);
+        drop(session);
+        record_native_surface_sample(
+            &app,
+            &request,
+            request_started_at,
+            decode_timings,
+            queue_hit,
+            scheduler_wait_us,
+            None,
+            None,
+            None,
+            None,
+            true,
+            false,
+        );
         return Ok(NativeSurfacePresentation {
             contract_version: NATIVE_CORE_CONTRACT_VERSION,
             request_id: request.request_id,
@@ -1531,6 +1671,22 @@ pub async fn present_native_frame(
     }
     if late_for_audio {
         SYNC_METRICS.record_dropped_frame();
+        drop(surface);
+        drop(session);
+        record_native_surface_sample(
+            &app,
+            &request,
+            request_started_at,
+            decode_timings,
+            queue_hit,
+            scheduler_wait_us,
+            None,
+            None,
+            None,
+            None,
+            true,
+            false,
+        );
         return Ok(NativeSurfacePresentation {
             contract_version: NATIVE_CORE_CONTRACT_VERSION,
             request_id: request.request_id,
@@ -1554,13 +1710,16 @@ pub async fn present_native_frame(
             "Native direct presentation requires an sRGB surface format, got {target_format:?}"
         ));
     }
+    let surface_acquire_started = Instant::now();
     let surface_texture = surface.acquire_current_texture(&session.gpu.device)?;
+    let surface_acquire_us = surface_acquire_started.elapsed().as_micros() as u64;
     let target_view = surface_texture
         .texture
         .create_view(&wgpu::TextureViewDescriptor::default());
 
     let canvas_width = legacy_request.canvas_width as f32;
     let canvas_height = legacy_request.canvas_height as f32;
+    let conversion_started = Instant::now();
     let mut textures = Vec::with_capacity(
         legacy_request.layers.len() + legacy_request.raster_layers.len(),
     );
@@ -1596,6 +1755,8 @@ pub async fn present_native_frame(
         textures.push(texture);
     }
 
+    let conversion_upload_us = conversion_started.elapsed().as_micros() as u64;
+    let compose_started = Instant::now();
     let compositor = MultiTrackCompositor::new_with_target_format(
         &session.gpu.device,
         &session.gpu.queue,
@@ -1707,10 +1868,13 @@ pub async fn present_native_frame(
             Some(clear_color),
         )?;
     }
+    let compose_us = compose_started.elapsed().as_micros() as u64;
     // Keep decoded textures and views alive until after queue submission.
     let _textures = textures;
+    let submit_present_started = Instant::now();
     surface_texture.present();
     surface.show_surface()?;
+    let submit_present_us = submit_present_started.elapsed().as_micros() as u64;
     let presented_ticks = (request.frame_time.ticks.max(0) as i128 * 1_000_000i128
         / request.frame_time.timescale.max(1) as i128)
         .min(i64::MAX as i128) as i64;
@@ -1719,6 +1883,22 @@ pub async fn present_native_frame(
         1_000_000i64 / i64::from(request.project.frame_rate.max(1)),
         matches!(request.mode.as_deref(), Some("playback") | Some("playback-lookahead")),
         request.mode.as_deref() != Some("playback-lookahead"),
+    );
+    drop(surface);
+    drop(session);
+    record_native_surface_sample(
+        &app,
+        &request,
+        request_started_at,
+        decode_timings,
+        queue_hit,
+        scheduler_wait_us,
+        Some(conversion_upload_us),
+        Some(compose_us),
+        Some(surface_acquire_us),
+        Some(submit_present_us),
+        false,
+        false,
     );
 
     Ok(NativeSurfacePresentation {
@@ -1788,7 +1968,7 @@ pub async fn render_native_frame(
                 bytes_transferred: packet.data.len() as u64,
                 cache_hit: true,
                 generation: request.generation,
-                mode: request.mode.clone(),
+                mode: PreviewMode::from_request_mode(request.mode.as_deref()),
                 quality: Some(format!("{:?}", request.quality)),
                 strategy: Some("HOT".to_string()),
                 cancelled: false,
@@ -1798,6 +1978,17 @@ pub async fn render_native_frame(
                 conversion_time_us: 0,
                 upload_time_us: 0,
                 present_time_us: 0,
+                decode_us: None,
+                conversion_upload_us: None,
+                compose_us: None,
+                readback_us: None,
+                present_us: None,
+                scheduler_wait_us: None,
+                ipc_wait_us: None,
+                decoder_mutex_wait_us: None,
+                gpu_queue_wait_us: None,
+                surface_acquire_us: None,
+                submit_present_us: None,
             });
             record_successful_readback_metrics(&app, &request);
             return Ok(tauri::ipc::Response::new(packet.data));
@@ -1837,7 +2028,7 @@ pub async fn render_native_frame(
             bytes_transferred: rgba.len() as u64,
             cache_hit: false,
             generation: request.generation,
-            mode: request.mode.clone(),
+            mode: PreviewMode::from_request_mode(request.mode.as_deref()),
             quality: Some(format!("{:?}", request.quality)),
             strategy: Some("COLD".to_string()),
             cancelled: false,
@@ -1847,6 +2038,17 @@ pub async fn render_native_frame(
             conversion_time_us: stage_timings.conversion_time_us,
             upload_time_us: 0,
             present_time_us: 0,
+            decode_us: Some(u64::from(stage_timings.decode_time_us)),
+            conversion_upload_us: Some(u64::from(stage_timings.conversion_time_us)),
+            compose_us: Some(u64::from(stage_timings.compose_time_us)),
+            readback_us: Some(u64::from(stage_timings.readback_time_us)),
+            present_us: None,
+            scheduler_wait_us: None,
+            ipc_wait_us: None,
+            decoder_mutex_wait_us: Some(stage_timings.decoder_mutex_wait_us),
+            gpu_queue_wait_us: None,
+            surface_acquire_us: None,
+            submit_present_us: None,
         });
     }
 
@@ -1873,9 +2075,11 @@ mod tests {
     use super::{
         color_params, merge_color_metadata, parse_blend_mode, project_layer_transform,
         validate_project_request, validate_video_project_request, NativeProjectFrameRequest,
-        NativePreviewFrameQueue, NativeVideoProjectFrameRequest,
+        NativeDecodeTimings, NativePreviewFrameQueue, NativeVideoProjectFrameRequest,
+        QueuedNativeFrame,
     };
     use crate::thumbnail_engine::decoder::VideoColorMetadata;
+    use std::time::Instant;
 
     #[test]
     fn unspecified_sdr_metadata_uses_limited_rec709_defaults() {
@@ -2011,19 +2215,25 @@ mod tests {
     #[test]
     fn native_preview_queue_is_bounded_and_consumable() {
         let mut queue = NativePreviewFrameQueue::new(2);
+        let queued_frame = || QueuedNativeFrame {
+            decoded_frames: Vec::new(),
+            decode_timings: NativeDecodeTimings::default(),
+            queued_at: Instant::now(),
+            scheduler_wait_us: 0,
+        };
         assert!(queue.begin("frame-1"));
         assert!(!queue.begin("frame-1"));
-        queue.complete("frame-1".to_string(), Vec::new());
+        queue.complete("frame-1".to_string(), queued_frame());
         assert!(queue.contains("frame-1"));
         assert!(queue.take("frame-1").is_some());
         assert!(!queue.contains("frame-1"));
 
         assert!(queue.begin("frame-2"));
-        queue.complete("frame-2".to_string(), Vec::new());
+        queue.complete("frame-2".to_string(), queued_frame());
         assert!(queue.begin("frame-3"));
-        queue.complete("frame-3".to_string(), Vec::new());
+        queue.complete("frame-3".to_string(), queued_frame());
         assert!(queue.begin("frame-4"));
-        queue.complete("frame-4".to_string(), Vec::new());
+        queue.complete("frame-4".to_string(), queued_frame());
         assert!(!queue.contains("frame-2"));
         assert!(queue.contains("frame-3"));
         assert!(queue.contains("frame-4"));

--- a/src-tauri/src/native_core/performance.rs
+++ b/src-tauri/src/native_core/performance.rs
@@ -1,6 +1,34 @@
 use serde::{Deserialize, Serialize};
 use std::time::{SystemTime, UNIX_EPOCH};
 
+/// Preview interaction modes used by the native performance diagnostics.
+/// Unknown or non-preview request modes remain representable as `None` on a
+/// sample so legacy callers cannot accidentally enter the wrong bucket.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum PreviewMode {
+    Playback,
+    PlaybackLookahead,
+    Seek,
+    Scrub,
+    FrameStep,
+    Prefetch,
+}
+
+impl PreviewMode {
+    pub fn from_request_mode(mode: Option<&str>) -> Option<Self> {
+        match mode {
+            Some("playback") => Some(Self::Playback),
+            Some("playback-lookahead") => Some(Self::PlaybackLookahead),
+            Some("seek") => Some(Self::Seek),
+            Some("scrub") => Some(Self::Scrub),
+            Some("frameStep") | Some("frame-step") => Some(Self::FrameStep),
+            Some("prefetch") => Some(Self::Prefetch),
+            _ => None,
+        }
+    }
+}
+
 /// Runtime limits used to protect the fast editing path during migration.
 /// Durations are integer microseconds; timestamps remain governed by FrameTime.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -57,7 +85,7 @@ pub struct PerformanceSample {
     #[serde(default)]
     pub generation: Option<u64>,
     #[serde(default)]
-    pub mode: Option<String>,
+    pub mode: Option<PreviewMode>,
     #[serde(default)]
     pub quality: Option<String>,
     #[serde(default)]
@@ -76,6 +104,30 @@ pub struct PerformanceSample {
     pub upload_time_us: u32,
     #[serde(default)]
     pub present_time_us: u32,
+    /// Optional phase timings that are only meaningful on the path where the
+    /// corresponding phase exists. `None` is different from a measured zero.
+    #[serde(default)]
+    pub decode_us: Option<u64>,
+    #[serde(default)]
+    pub conversion_upload_us: Option<u64>,
+    #[serde(default)]
+    pub compose_us: Option<u64>,
+    #[serde(default)]
+    pub readback_us: Option<u64>,
+    #[serde(default)]
+    pub present_us: Option<u64>,
+    #[serde(default)]
+    pub scheduler_wait_us: Option<u64>,
+    #[serde(default)]
+    pub ipc_wait_us: Option<u64>,
+    #[serde(default)]
+    pub decoder_mutex_wait_us: Option<u64>,
+    #[serde(default)]
+    pub gpu_queue_wait_us: Option<u64>,
+    #[serde(default)]
+    pub surface_acquire_us: Option<u64>,
+    #[serde(default)]
+    pub submit_present_us: Option<u64>,
 }
 
 impl PerformanceSample {
@@ -111,6 +163,57 @@ pub struct NativeFrameServiceStats {
     pub window_seek_p99_ms: Option<f64>,
     #[serde(default)]
     pub window_cache_hit_rate: f64,
+    #[serde(default)]
+    pub mode_stats: Vec<ModeStats>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct StagePercentiles {
+    pub p50: Option<u64>,
+    pub p95: Option<u64>,
+    pub p99: Option<u64>,
+    pub sample_count: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ModeStats {
+    pub mode: PreviewMode,
+    pub decode: StagePercentiles,
+    pub conversion_upload: StagePercentiles,
+    pub compose: StagePercentiles,
+    pub readback: StagePercentiles,
+    pub present: StagePercentiles,
+    pub scheduler_wait: StagePercentiles,
+    pub ipc_wait: StagePercentiles,
+    pub decoder_mutex_wait: StagePercentiles,
+    pub gpu_queue_wait: StagePercentiles,
+    pub surface_acquire: StagePercentiles,
+    pub submit_present: StagePercentiles,
+    pub dropped_count: usize,
+    pub stale_count: usize,
+}
+
+pub(crate) fn optional_stage_percentiles(
+    samples: &[PerformanceSample],
+    pick: impl Fn(&PerformanceSample) -> Option<u64>,
+) -> StagePercentiles {
+    let mut values: Vec<u64> = samples.iter().filter_map(pick).collect();
+    values.sort_unstable();
+    let percentile = |pct: f64| -> Option<u64> {
+        if values.is_empty() {
+            return None;
+        }
+        let index = ((values.len() - 1) as f64 * pct).round() as usize;
+        values.get(index).copied()
+    };
+    StagePercentiles {
+        p50: percentile(0.50),
+        p95: percentile(0.95),
+        p99: percentile(0.99),
+        sample_count: values.len(),
+    }
 }
 
 pub fn now_ms() -> u64 {
@@ -164,6 +267,17 @@ mod tests {
             conversion_time_us: 0,
             upload_time_us: 0,
             present_time_us: 0,
+            decode_us: None,
+            conversion_upload_us: None,
+            compose_us: None,
+            readback_us: None,
+            present_us: None,
+            scheduler_wait_us: None,
+            ipc_wait_us: None,
+            decoder_mutex_wait_us: None,
+            gpu_queue_wait_us: None,
+            surface_acquire_us: None,
+            submit_present_us: None,
         };
         assert!(sample.exceeds_render_budget(&budget));
     }

--- a/src-tauri/src/native_core/service.rs
+++ b/src-tauri/src/native_core/service.rs
@@ -3,7 +3,9 @@ use super::{
     PerformanceSample,
 };
 use std::collections::VecDeque;
-use super::performance::{now_ms, percentile_ms};
+use super::performance::{
+    now_ms, optional_stage_percentiles, percentile_ms, ModeStats, PreviewMode,
+};
 
 /// Reusable native frame service boundary.
 ///
@@ -94,9 +96,63 @@ impl NativeFrameService {
 
     pub fn stats(&self) -> NativeFrameServiceStats {
         let now = now_ms();
-        let mut seek_samples: Vec<u32> = self.window_samples.iter().map(|(_, sample)| sample.total_time_us).collect();
+        let mut seek_samples: Vec<u32> = self
+            .window_samples
+            .iter()
+            .filter(|(_, sample)| {
+                matches!(
+                    sample.mode,
+                    Some(PreviewMode::Seek | PreviewMode::Scrub | PreviewMode::FrameStep)
+                )
+            })
+            .map(|(_, sample)| sample.total_time_us)
+            .collect();
         let requests = self.window_samples.len() as u64;
         let hits = self.window_samples.iter().filter(|(_, sample)| sample.cache_hit).count() as u64;
+        let cache_samples = self
+            .window_samples
+            .iter()
+            .filter(|(_, sample)| {
+                !matches!(
+                    sample.strategy.as_deref(),
+                    Some("SURFACE_WARM" | "SURFACE_COLD")
+                )
+            })
+            .count() as u64;
+        let mode_stats = [
+            PreviewMode::Playback,
+            PreviewMode::PlaybackLookahead,
+            PreviewMode::Seek,
+            PreviewMode::Scrub,
+            PreviewMode::FrameStep,
+            PreviewMode::Prefetch,
+        ]
+        .into_iter()
+        .map(|mode| {
+            let samples: Vec<PerformanceSample> = self
+                .window_samples
+                .iter()
+                .filter(|(_, sample)| sample.mode == Some(mode))
+                .map(|(_, sample)| sample.clone())
+                .collect();
+            ModeStats {
+                mode,
+                decode: optional_stage_percentiles(&samples, |sample| sample.decode_us),
+                conversion_upload: optional_stage_percentiles(&samples, |sample| sample.conversion_upload_us),
+                compose: optional_stage_percentiles(&samples, |sample| sample.compose_us),
+                readback: optional_stage_percentiles(&samples, |sample| sample.readback_us),
+                present: optional_stage_percentiles(&samples, |sample| sample.present_us),
+                scheduler_wait: optional_stage_percentiles(&samples, |sample| sample.scheduler_wait_us),
+                ipc_wait: optional_stage_percentiles(&samples, |sample| sample.ipc_wait_us),
+                decoder_mutex_wait: optional_stage_percentiles(&samples, |sample| sample.decoder_mutex_wait_us),
+                gpu_queue_wait: optional_stage_percentiles(&samples, |sample| sample.gpu_queue_wait_us),
+                surface_acquire: optional_stage_percentiles(&samples, |sample| sample.surface_acquire_us),
+                submit_present: optional_stage_percentiles(&samples, |sample| sample.submit_present_us),
+                dropped_count: samples.iter().filter(|sample| sample.dropped).count(),
+                stale_count: samples.iter().filter(|sample| sample.stale).count(),
+            }
+        })
+        .collect();
         NativeFrameServiceStats {
             total_requests: self.total_requests,
             cache_hits: self.cache_hits,
@@ -112,7 +168,8 @@ impl NativeFrameService {
             window_seek_p50_ms: percentile_ms(&mut seek_samples, 0.50),
             window_seek_p95_ms: percentile_ms(&mut seek_samples, 0.95),
             window_seek_p99_ms: percentile_ms(&mut seek_samples, 0.99),
-            window_cache_hit_rate: if requests == 0 { 0.0 } else { hits as f64 / requests as f64 },
+            window_cache_hit_rate: if cache_samples == 0 { 0.0 } else { hits as f64 / cache_samples as f64 },
+            mode_stats,
         }
     }
 }

--- a/src-tauri/src/wgpu_compositor/multi_track_composer.rs
+++ b/src-tauri/src/wgpu_compositor/multi_track_composer.rs
@@ -936,6 +936,31 @@ impl MultiTrackCompositor {
         clear_color: Option<wgpu::Color>,
         #[cfg(target_arch = "wasm32")] is_gl: bool,
     ) -> Result<Vec<u8>, String> {
+        self.render_to_rgba_bytes_with_size_timed(
+            device,
+            queue,
+            width,
+            height,
+            layers,
+            clear_color,
+            #[cfg(target_arch = "wasm32")] is_gl,
+        )
+        .await
+        .map(|(bytes, _, _)| bytes)
+    }
+
+    /// Render to RGBA bytes and return CPU-observable composition and readback
+    /// durations. The readback duration includes GPU completion/map latency.
+    pub async fn render_to_rgba_bytes_with_size_timed(
+        &self,
+        device: &wgpu::Device,
+        queue: &wgpu::Queue,
+        width: u32,
+        height: u32,
+        layers: &[CompositeLayer<'_>],
+        clear_color: Option<wgpu::Color>,
+        #[cfg(target_arch = "wasm32")] is_gl: bool,
+    ) -> Result<(Vec<u8>, u64, u64), String> {
         let texture_desc = wgpu::TextureDescriptor {
             label: Some("Compositor Render Target"),
             size: wgpu::Extent3d {
@@ -954,7 +979,10 @@ impl MultiTrackCompositor {
         let target_texture = device.create_texture(&texture_desc);
         let target_view = target_texture.create_view(&wgpu::TextureViewDescriptor::default());
 
+        let compose_started = std::time::Instant::now();
         self.composite_layers(device, queue, &target_view, layers, clear_color)?;
+        let compose_us = compose_started.elapsed().as_micros() as u64;
+        let readback_started = std::time::Instant::now();
 
         let bytes_per_pixel = 4u32;
         let unpadded_bytes_per_row = width * bytes_per_pixel;
@@ -1077,7 +1105,11 @@ impl MultiTrackCompositor {
         drop(mapped_range);
         output_buffer.unmap();
 
-        Ok(unpadded_rgba)
+        Ok((
+            unpadded_rgba,
+            compose_us,
+            readback_started.elapsed().as_micros() as u64,
+        ))
     }
 
     /// Composites a dual-texture transition (from -> to) onto the target view.
@@ -1178,6 +1210,34 @@ impl MultiTrackCompositor {
         uniforms: &TransitionUniforms,
         #[cfg(target_arch = "wasm32")] is_gl: bool,
     ) -> Result<Vec<u8>, String> {
+        self.render_transition_to_rgba_bytes_timed(
+            device,
+            queue,
+            width,
+            height,
+            from_view,
+            to_view,
+            uniforms,
+            #[cfg(target_arch = "wasm32")] is_gl,
+        )
+        .await
+        .map(|(bytes, _, _)| bytes)
+    }
+
+    /// Render a transition and return CPU-observable composition and readback
+    /// durations.
+    #[allow(clippy::too_many_arguments)]
+    pub async fn render_transition_to_rgba_bytes_timed(
+        &self,
+        device: &wgpu::Device,
+        queue: &wgpu::Queue,
+        width: u32,
+        height: u32,
+        from_view: &wgpu::TextureView,
+        to_view: &wgpu::TextureView,
+        uniforms: &TransitionUniforms,
+        #[cfg(target_arch = "wasm32")] is_gl: bool,
+    ) -> Result<(Vec<u8>, u64, u64), String> {
         let texture_desc = wgpu::TextureDescriptor {
             label: Some("Transition Render Target"),
             size: wgpu::Extent3d {
@@ -1196,6 +1256,7 @@ impl MultiTrackCompositor {
         let target_texture = device.create_texture(&texture_desc);
         let target_view = target_texture.create_view(&wgpu::TextureViewDescriptor::default());
 
+        let compose_started = std::time::Instant::now();
         self.composite_transition(
             device,
             queue,
@@ -1205,6 +1266,8 @@ impl MultiTrackCompositor {
             uniforms,
             Some(wgpu::Color::BLACK),
         )?;
+        let compose_us = compose_started.elapsed().as_micros() as u64;
+        let readback_started = std::time::Instant::now();
 
         let bytes_per_pixel = 4u32;
         let unpadded_bytes_per_row = width * bytes_per_pixel;
@@ -1327,6 +1390,10 @@ impl MultiTrackCompositor {
         drop(mapped_range);
         output_buffer.unmap();
 
-        Ok(unpadded_rgba)
+        Ok((
+            unpadded_rgba,
+            compose_us,
+            readback_started.elapsed().as_micros() as u64,
+        ))
     }
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Clypra",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "identifier": "com.clypra.editor",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src/components/editor/preview/NativeProgramPreview.tsx
+++ b/src/components/editor/preview/NativeProgramPreview.tsx
@@ -31,6 +31,7 @@ import { getFrameIndexAtTime, getFrameStartTime } from "@/lib/utils/frameTime";
 import { clampAndSnapProgramTime } from "@/lib/timeline/programTimelineBridge";
 import { getPlaybackMetricsSnapshot, tracePlayback } from "@/core/playback/playbackTrace";
 import { getSyncMetricsSnapshot, startSyncMetricsFlushLoop } from "@/lib/playback/syncMetrics";
+import { nativePerfCollector, type NativePerfSpan } from "@/core/playback/nativePerfTelemetry";
 import type { SeekIntent } from "@/core/playback/seekController";
 import {
   getNativePreviewSurfaceGeometry,
@@ -668,6 +669,7 @@ export const NativeProgramPreview: React.FC = () => {
     const registeredNativeAnimatedStickerAssets = new Set<string>();
     const nativeBackgroundAssetsById = new Map<string, NativeRasterLayerSnapshot & { rgba: number[] }>();
     const registeredNativeBackgroundAssets = new Set<string>();
+    const nativeFrontendPerfSpans = new Map<string, NativePerfSpan>();
     const maxNativeTextRasterCacheEntries = 96;
     const maxNativeBodyMaskCacheEntries = 90;
     const maxNativeSmartOverlayCacheEntries = 48;
@@ -1020,7 +1022,20 @@ export const NativeProgramPreview: React.FC = () => {
         if (signal?.aborted) {
           throw new DOMException("Native preview request cancelled", "AbortError");
         }
-        const render = () => renderNativeFrame(request);
+        const requestKey = getNativeFrameRequestKey(request);
+        const frontendSpan = nativePerfCollector.isEnabled()
+          ? nativePerfCollector.begin(request)
+          : null;
+        frontendSpan?.markDispatchStarted();
+        if (frontendSpan) nativeFrontendPerfSpans.set(requestKey, frontendSpan);
+        const render = async () => {
+          frontendSpan?.markIpcStarted();
+          try {
+            return await renderNativeFrame(request);
+          } finally {
+            frontendSpan?.markIpcFinished();
+          }
+        };
         let rgba: ArrayBuffer;
         try {
           rgba = await render();
@@ -1347,18 +1362,26 @@ export const NativeProgramPreview: React.FC = () => {
             };
 
             if (nativeSurfaceUsable) {
+              const frontendSpan = nativePerfCollector.isEnabled()
+                ? nativePerfCollector.begin(requestToPresent)
+                : null;
+              frontendSpan?.markDispatchStarted();
+              frontendSpan?.markIpcStarted();
               nativePlaybackInFlight = presentNativePlaybackFrame(requestToPresent)
                 .then((presentation) => {
+                  frontendSpan?.markIpcFinished();
                   const elapsedMs = performance.now() - requestStartedAt;
                   nativePresentationLatencyMs = nativePresentationLatencyMs > 0
                     ? nativePresentationLatencyMs * 0.75 + elapsedMs * 0.25
                     : elapsedMs;
                   if (!presentation.presented) {
+                    frontendSpan?.finish({ dropped: presentation.dropped, stale: presentation.stale === true });
                     lastNativePlaybackRequestKey = "";
                     if (presentation.dropped) {
                       nativeDroppedFrameCount += 1;
                     }
                   } else {
+                    frontendSpan?.finish();
                     const current = renderStateRef.current;
                     if (
                       isActive &&
@@ -1382,6 +1405,8 @@ export const NativeProgramPreview: React.FC = () => {
                   }
                 })
                 .catch((error) => {
+                  frontendSpan?.markIpcFinished();
+                  frontendSpan?.finish({ dropped: true });
                   nativeContinuousFailureStreak += 1;
                   lastNativePlaybackRequestKey = "";
                   if (nativeContinuousFailureStreak >= 3) {
@@ -1403,6 +1428,9 @@ export const NativeProgramPreview: React.FC = () => {
               nativePlaybackInFlight = nativePreviewScheduler
                 .requestVisible(requestSource)
                 .then((frame) => {
+                  const frontendSpan = nativeFrontendPerfSpans.get(requestKey);
+                  frontendSpan?.finish();
+                  nativeFrontendPerfSpans.delete(requestKey);
                   const current = renderStateRef.current;
                   if (
                     isActive &&
@@ -1418,6 +1446,9 @@ export const NativeProgramPreview: React.FC = () => {
                   }
                 })
                 .catch((error) => {
+                  const frontendSpan = nativeFrontendPerfSpans.get(requestKey);
+                  frontendSpan?.finish({ stale: true, cancelled: error instanceof DOMException && error.name === "AbortError" });
+                  nativeFrontendPerfSpans.delete(requestKey);
                   nativeContinuousFailureStreak += 1;
                   lastNativePlaybackRequestKey = "";
                   if (nativeContinuousFailureStreak >= 3) {
@@ -1493,6 +1524,9 @@ export const NativeProgramPreview: React.FC = () => {
               // was awaiting FFmpeg/GPU readback. Never commit that stale
               // response to the current program canvas.
               if (!targetStillCurrent()) {
+                const frontendSpan = nativeFrontendPerfSpans.get(nativeRequestKey);
+                frontendSpan?.finish({ stale: true });
+                nativeFrontendPerfSpans.delete(nativeRequestKey);
                 tracePlayback("native-render.stale-seek-frame", {
                   requestedTime: timeToRender,
                   requestedFrameIndex: frameIndex,
@@ -1530,6 +1564,12 @@ export const NativeProgramPreview: React.FC = () => {
                 blocked: nativeBlockedKey === nativeRequestKey,
                 error: error instanceof Error ? error.message : String(error),
               });
+              const frontendSpan = nativeFrontendPerfSpans.get(nativeRequestKey);
+              frontendSpan?.finish({
+                stale: error instanceof Error && /stale|cancel/i.test(error.message),
+                cancelled: error instanceof DOMException && error.name === "AbortError",
+              });
+              nativeFrontendPerfSpans.delete(nativeRequestKey);
               nativeRetryAt = performance.now() + 250;
               if (nativeOnlyMode) {
                 setNativeOnlyBlocked(true);
@@ -1549,8 +1589,22 @@ export const NativeProgramPreview: React.FC = () => {
             return;
           }
 
-          if (nativeFrame && canvasEl && !drawNativeFrameToCanvas(canvasEl, nativeFrame)) {
-            throw new Error("Native preview returned a frame that could not be drawn to the preview canvas");
+          let canvasPaintMs: number | undefined;
+          if (nativeFrame && canvasEl) {
+            const canvasPaintStarted = performance.now();
+            if (!drawNativeFrameToCanvas(canvasEl, nativeFrame)) {
+              throw new Error("Native preview returned a frame that could not be drawn to the preview canvas");
+            }
+            canvasPaintMs = performance.now() - canvasPaintStarted;
+          }
+          if (nativeFrame && canvasEl && exactNativeFrame !== null) {
+            const frontendSpan = nativeFrontendPerfSpans.get(nativeRequestKey);
+            if (frontendSpan) {
+              frontendSpan.finish({
+                canvasPaintMs,
+              });
+              nativeFrontendPerfSpans.delete(nativeRequestKey);
+            }
           }
 
           // Smart overlays are already rasterized into the native request. The

--- a/src/components/editor/timeline/TrackLabel.tsx
+++ b/src/components/editor/timeline/TrackLabel.tsx
@@ -115,9 +115,10 @@ export const TrackLabel: React.FC<TrackLabelProps> = ({ track, visualSpec: visua
             e.stopPropagation();
             toggleTrackMute(track.id);
           }}
-          className={`p-1 rounded transition-colors cursor-pointer hover:bg-timeline-button-hover ${track.muted ? "bg-timeline-button-hover text-timeline-track-name" : "text-timeline-button-icon"}`}
+          disabled={track.locked}
+          className={`p-1 rounded transition-colors ${track.locked ? "cursor-not-allowed opacity-50" : "cursor-pointer hover:bg-timeline-button-hover"} ${track.muted ? "bg-timeline-button-hover text-timeline-track-name" : "text-timeline-button-icon"}`}
           aria-label={track.muted ? "Unmute track" : "Mute track"}
-          title={track.muted ? "Unmute track" : "Mute track"}
+          title={track.locked ? "Unlock track to mute or unmute" : track.muted ? "Unmute track" : "Mute track"}
         >
           {track.muted ? <VolumeX className="w-3 h-3" /> : <Volume2 className="w-3 h-3" />}
         </button>

--- a/src/components/editor/timeline/__tests__/TrackList.test.tsx
+++ b/src/components/editor/timeline/__tests__/TrackList.test.tsx
@@ -37,9 +37,9 @@ describe("TrackLabel interactions", () => {
       </>
     );
 
+    fireEvent.click(screen.getAllByLabelText("Mute track")[0]);
     fireEvent.click(screen.getAllByLabelText("Lock track")[0]);
     fireEvent.click(screen.getAllByLabelText("Hide track")[0]);
-    fireEvent.click(screen.getAllByLabelText("Mute track")[0]);
 
     const [first, second] = useTimelineStore.getState().tracks;
     expect(first.locked).toBe(true);

--- a/src/core/commands/timelineCommands.ts
+++ b/src/core/commands/timelineCommands.ts
@@ -137,12 +137,18 @@ export const timelineCommands: TimelineCommand[] = [
     icon: VolumeX,
     group: "track",
     isVisible: (ctx) => Boolean(ctx.clickedTrackId),
-    isEnabled: (ctx) => Boolean(ctx.clickedTrackId),
+    isEnabled: (ctx) => Boolean(ctx.clickedTrackId && !ctx.tracks.find((track) => track.id === ctx.clickedTrackId)?.locked),
+    disabledReason: () => "Unlock the track before changing mute",
     execute: (ctx) => {
       if (!ctx.clickedTrackId) return;
       const store = useTimelineStore.getState();
+      const trackBefore = store.tracks.find((track) => track.id === ctx.clickedTrackId);
+      if (trackBefore?.locked) {
+        toast.info("Unlock the track before changing mute");
+        return;
+      }
       store.toggleTrackMute(ctx.clickedTrackId);
-      const track = store.tracks.find((t) => t.id === ctx.clickedTrackId);
+      const track = useTimelineStore.getState().tracks.find((t) => t.id === ctx.clickedTrackId);
       toast.info(track?.muted ? "Track muted" : "Track unmuted");
     },
   },

--- a/src/core/history/CommandJournal.ts
+++ b/src/core/history/CommandJournal.ts
@@ -241,6 +241,13 @@ export class CommandJournal {
     const composite = transaction.toCompositeCommand();
     transaction.commit();
 
+    // A committed transaction is a new edit just like a standalone command.
+    // Discard any commands that were undone before this transaction started;
+    // they describe a stale future and must not remain redoable.
+    if (this._position < this._history.length - 1) {
+      this._history = this._history.slice(0, this._position + 1);
+    }
+
     // Add to history (without executing - already applied)
     this._history.push(composite);
     this._position++;

--- a/src/core/history/__tests__/history.test.ts
+++ b/src/core/history/__tests__/history.test.ts
@@ -88,6 +88,30 @@ describe("CommandHistory — CommandJournal & Transaction", () => {
     expect(journal.getState().size).toBe(2);
   });
 
+  it("should clear redo history when committing a new transaction", () => {
+    const journal = new CommandJournal();
+    let state = { count: 10 };
+
+    state = journal.execute(new MockCommand(15, 10), state); // 15
+    state = journal.execute(new MockCommand(18, 15), state); // 18
+    state = journal.undo(state); // 15; 18 is now a redo candidate
+    expect(journal.canRedo()).toBe(true);
+
+    journal.beginTransaction("Replace Future");
+    state = journal.execute(new MockCommand(16, 15), state);
+    state = journal.commitTransaction(state);
+
+    expect(state.count).toBe(16);
+    expect(journal.canRedo()).toBe(false);
+    expect(journal.getState().size).toBe(2);
+
+    // The committed transaction is the only valid redo future.
+    state = journal.undo(state);
+    expect(state.count).toBe(15);
+    state = journal.redo(state);
+    expect(state.count).toBe(16);
+  });
+
   it("should enforce maximum history size limits", () => {
     const journal = new CommandJournal({ maxSize: 2 });
     let state = { count: 10 };

--- a/src/core/history/commands/CompoundClipCommands.ts
+++ b/src/core/history/commands/CompoundClipCommands.ts
@@ -1,4 +1,5 @@
 import type { Clip, Track, TransitionTimelineItem } from "@/types";
+import type { Gap } from "@/types/gap";
 import type { Command } from "../Command";
 import { generateCommandId } from "../Command";
 import { generateId } from "@/lib/utils/id";
@@ -8,6 +9,7 @@ interface TimelineState {
   tracks: Track[];
   clips: Clip[];
   transitions?: TransitionTimelineItem[];
+  gaps?: Gap[];
   epoch: number;
 }
 
@@ -34,6 +36,7 @@ export class GroupClipsCommand implements Command {
   private readonly originalClips: Clip[];
   private readonly parent: Clip;
   private readonly originalIndex: number;
+  private originalGaps: Gap[] | null = null;
 
   constructor(clipIds: string[], clips: Clip[], tracks: Track[], preview?: string, transitions: TransitionTimelineItem[] = [], parentId?: string) {
     const validation = validateGroupSelection(clipIds, clips, tracks, transitions);
@@ -70,14 +73,24 @@ export class GroupClipsCommand implements Command {
     if (state.clips.some((clip) => clip.id === this.parent.id)) return state;
     const selectedIds = new Set(this.originalClips.map((clip) => clip.id));
     if (!this.originalClips.every((clip) => state.clips.some((candidate) => candidate.id === clip.id))) return state;
+    this.originalGaps = state.gaps?.map((gap) => ({
+      ...gap,
+      metadata: gap.metadata ? { ...gap.metadata } : gap.metadata,
+    })) ?? null;
     const remaining = state.clips.filter((clip) => !selectedIds.has(clip.id));
     const insertIndex = Math.max(0, Math.min(this.originalIndex, remaining.length));
     remaining.splice(insertIndex, 0, this.parent);
-    return { ...state, clips: remaining, epoch: state.epoch + 1 };
+    const groupEnd = this.parent.startTime + this.parent.duration;
+    const gaps = state.gaps?.filter((gap) => {
+      if (gap.trackId !== this.parent.trackId) return true;
+      const gapEnd = gap.startTime + gap.duration;
+      return !(gap.startTime >= this.parent.startTime - 0.001 && gapEnd <= groupEnd + 0.001);
+    });
+    return { ...state, clips: remaining, ...(gaps ? { gaps } : {}), epoch: state.epoch + 1 };
   }
 
   invert(): UngroupClipsCommand {
-    return new UngroupClipsCommand(this.parent, this.originalClips, this.originalIndex, this);
+    return new UngroupClipsCommand(this.parent, this.originalClips, this.originalIndex, this, [], this.originalGaps ?? undefined);
   }
 
   getParentClip(): Clip { return this.parent; }
@@ -96,6 +109,7 @@ export class UngroupClipsCommand implements Command {
     private readonly _parentIndex = 0,
     private readonly inverse?: GroupClipsCommand,
     private readonly tracks: Track[] = [],
+    private readonly restoredGaps?: Gap[],
   ) {}
 
   apply(state: TimelineState): TimelineState {
@@ -104,7 +118,11 @@ export class UngroupClipsCommand implements Command {
     const children = this.originalChildren.map((child) => ({ ...child, startTime: this.parent.startTime + child.startTime, trackId: this.parent.trackId }));
     const clips = [...state.clips.filter((clip) => clip.id !== this.parent.id)];
     clips.splice(Math.min(parentIndex, clips.length), 0, ...children);
-    return { ...state, clips, epoch: state.epoch + 1 };
+    const gaps = this.restoredGaps?.map((gap) => ({
+      ...gap,
+      metadata: gap.metadata ? { ...gap.metadata } : gap.metadata,
+    }));
+    return { ...state, clips, ...(gaps ? { gaps } : {}), epoch: state.epoch + 1 };
   }
 
   invert(): GroupClipsCommand {

--- a/src/core/history/commands/DeleteClipCommand.ts
+++ b/src/core/history/commands/DeleteClipCommand.ts
@@ -5,12 +5,14 @@
 import type { Command } from "../Command";
 import { generateCommandId } from "../Command";
 import type { Clip, Track, TransitionTimelineItem } from "@/types";
+import type { Gap } from "@/types/gap";
 import { shouldAutoPruneTrack } from "@/lib/timeline/trackTypeConfig";
 
 interface TimelineState {
   tracks?: Track[];
   clips: Clip[];
   transitions?: TransitionTimelineItem[];
+  gaps?: Gap[];
   epoch: number;
 }
 
@@ -24,6 +26,8 @@ export class DeleteClipCommand implements Command {
   private deletedTrack: Track | null = null;
   private deletedTrackIndex: number = -1;
   private deletedTransitions: TransitionTimelineItem[] = [];
+  private deletedClipIndex: number = -1;
+  private deletedGaps: Gap[] | undefined;
 
   constructor(private readonly clipId: string) {
     this.id = generateCommandId();
@@ -36,6 +40,12 @@ export class DeleteClipCommand implements Command {
     this.deletedClip = clip || null;
 
     if (!clip) return state;
+
+    this.deletedClipIndex = state.clips.findIndex((candidate) => candidate.id === this.clipId);
+    this.deletedGaps = state.gaps?.map((gap) => ({
+      ...gap,
+      metadata: gap.metadata ? { ...gap.metadata } : gap.metadata,
+    }));
 
     const remainingClips = state.clips.filter((c) => c.id !== this.clipId);
     const hasOtherClips = remainingClips.some((c) => c.trackId === clip.trackId);
@@ -78,7 +88,14 @@ export class DeleteClipCommand implements Command {
     if (!this.deletedClip) {
       throw new Error("Cannot invert DeleteClipCommand: no deleted clip stored");
     }
-    return new AddClipCommand(this.deletedClip, this.deletedTrack, this.deletedTrackIndex, this.deletedTransitions);
+    return new AddClipCommand(
+      this.deletedClip,
+      this.deletedTrack,
+      this.deletedTrackIndex,
+      this.deletedTransitions,
+      this.deletedClipIndex,
+      this.deletedGaps,
+    );
   }
 
   toJSON(): Record<string, any> {
@@ -88,6 +105,8 @@ export class DeleteClipCommand implements Command {
       deletedClip: this.deletedClip,
       deletedTrack: this.deletedTrack,
       deletedTrackIndex: this.deletedTrackIndex,
+      deletedClipIndex: this.deletedClipIndex,
+      deletedGaps: this.deletedGaps,
     };
   }
 
@@ -96,6 +115,8 @@ export class DeleteClipCommand implements Command {
     cmd.deletedClip = data.deletedClip;
     cmd.deletedTrack = data.deletedTrack;
     cmd.deletedTrackIndex = data.deletedTrackIndex ?? -1;
+    cmd.deletedClipIndex = data.deletedClipIndex ?? -1;
+    cmd.deletedGaps = data.deletedGaps;
     return cmd;
   }
 }
@@ -114,6 +135,8 @@ export class AddClipCommand implements Command {
     private readonly restoredTrack?: Track | null,
     private readonly restoredTrackIndex?: number,
     private readonly restoredTransitions: TransitionTimelineItem[] = [],
+    private readonly restoredClipIndex: number = -1,
+    private readonly restoredGaps?: Gap[],
   ) {
     this.id = generateCommandId();
     this.label = "Add Clip";
@@ -128,35 +151,37 @@ export class AddClipCommand implements Command {
       tracks.splice(insertIndex, 0, this.restoredTrack);
     }
 
-    // Check for overlap and adjust position if needed
-    const trackClips = state.clips.filter((c) => c.trackId === this.clip.trackId).sort((a, b) => a.startTime - b.startTime);
+    let clips: Clip[];
+    if (this.restoredClipIndex >= 0) {
+      clips = [...state.clips];
+      const insertIndex = Math.max(0, Math.min(this.restoredClipIndex, clips.length));
+      clips.splice(insertIndex, 0, { ...this.clip });
+    } else {
+      // New clips use the legacy safe-position behavior; deleted clips carry
+      // an explicit index and are restored exactly at their original slot.
+      const trackClips = state.clips.filter((c) => c.trackId === this.clip.trackId).sort((a, b) => a.startTime - b.startTime);
+      let finalStartTime = this.clip.startTime;
+      let hasOverlap = true;
 
-    let finalStartTime = this.clip.startTime;
-    let hasOverlap = true;
-
-    // Keep checking until no overlaps (handle cascading shifts)
-    while (hasOverlap) {
-      hasOverlap = false;
-      for (const existingClip of trackClips) {
-        const existingEnd = existingClip.startTime + existingClip.duration;
-        const newEnd = finalStartTime + this.clip.duration;
-
-        // Check for overlap
-        if (finalStartTime < existingEnd && newEnd > existingClip.startTime) {
-          // Overlap detected - move to end of conflicting clip
-          finalStartTime = existingEnd;
-          hasOverlap = true; // Re-check with new position
-          break; // Restart the loop from beginning
+      while (hasOverlap) {
+        hasOverlap = false;
+        for (const existingClip of trackClips) {
+          const existingEnd = existingClip.startTime + existingClip.duration;
+          const newEnd = finalStartTime + this.clip.duration;
+          if (finalStartTime < existingEnd && newEnd > existingClip.startTime) {
+            finalStartTime = existingEnd;
+            hasOverlap = true;
+            break;
+          }
         }
       }
-    }
 
-    // Create clip with safe position
-    const safeClip = { ...this.clip, startTime: finalStartTime };
+      clips = [...state.clips, { ...this.clip, startTime: finalStartTime }];
+    }
 
     const nextState: TimelineState = {
       ...state,
-      clips: [...state.clips, safeClip],
+      clips,
       epoch: state.epoch + 1, // ✅ Epoch increment inside command
     };
 
@@ -168,6 +193,13 @@ export class AddClipCommand implements Command {
       const existingIds = new Set(state.transitions.map((t) => t.id));
       const transitionsToAdd = this.restoredTransitions.filter((t) => !existingIds.has(t.id));
       nextState.transitions = [...state.transitions, ...transitionsToAdd];
+    }
+
+    if (state.gaps !== undefined && this.restoredGaps !== undefined) {
+      nextState.gaps = this.restoredGaps.map((gap) => ({
+        ...gap,
+        metadata: gap.metadata ? { ...gap.metadata } : gap.metadata,
+      }));
     }
 
     return nextState;
@@ -183,10 +215,19 @@ export class AddClipCommand implements Command {
       clip: this.clip,
       restoredTrack: this.restoredTrack,
       restoredTrackIndex: this.restoredTrackIndex,
+      restoredClipIndex: this.restoredClipIndex,
+      restoredGaps: this.restoredGaps,
     };
   }
 
   static fromJSON(data: Record<string, any>): AddClipCommand {
-    return new AddClipCommand(data.clip, data.restoredTrack, data.restoredTrackIndex);
+    return new AddClipCommand(
+      data.clip,
+      data.restoredTrack,
+      data.restoredTrackIndex,
+      data.restoredTransitions ?? [],
+      data.restoredClipIndex ?? -1,
+      data.restoredGaps,
+    );
   }
 }

--- a/src/core/history/commands/SplitClipCommand.ts
+++ b/src/core/history/commands/SplitClipCommand.ts
@@ -25,6 +25,7 @@ export class SplitClipCommand implements Command {
   // Generate new IDs for BOTH splits (not just right)
   private leftClipId: string | null = null;
   private rightClipId: string | null = null;
+  private originalClipIndex: number = -1;
 
   constructor(
     private readonly clipId: string,
@@ -40,6 +41,7 @@ export class SplitClipCommand implements Command {
   apply(state: TimelineState): TimelineState {
     const clip = state.clips.find((c) => c.id === this.clipId);
     if (!clip) return state;
+    this.originalClipIndex = state.clips.findIndex((c) => c.id === this.clipId);
 
     const clipEndTime = clip.startTime + clip.duration;
     if (this.splitTime <= clip.startTime || this.splitTime >= clipEndTime) {
@@ -137,7 +139,7 @@ export class SplitClipCommand implements Command {
 
   invert(): Command {
     // Pass both clip IDs and the original splitTime to merge command
-    return new MergeSplitClipsCommand(this.leftClipId!, this.rightClipId!, this.originalClip, this.frameRate, this.splitTime);
+    return new MergeSplitClipsCommand(this.leftClipId!, this.rightClipId!, this.originalClip, this.frameRate, this.splitTime, this.originalClipIndex);
   }
 
   toJSON(): Record<string, any> {
@@ -150,6 +152,7 @@ export class SplitClipCommand implements Command {
       // Serialize both new IDs
       leftClipId: this.leftClipId,
       rightClipId: this.rightClipId,
+      originalClipIndex: this.originalClipIndex,
       // Keep newClipId for backward compatibility with old saved projects
       newClipId: this.rightClipId,
     };
@@ -170,6 +173,7 @@ export class SplitClipCommand implements Command {
       cmd.leftClipId = data.clipId; // Original ID for left (old behavior)
       cmd.rightClipId = data.newClipId;
     }
+    cmd.originalClipIndex = data.originalClipIndex ?? -1;
 
     return cmd;
   }
@@ -193,6 +197,7 @@ class MergeSplitClipsCommand implements Command {
     private readonly frameRate: number = 30,
     // TL-BUG-002 fix: Store the exact split time for correct invert()
     private readonly splitTime?: number,
+    private readonly originalClipIndex: number = -1,
   ) {
     this.id = generateCommandId();
     this.label = "Merge Split Clips";
@@ -201,9 +206,14 @@ class MergeSplitClipsCommand implements Command {
 
   apply(state: TimelineState): TimelineState {
     // Remove BOTH split clips and restore original
+    const clips = state.clips.filter((c) => c.id !== this.leftClipId && c.id !== this.rightClipId);
+    const insertIndex = this.originalClipIndex >= 0
+      ? Math.min(this.originalClipIndex, clips.length)
+      : clips.length;
+    clips.splice(insertIndex, 0, this.originalClip);
     return {
       ...state,
-      clips: [...state.clips.filter((c) => c.id !== this.leftClipId && c.id !== this.rightClipId), this.originalClip],
+      clips,
       epoch: state.epoch + 1, // ✅ Epoch increment inside command
     };
   }
@@ -227,10 +237,11 @@ class MergeSplitClipsCommand implements Command {
       frameRate: this.frameRate,
       // TL-BUG-002 fix: Serialize splitTime for correct deserialized invert()
       splitTime: this.splitTime,
+      originalClipIndex: this.originalClipIndex,
     };
   }
 
   static fromJSON(data: Record<string, any>): MergeSplitClipsCommand {
-    return new MergeSplitClipsCommand(data.leftClipId, data.rightClipId, data.originalClip, data.frameRate || 30, data.splitTime);
+    return new MergeSplitClipsCommand(data.leftClipId, data.rightClipId, data.originalClip, data.frameRate || 30, data.splitTime, data.originalClipIndex ?? -1);
   }
 }

--- a/src/core/history/commands/SwapClipsCommand.ts
+++ b/src/core/history/commands/SwapClipsCommand.ts
@@ -65,6 +65,19 @@ export class SwapClipsCommand implements Command {
         return (right.startTime < end && right.startTime + left.duration > clip.startTime) || (left.startTime < end && left.startTime + right.duration > clip.startTime);
       });
       if (collision) return "Not enough space to swap — clips would overlap";
+    } else {
+      const collision = state.clips.some((clip) => {
+        if (clip.id === clipA.id || clip.id === clipB.id) return false;
+        const clipEnd = clip.startTime + clip.duration;
+        const aInDestination = clip.trackId === clipB.trackId &&
+          clipB.startTime < clipEnd &&
+          clipB.startTime + clipA.duration > clip.startTime;
+        const bInDestination = clip.trackId === clipA.trackId &&
+          clipA.startTime < clipEnd &&
+          clipA.startTime + clipB.duration > clip.startTime;
+        return aInDestination || bInDestination;
+      });
+      if (collision) return "Not enough space to swap — clips would overlap";
     }
     return null;
   }

--- a/src/core/history/commands/TimelineDragCommand.ts
+++ b/src/core/history/commands/TimelineDragCommand.ts
@@ -113,6 +113,12 @@ export function buildTimelineDragResult(input: BuildTimelineDragResultInput): Ti
   if (!state.clips.some((item) => item.id === clip.id) || drag.draggedClipIds.length === 0 || drag.draggedClipIds.some((id) => !state.clips.some((item) => item.id === id))) {
     return null;
   }
+  // A multi-clip drag must be atomic: a locked source clip cannot be moved
+  // indirectly because it was selected together with an unlocked clip.
+  const draggedClips = state.clips.filter((item) => drag.draggedClipIds.includes(item.id));
+  if (draggedClips.some((item) => state.tracks.find((track) => track.id === item.trackId)?.locked)) {
+    return null;
+  }
   const sourceTrackIds = new Set(Object.values(drag.originalPlacements).map((placement) => placement.trackId));
   const affectedTrackIds = new Set(sourceTrackIds);
   const updates = new Map<string, Partial<Clip>>();

--- a/src/core/history/commands/__tests__/CompoundClipCommands.test.ts
+++ b/src/core/history/commands/__tests__/CompoundClipCommands.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import type { Clip, Track } from "@/types";
 import { GroupClipsCommand, UngroupClipsCommand, validateGroupSelection } from "../CompoundClipCommands";
 import { expandCompoundClips } from "@/core/timeline/compoundClips";
+import type { Gap } from "@/types/gap";
 
 const track: Track = { id: "track-v", type: "video", name: "Video", muted: false, locked: false, visible: true, height: 80 };
 const makeClip = (id: string, startTime: number, duration: number): Clip => ({
@@ -12,13 +13,18 @@ const makeClip = (id: string, startTime: number, duration: number): Clip => ({
 describe("CompoundClipCommands", () => {
   it("preserves same-track timing gaps and expands recursively", () => {
     const clips = [makeClip("a", 2, 3), makeClip("b", 8, 2)];
+    const internalGap: Gap = { id: "internal-gap", trackId: track.id, startTime: 5, duration: 3, type: "auto", source: "clip-delete", protected: false };
     const command = new GroupClipsCommand(["a", "b"], clips, [track]);
-    const grouped = command.apply({ tracks: [track], clips, epoch: 0 });
+    const grouped = command.apply({ tracks: [track], clips, gaps: [internalGap], epoch: 0 });
     const parent = grouped.clips[0];
 
     expect(parent).toMatchObject({ kind: "compound", startTime: 2, duration: 8 });
     expect(parent.compoundChildren?.map((child) => child.startTime)).toEqual([0, 6]);
     expect(expandCompoundClips(grouped.clips).map((clip) => [clip.id, clip.startTime])).toEqual([["a", 2], ["b", 8]]);
+    expect(grouped.gaps).toEqual([]);
+
+    const restored = command.invert().apply(grouped);
+    expect(restored.gaps).toEqual([internalGap]);
   });
 
   it("restores exact child and parent IDs through undo/redo", () => {

--- a/src/core/history/commands/__tests__/SplitClipCommand.test.ts
+++ b/src/core/history/commands/__tests__/SplitClipCommand.test.ts
@@ -55,6 +55,18 @@ describe("SplitClipCommand", () => {
       expect(newState.clips.find((c) => c.id === "clip-1")).toBeUndefined();
     });
 
+    it("restores a middle clip to its original array position on undo", () => {
+      const before = createTestClip({ id: "before", startTime: 0, duration: 2, trimOut: 2 });
+      const middle = createTestClip({ id: "middle", startTime: 2, duration: 6, trimOut: 6 });
+      const after = createTestClip({ id: "after", startTime: 8, duration: 2, trimIn: 6, trimOut: 8 });
+      const command = new SplitClipCommand("middle", 5, 30, middle);
+
+      const split = command.apply({ clips: [before, middle, after], epoch: 0 });
+      const restored = command.invert().apply(split);
+
+      expect(restored.clips.map((clip: Clip) => clip.id)).toEqual(["before", "middle", "after"]);
+    });
+
     it("sets trimOut correctly on left clip", () => {
       const clip = createTestClip({
         startTime: 0,

--- a/src/core/history/commands/__tests__/SwapClipsCommand.test.ts
+++ b/src/core/history/commands/__tests__/SwapClipsCommand.test.ts
@@ -37,4 +37,20 @@ describe("SwapClipsCommand", () => {
     const state: { tracks: Track[]; clips: Clip[]; transitions: []; epoch: number } = { tracks: [track], clips: [makeClip("a", 0, 2), makeClip("b", 12, 10), makeClip("c", 2, 10)], transitions: [], epoch: 0 };
     expect(SwapClipsCommand.validate(state, "a", "b")).toContain("overlap");
   });
+
+  it("rejects a cross-track swap that would overlap a destination neighbor", () => {
+    const otherTrack: Track = { ...track, id: "track-2", name: "Video 2" };
+    const a = { ...makeClip("a", 0, 10), trackId: track.id };
+    const b = { ...makeClip("b", 0, 20), trackId: otherTrack.id };
+    const neighborOnA = { ...makeClip("neighbor-a", 10, 5), trackId: track.id };
+    const neighborOnB = { ...makeClip("neighbor-b", 20, 5), trackId: otherTrack.id };
+    const state: { tracks: Track[]; clips: Clip[]; transitions: []; epoch: number } = {
+      tracks: [track, otherTrack],
+      clips: [a, b, neighborOnA, neighborOnB],
+      transitions: [],
+      epoch: 0,
+    };
+
+    expect(SwapClipsCommand.validate(state, "a", "b")).toContain("overlap");
+  });
 });

--- a/src/core/history/commands/__tests__/TimelineDragCommand.test.ts
+++ b/src/core/history/commands/__tests__/TimelineDragCommand.test.ts
@@ -122,6 +122,36 @@ describe("TimelineDragCommand", () => {
     })).toBeNull();
   });
 
+  it("rejects a mixed selection when any source track is locked", () => {
+    const source = track("source");
+    const lockedSource = { ...track("locked-source"), locked: true };
+    const movable = clip("movable", "source", 0, 2);
+    const lockedClip = clip("locked", "locked-source", 0, 2);
+    const state = {
+      tracks: [source, lockedSource],
+      clips: [movable, lockedClip],
+      gaps: [] as Gap[],
+      mainVideoTrackId: "source",
+      epoch: 0,
+    };
+
+    expect(buildTimelineDragCommand({
+      state,
+      drag: drag({
+        draggingClipId: "movable",
+        draggedClipIds: ["movable", "locked"],
+        originalPlacements: {
+          movable: { trackId: "source", startTime: 0, index: 0 },
+          locked: { trackId: "locked-source", startTime: 0, index: 0 },
+        },
+      }),
+      clip: movable,
+      snapEnabled: false,
+      currentTime: 0,
+      pixelsPerSecond: 100,
+    })).toBeNull();
+  });
+
   it("preserves unrelated empty tracks and supports existing-track moves", () => {
     const source = track("source");
     const target = track("target", "audio");

--- a/src/core/interactions/__tests__/EditingActions.test.ts
+++ b/src/core/interactions/__tests__/EditingActions.test.ts
@@ -156,4 +156,24 @@ describe("EditingActions split interactions", () => {
     EditingActions.deleteSelection(["left"], true);
     expect(useTimelineStore.getState().clips.find((clip) => clip.id === "right")?.startTime).toBe(5);
   });
+
+  it("restores lift-deleted clip order and gaps on undo", () => {
+    useTimelineStore.setState({
+      clips: [
+        makeClip({ id: "left", startTime: 0, duration: 5, trimOut: 5 }),
+        makeClip({ id: "middle", startTime: 5, duration: 5, trimIn: 5, trimOut: 10 }),
+        makeClip({ id: "right", startTime: 10, duration: 5, trimIn: 10, trimOut: 15 }),
+      ],
+      gaps: [],
+    });
+
+    EditingActions.deleteSelection(["middle"], true);
+    expect(useTimelineStore.getState().gaps).toHaveLength(1);
+
+    useHistoryStore.getState().undo();
+
+    const restored = useTimelineStore.getState();
+    expect(restored.clips.map((clip) => clip.id)).toEqual(["left", "middle", "right"]);
+    expect(restored.gaps).toEqual([]);
+  });
 });

--- a/src/core/playback/nativePerfTelemetry.ts
+++ b/src/core/playback/nativePerfTelemetry.ts
@@ -1,0 +1,210 @@
+import type { NativeFrameRequest, NativePreviewMode } from "@/lib/platform/nativeCore";
+
+export interface NativeFrontendPerfSample {
+  requestId: string;
+  generation?: number;
+  frameIndex: number;
+  mode: NativePreviewMode;
+  dispatchMs: number;
+  ipcMs: number;
+  canvasPaintMs?: number;
+  totalMs: number;
+  dropped: boolean;
+  stale: boolean;
+  cancelled: boolean;
+}
+
+export interface NativeFrontendStagePercentiles {
+  p50: number | null;
+  p95: number | null;
+  p99: number | null;
+  sampleCount: number;
+}
+
+export interface NativeFrontendModeStats {
+  mode: NativePreviewMode;
+  dispatch: NativeFrontendStagePercentiles;
+  ipc: NativeFrontendStagePercentiles;
+  canvasPaint: NativeFrontendStagePercentiles;
+  total: NativeFrontendStagePercentiles;
+  droppedCount: number;
+  staleCount: number;
+  cancelledCount: number;
+}
+
+const TRACE_STORAGE_KEY = "clypra:debug:native-perf";
+const RING_CAPACITY = 600;
+
+function readTraceFlag(): boolean {
+  try {
+    return typeof localStorage !== "undefined" && localStorage.getItem(TRACE_STORAGE_KEY) === "1";
+  } catch {
+    return false;
+  }
+}
+
+function percentile(values: number[], pct: number): number | null {
+  if (values.length === 0) return null;
+  values.sort((left, right) => left - right);
+  return values[Math.round((values.length - 1) * pct)] ?? null;
+}
+
+function stagePercentiles(
+  samples: readonly NativeFrontendPerfSample[],
+  pick: (sample: NativeFrontendPerfSample) => number | undefined,
+): NativeFrontendStagePercentiles {
+  const values = samples
+    .map(pick)
+    .filter((value): value is number => value !== undefined && Number.isFinite(value));
+  return {
+    p50: percentile(values, 0.5),
+    p95: percentile(values, 0.95),
+    p99: percentile(values, 0.99),
+    sampleCount: values.length,
+  };
+}
+
+export class NativePerfSpan {
+  private readonly startedAt = performance.now();
+  private dispatchStartedAt = this.startedAt;
+  private ipcStartedAt: number | null = null;
+  private ipcMs = 0;
+  private finished = false;
+
+  constructor(
+    private readonly collector: NativePerfCollector,
+    private readonly request: NativeFrameRequest,
+    private readonly mode: NativePreviewMode,
+  ) {}
+
+  markDispatchStarted(): void {
+    if (this.finished) return;
+    this.dispatchStartedAt = performance.now();
+  }
+
+  markIpcStarted(): void {
+    if (this.finished) return;
+    this.ipcStartedAt = performance.now();
+  }
+
+  markIpcFinished(): void {
+    if (this.finished || this.ipcStartedAt === null) return;
+    this.ipcMs += Math.max(0, performance.now() - this.ipcStartedAt);
+    this.ipcStartedAt = null;
+  }
+
+  finish(options: {
+    canvasPaintMs?: number;
+    dropped?: boolean;
+    stale?: boolean;
+    cancelled?: boolean;
+  } = {}): void {
+    if (this.finished) return;
+    this.markIpcFinished();
+    this.finished = true;
+    this.collector.record({
+      requestId: this.request.requestId,
+      generation: this.request.generation,
+      frameIndex: this.request.frameTime.frameIndex,
+      mode: this.mode,
+      dispatchMs: Math.max(0, this.dispatchStartedAt - this.startedAt),
+      ipcMs: this.ipcMs,
+      canvasPaintMs: options.canvasPaintMs,
+      totalMs: Math.max(0, performance.now() - this.startedAt),
+      dropped: options.dropped === true,
+      stale: options.stale === true,
+      cancelled: options.cancelled === true,
+    });
+  }
+}
+
+class NativePerfCollector {
+  private readonly samples = new Map<NativePreviewMode, NativeFrontendPerfSample[]>();
+  private enabled = readTraceFlag();
+
+  constructor() {
+    for (const mode of [
+      "playback",
+      "playback-lookahead",
+      "seek",
+      "scrub",
+      "frame-step",
+      "prefetch",
+    ] as NativePreviewMode[]) {
+      this.samples.set(mode, []);
+    }
+  }
+
+  setEnabled(enabled: boolean): void {
+    this.enabled = enabled;
+    if (enabled) this.clear();
+  }
+
+  isEnabled(): boolean {
+    return this.enabled;
+  }
+
+  begin(request: NativeFrameRequest): NativePerfSpan {
+    return new NativePerfSpan(this, request, normalizeMode(request.mode));
+  }
+
+  record(sample: NativeFrontendPerfSample): void {
+    if (!this.enabled) return;
+    const bucket = this.samples.get(sample.mode);
+    if (!bucket) return;
+    bucket.push(sample);
+    if (bucket.length > RING_CAPACITY) bucket.shift();
+  }
+
+  statsFor(mode: NativePreviewMode): NativeFrontendModeStats {
+    const samples = this.samples.get(mode) ?? [];
+    return {
+      mode,
+      dispatch: stagePercentiles(samples, (sample) => sample.dispatchMs),
+      ipc: stagePercentiles(samples, (sample) => sample.ipcMs),
+      canvasPaint: stagePercentiles(samples, (sample) => sample.canvasPaintMs),
+      total: stagePercentiles(samples, (sample) => sample.totalMs),
+      droppedCount: samples.filter((sample) => sample.dropped).length,
+      staleCount: samples.filter((sample) => sample.stale).length,
+      cancelledCount: samples.filter((sample) => sample.cancelled).length,
+    };
+  }
+
+  allStats(): NativeFrontendModeStats[] {
+    return [
+      "playback",
+      "playback-lookahead",
+      "seek",
+      "scrub",
+      "frame-step",
+      "prefetch",
+    ].map((mode) => this.statsFor(mode as NativePreviewMode));
+  }
+
+  dump(mode?: NativePreviewMode): NativeFrontendPerfSample[] {
+    if (mode) return [...(this.samples.get(mode) ?? [])];
+    return [...this.samples.values()].flatMap((bucket) => bucket);
+  }
+
+  clear(): void {
+    for (const bucket of this.samples.values()) bucket.length = 0;
+  }
+}
+
+function normalizeMode(mode: NativeFrameRequest["mode"]): NativePreviewMode {
+  if (mode === "frameStep") return "frame-step";
+  return mode ?? "seek";
+}
+
+export const nativePerfCollector = new NativePerfCollector();
+
+export function setNativePerfTraceEnabled(enabled: boolean): void {
+  try {
+    if (typeof localStorage !== "undefined") {
+      localStorage.setItem(TRACE_STORAGE_KEY, enabled ? "1" : "0");
+    }
+  } catch {
+    // The in-memory flag still controls collection when storage is unavailable.
+  }
+  nativePerfCollector.setEnabled(enabled);
+}

--- a/src/hooks/timeline/useTimelineDrag.ts
+++ b/src/hooks/timeline/useTimelineDrag.ts
@@ -260,10 +260,20 @@ export function useTimelineDrag(containerRef: RefObject<HTMLDivElement | null>) 
     (clipId: string, startX: number, startY: number, pointerOffsetFromLeft?: number) => {
       const clip = clipMapRef.current.get(clipId);
       if (!clip) return;
-      pause();
-      suspendAutoSave();
       const selectedClipIds = useUIStore.getState().selectedClipIds;
       const draggedClipIds = selectedClipIds.includes(clipId) ? selectedClipIds : [clipId];
+      const timelineState = useTimelineStore.getState();
+      const hasLockedSourceClip = draggedClipIds.some((draggedId) => {
+        const dragged = clipMapRef.current.get(draggedId);
+        return timelineState.tracks.find((track) => track.id === dragged?.trackId)?.locked ?? false;
+      });
+
+      // A multi-selection is one atomic drag. Do not allow an unlocked clip
+      // to carry a locked clip along with it.
+      if (hasLockedSourceClip) return;
+
+      pause();
+      suspendAutoSave();
 
       // Find clip's index in its track
       const trackClips = trackClipsMapRef.current.get(clip.trackId) ?? [];

--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -340,9 +340,14 @@ export const useKeyboardShortcuts = () => {
         }
 
         const store = useTimelineStore.getState();
+        const trackBefore = store.tracks.find((track) => track.id === selectedTrackId);
+        if (trackBefore?.locked) {
+          toast.info("Unlock the track before changing mute");
+          return;
+        }
         store.toggleTrackMute(selectedTrackId);
 
-        const track = store.tracks.find((t) => t.id === selectedTrackId);
+        const track = useTimelineStore.getState().tracks.find((t) => t.id === selectedTrackId);
         toast.info(track?.muted ? "Track muted" : "Track unmuted");
       } else if (isMeta && e.altKey && e.key.toLowerCase() === "p") {
         e.preventDefault();

--- a/src/lib/platform/nativeCore.ts
+++ b/src/lib/platform/nativeCore.ts
@@ -75,7 +75,7 @@ export interface NativePerformanceSample {
   bytesTransferred: number;
   cacheHit: boolean;
   generation?: number;
-  mode?: "playback" | "scrub" | "seek" | "frameStep";
+  mode?: NativePreviewMode;
   quality?: NativeQualityTier;
   strategy?: "HOT" | "WARM" | "COLD";
   cancelled?: boolean;
@@ -85,6 +85,49 @@ export interface NativePerformanceSample {
   conversionTimeUs?: number;
   uploadTimeUs?: number;
   presentTimeUs?: number;
+  decodeUs?: number;
+  conversionUploadUs?: number;
+  composeUs?: number;
+  readbackUs?: number;
+  presentUs?: number;
+  schedulerWaitUs?: number;
+  ipcWaitUs?: number;
+  decoderMutexWaitUs?: number;
+  gpuQueueWaitUs?: number;
+  surfaceAcquireUs?: number;
+  submitPresentUs?: number;
+}
+
+export type NativePreviewMode =
+  | "playback"
+  | "playback-lookahead"
+  | "seek"
+  | "scrub"
+  | "frame-step"
+  | "prefetch";
+
+export interface NativeStagePercentiles {
+  p50: number | null;
+  p95: number | null;
+  p99: number | null;
+  sampleCount: number;
+}
+
+export interface NativeModeStats {
+  mode: NativePreviewMode;
+  decode: NativeStagePercentiles;
+  conversionUpload: NativeStagePercentiles;
+  compose: NativeStagePercentiles;
+  readback: NativeStagePercentiles;
+  present: NativeStagePercentiles;
+  schedulerWait: NativeStagePercentiles;
+  ipcWait: NativeStagePercentiles;
+  decoderMutexWait: NativeStagePercentiles;
+  gpuQueueWait: NativeStagePercentiles;
+  surfaceAcquire: NativeStagePercentiles;
+  submitPresent: NativeStagePercentiles;
+  droppedCount: number;
+  staleCount: number;
 }
 
 export interface NativeFrameServiceStats {
@@ -103,6 +146,7 @@ export interface NativeFrameServiceStats {
   windowSeekP95Ms?: number;
   windowSeekP99Ms?: number;
   windowCacheHitRate?: number;
+  modeStats?: NativeModeStats[];
 }
 
 export const NATIVE_PLAYBACK_POLICY = {

--- a/src/store/__tests__/timelineStore.lockedMute.test.ts
+++ b/src/store/__tests__/timelineStore.lockedMute.test.ts
@@ -1,0 +1,50 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { useTimelineStore } from "../timelineStore";
+
+describe("Timeline Store - Locked Track Mute", () => {
+  beforeEach(() => {
+    useTimelineStore.setState({
+      tracks: [
+        {
+          id: "unlocked-track",
+          type: "video",
+          name: "Unlocked",
+          muted: false,
+          locked: false,
+          visible: true,
+          height: 68,
+        },
+        {
+          id: "locked-track",
+          type: "video",
+          name: "Locked",
+          muted: false,
+          locked: true,
+          visible: true,
+          height: 68,
+        },
+      ],
+      clips: [],
+      transitions: [],
+      gaps: [],
+      epoch: 0,
+    } as any);
+  });
+
+  it("does not change mute state or epoch on a locked track", () => {
+    const store = useTimelineStore.getState();
+
+    store.toggleTrackMute("locked-track");
+
+    const lockedTrack = useTimelineStore.getState().tracks.find((track) => track.id === "locked-track")!;
+    expect(lockedTrack.muted).toBe(false);
+    expect(useTimelineStore.getState().epoch).toBe(0);
+  });
+
+  it("still toggles mute on an unlocked track", () => {
+    useTimelineStore.getState().toggleTrackMute("unlocked-track");
+
+    expect(useTimelineStore.getState().tracks.find((track) => track.id === "unlocked-track")?.muted).toBe(true);
+    expect(useTimelineStore.getState().epoch).toBe(1);
+  });
+});

--- a/src/store/__tests__/timelineStore.swap.test.ts
+++ b/src/store/__tests__/timelineStore.swap.test.ts
@@ -1,0 +1,37 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { useTimelineStore } from "../timelineStore";
+import { useUIStore } from "../uiStore";
+
+describe("Timeline Store - Cross-Track Swap", () => {
+  beforeEach(() => {
+    useTimelineStore.setState({
+      tracks: [
+        { id: "track-a", type: "video", name: "A", muted: false, locked: false, visible: true, height: 68 },
+        { id: "track-b", type: "video", name: "B", muted: false, locked: false, visible: true, height: 68 },
+      ],
+      clips: [
+        { id: "clip-a", trackId: "track-a", mediaId: "a", startTime: 0, duration: 10, trimIn: 0, trimOut: 10 },
+        { id: "clip-b", trackId: "track-b", mediaId: "b", startTime: 0, duration: 20, trimIn: 0, trimOut: 20 },
+        { id: "neighbor-a", trackId: "track-a", mediaId: "neighbor-a", startTime: 10, duration: 5, trimIn: 0, trimOut: 5 },
+        { id: "neighbor-b", trackId: "track-b", mediaId: "neighbor-b", startTime: 20, duration: 5, trimIn: 0, trimOut: 5 },
+      ],
+      transitions: [],
+      gaps: [],
+      epoch: 0,
+    } as any);
+    useUIStore.setState({ selectedClipIds: ["clip-a", "clip-b"] });
+  });
+
+  it("rejects a cross-track swap that would overlap a neighbor", () => {
+    const result = useTimelineStore.getState().swapClips();
+
+    expect(result.error).toContain("overlap");
+    expect(useTimelineStore.getState().clips.map((clip) => [clip.id, clip.trackId, clip.startTime])).toEqual([
+      ["clip-a", "track-a", 0],
+      ["clip-b", "track-b", 0],
+      ["neighbor-a", "track-a", 10],
+      ["neighbor-b", "track-b", 20],
+    ]);
+    expect(useTimelineStore.getState().epoch).toBe(0);
+  });
+});

--- a/src/store/timelineStore.ts
+++ b/src/store/timelineStore.ts
@@ -417,6 +417,8 @@ export const useTimelineStore = create<TimelineStore>(
     // HIDDEN-006 fix: toggleTrackMute and toggleTrackVisibility now increment epoch
     // so the evaluation cache is invalidated and the render pipeline sees the change.
     toggleTrackMute: (trackId) => {
+      if (get().tracks.find((track) => track.id === trackId)?.locked) return;
+
       set((state) => {
         const next: Partial<TimelineStore> = {
           tracks: state.tracks.map((track) => (track.id === trackId ? { ...track, muted: !track.muted } : track)),

--- a/src/store/timelineStore.ts
+++ b/src/store/timelineStore.ts
@@ -877,6 +877,22 @@ export const useTimelineStore = create<TimelineStore>(
 
       // Case: different tracks — simple position + track swap
       if (clipA.trackId !== clipB.trackId) {
+        const collision = state.clips.some((clip) => {
+          if (clip.id === clipA.id || clip.id === clipB.id) return false;
+          const clipEnd = clip.startTime + clip.duration;
+          const clipAOverlapsDestination = clip.trackId === clipB.trackId &&
+            clipB.startTime < clipEnd &&
+            clipB.startTime + clipA.duration > clip.startTime;
+          const clipBOverlapsDestination = clip.trackId === clipA.trackId &&
+            clipA.startTime < clipEnd &&
+            clipA.startTime + clipB.duration > clip.startTime;
+          return clipAOverlapsDestination || clipBOverlapsDestination;
+        });
+
+        if (collision) {
+          return { error: "Not enough space to swap — clips would overlap" };
+        }
+
         set((state) => {
           // TL-04 fix: Remove transitions that would bridge different tracks after swap
           const updatedTransitions = state.transitions.filter((t) => {


### PR DESCRIPTION
## Clypra v1.4.4

### 🛠️ Timeline Editing Fixes
- Trim undo now restores clip order, positions, and gaps atomically
- Ripple-left trim no longer creates a gap between clips
- Stale redo history is cleared when a new transaction is committed
- Mixed locked/unlocked multi-select drag is rejected before drag begins
- Locked tracks can no longer be muted through any input path
- Cross-track swap validates destination overlap before committing
- Lift-delete undo restores original clip array order and gap state
- Grouping removes stale gaps inside the compound span; undo restores exact gap list
- Split undo restores original middle-clip array order

### ⚡ Native Preview Performance
- Per-stage timing instrumentation: decode, decoder mutex wait, conversion/upload, composition, GPU readback, surface acquire, submit/present
- Mode-partition- Mode-partition- Mode-partition- Mode-partition- Mode-partition- Mode-partition- Mode-partition- Mode-partition- ed- Mode-partition- Mode-partiic- Mode-parocking t- Mode-partition- Mode-pso instrumentation never delays presentation
- Frontend dispatch/IPC/canvas-paint span collector with bounded ring buffer
- Correct cache-hit rate reporting

### ��### ��### ��### ��### ��### ��### ��### ��### ��### ��### ��### �tig### ��### ��### ��### ��### ��### ��### ��### ��### ��### ��### ��### �hi### ��### ��### ��### ��### ��### ��### ��### ��### ��### ��dated with stage timing semantics and Rust/browser clock correlation rules