### PR TITLE
chore(release): bump version to 1.4.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clypra",
-  "version": "1.4.5",
+  "version": "1.4.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clypra",
-      "version": "1.4.5",
+      "version": "1.4.6",
       "license": "MIT",
       "dependencies": {
         "@capacitor/core": "^8.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clypra",
-  "version": "1.4.5",
+  "version": "1.4.6",
   "description": "A modern, open-source video editor built with Tauri, React, and TypeScript",
   "author": "Clypra Contributors",
   "license": "MIT",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clypra"
-version = "1.4.5"
+version = "1.4.6"
 description = "A modern, open-source video editor with native performance and GPU-accelerated preview"
 authors = ["Clypra Contributors"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Clypra",
-  "version": "1.4.5",
+  "version": "1.4.6",
   "identifier": "com.clypra.editor",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
Version bump to 1.4.6. Merge this PR then the tag will be pushed.- `package.json` → 1.4.6- `package-lock.json` → 1.4.6- `src-tauri/tauri.conf.json` → 1.4.6- `src-tauri/Cargo.toml` → 1.4.6