### PR TITLE
fix(ci): sync package-lock with noto-emoji and update fixtures to contract v2

### DIFF
--- a/crates/clypra-native-cli/fixtures/minimal-request.json
+++ b/crates/clypra-native-cli/fixtures/minimal-request.json
@@ -1,5 +1,5 @@
 {
-  "contractVersion": 1,
+  "contractVersion": 2,
   "requestId": "fixture:minimal:0",
   "frameTime": {
     "frameIndex": 0,

--- a/crates/clypra-native-cli/fixtures/raster-request.json
+++ b/crates/clypra-native-cli/fixtures/raster-request.json
@@ -1,5 +1,5 @@
 {
-  "contractVersion": 1,
+  "contractVersion": 2,
   "requestId": "fixture:raster:0",
   "frameTime": { "frameIndex": 0, "ticks": 0, "timescale": 1000000 },
   "project": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
         "@fontsource/bangers": "^5.2.8",
         "@fontsource/bebas-neue": "^5.2.7",
         "@fontsource/lato": "^5.2.7",
+        "@fontsource/noto-emoji": "5.3.0",
         "@fontsource/pacifico": "^5.2.7",
         "@fontsource/permanent-marker": "^5.2.7",
         "@fontsource/poppins": "^5.2.7",
@@ -1691,6 +1692,15 @@
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/@fontsource/lato/-/lato-5.3.0.tgz",
       "integrity": "sha512-0WhF/4rhrw+ErIyneKvhHn2YAl+xf8GDtllgOgOzDmeaSlLQtjpChXaQOpWhG2BchQW0WJy2zLV12Hdg0ndOMw==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@fontsource/noto-emoji": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@fontsource/noto-emoji/-/noto-emoji-5.3.0.tgz",
+      "integrity": "sha512-y/aOmKKsVYi91vu3jwcrcyFN6Q80YV8UG9U5KGbV+Fxmfxr2lzSRmDkGSLaTdHPjJI+niiknSFixL+x7ti6gNg==",
       "license": "OFL-1.1",
       "funding": {
         "url": "https://github.com/sponsors/ayuhito"


### PR DESCRIPTION
### Fixes
- Synchronized `package-lock.json` with `@fontsource/noto-emoji@5.3.0` so `npm ci` succeeds in GitHub Actions CI and Release workflows.
- Updated `crates/clypra-native-cli/fixtures/{minimal,raster}-request.json` to `contractVersion: 2` matching the v2 native core contract, resolving Native Golden render failure.