### PR TITLE
fix(ci): sync package-lock.json to @clypra-studio/engine@1.7.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@capacitor/core": "^8.4.0",
         "@capacitor/filesystem": "^8.1.2",
         "@capacitor/share": "^8.0.1",
-        "@clypra-studio/engine": "1.6.0",
+        "@clypra-studio/engine": "1.7.0",
         "@clypra-studio/shaders": "0.1.5",
         "@clypra/ui-color-picker": "0.2.1",
         "@fontsource-variable/dancing-script": "^5.2.8",
@@ -718,9 +718,9 @@
       "license": "ISC"
     },
     "node_modules/@clypra-studio/engine": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@clypra-studio/engine/-/engine-1.6.0.tgz",
-      "integrity": "sha512-pbxuQlVJfI5nCamEK6uiJniKINWzNi1R4w18PkgJZfNPtoEDSCZTYfMgIOojm9rOBjyI8suUptLX16i2e8Blsw==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@clypra-studio/engine/-/engine-1.7.0.tgz",
+      "integrity": "sha512-xF1LMj6+5hsnO+ilEygSnc21uFeHyNNBYz4xJlFJ4Gm3z78nwPQmOFPntH0U9oJA82Phuiw/Pjgt8U+wnT2hIw==",
       "license": "MIT",
       "dependencies": {
         "@clypra-studio/shaders": "^0.1.5",


### PR DESCRIPTION
CI was failing with: `lock file's @clypra-studio/engine@1.6.0 does not satisfy @clypra-studio/engine@1.7.0`

`package.json` was bumped to 1.7.0 in PR #280 but `package-lock.json` was not regenerated alongside it, causing `npm ci` to reject the install on every CI run.

**Fix**: ran `npm install --package-lock-only` to update only the lock file — resolved entry and integrity hash now point to 1.7.0. No other dependency changes.