### PR TITLE
fix: restore text effect styling and decoder forward-window

### DIFF
--- a/src-tauri/src/thumbnail_engine/decoder.rs
+++ b/src-tauri/src/thumbnail_engine/decoder.rs
@@ -319,15 +319,13 @@ impl DecoderState {
         }
 
         let distance = target_pts - self.current_pts;
-        if distance > sequential_window {
-            return false;
-        }
+        let max_distance = if self.sequential_hits >= 3 {
+            sequential_window * 2
+        } else {
+            sequential_window
+        };
 
-        if self.sequential_hits >= 3 {
-            return distance <= sequential_window * 2;
-        }
-
-        true
+        distance <= max_distance
     }
 
     fn update_sequential(&mut self, target_pts: i64) {

--- a/src/components/editor/sidebar/tabs/TextTab.tsx
+++ b/src/components/editor/sidebar/tabs/TextTab.tsx
@@ -489,6 +489,7 @@ export const TextTab: React.FC<TabProps> = ({ onAddToTimeline }) => {
           completeDownload(itemId, type);
           onAddToTimeline?.(
             {
+              id: fullEffect.id,
               name: fullEffect.name,
               text: fullEffect.text || "CLYPRA",
               presetType: "effect",
@@ -531,6 +532,7 @@ export const TextTab: React.FC<TabProps> = ({ onAddToTimeline }) => {
         const targetEffect: any = cachedEffect || item;
         onAddToTimeline?.(
           {
+            id: targetEffect.id,
             name: targetEffect.name,
             text: targetEffect.text || "CLYPRA",
             presetType: "effect",
@@ -585,6 +587,7 @@ export const TextTab: React.FC<TabProps> = ({ onAddToTimeline }) => {
   const handleNewEffectApply = (text: string, effect: any) => {
     onAddToTimeline?.(
       {
+        id: effect.id,
         name: effect.name,
         text: text || "CLYPRA",
         presetType: "effect",

--- a/src/core/evaluation/evaluator.ts
+++ b/src/core/evaluation/evaluator.ts
@@ -253,7 +253,9 @@ export function evaluateTimelineScene(
                 (catalogStyleDefinition as any)?.name ||
                 textClip.styleId ||
                 "Pinned Text Effect",
-              scene: textClip.styleSnapshot,
+              scene:
+                textClip.styleSnapshot ??
+                (catalogStyleDefinition as any)?.scene,
             } as any)
           : undefined;
       const styleTypography = resolveTextEffectTypography(styleDefinition);

--- a/src/features/text-effects/components/TextEffectGrid.tsx
+++ b/src/features/text-effects/components/TextEffectGrid.tsx
@@ -59,6 +59,7 @@ export function TextEffectGrid({ searchQuery = "", onAddToTimeline }: TextEffect
   const applyEffectToTimeline = useCallback((effect: any) => {
     onAddToTimeline?.(
       {
+        id: effect.id,
         name: effect.name,
         text: effect.text || "CLYPRA",
         presetType: "effect",

--- a/src/lib/timeline/__tests__/placementEngine.test.ts
+++ b/src/lib/timeline/__tests__/placementEngine.test.ts
@@ -115,4 +115,30 @@ describe("TimelinePlacementEngine", () => {
       expect(trackIds.has(clip.trackId)).toBe(true);
     }
   });
+
+  it("preserves styleId, effectDefinition, and styleSnapshot when adding a text effect", async () => {
+    const mockScene = { effectLayers: [{ type: "gradient" }] };
+    const mockDef = { id: "gradient-punch", name: "Gradient Punch", scene: mockScene };
+
+    const res = await TimelinePlacementEngine.addToTimeline({
+      item: {
+        name: "Gradient Punch",
+        text: "CLYPRA",
+        presetType: "effect",
+        styleId: "gradient-punch",
+        styleSnapshot: mockScene,
+        effectDefinition: mockDef,
+      },
+      type: "text",
+    });
+
+    expect(res.success).toBe(true);
+    const clips = useTimelineStore.getState().clips;
+    const clip = clips.find((c) => c.kind === "text") as any;
+    expect(clip).toBeDefined();
+    expect(clip.styleId).toBe("gradient-punch");
+    expect(clip.styleSnapshot).toEqual(mockScene);
+    expect(clip.styleDefinition).toEqual(mockDef);
+    expect(clip.text).toBe("CLYPRA");
+  });
 });

--- a/src/lib/timeline/placementEngine.ts
+++ b/src/lib/timeline/placementEngine.ts
@@ -316,7 +316,7 @@ export class TimelinePlacementEngine {
           if (TEXT_PRESETS[presetName]) presetConfig = TEXT_PRESETS[presetName];
         }
 
-        const styleId = item.presetType === "effect" ? item.id : item.styleId;
+        const styleId = item.styleId ?? (item.presetType === "effect" ? item.id : undefined);
         let effectDefinition = item.effectDefinition;
         if (styleId && !effectDefinition) {
           effectDefinition = resolveTextEffectDefinition(


### PR DESCRIPTION
Fix 1: styleId resolution in placementEngine was broken. Fix 2: decoder forward-window extended range was dead code.