### PR TITLE
fix(ci): fix static FFmpeg 8.0 linking for CI and release workflows

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,8 @@
+# Cargo build configuration
+# Automatically configure FFMPEG_DIR and PKG_CONFIG_PATH for builds from project root
+
+[env]
+CMAKE_OSX_DEPLOYMENT_TARGET = "11.0"
+MACOSX_DEPLOYMENT_TARGET = "11.0"
+FFMPEG_DIR = { value = "src-tauri/ffmpeg-static", relative = true }
+PKG_CONFIG_PATH = { value = "src-tauri/ffmpeg-static/lib/pkgconfig", relative = true }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,8 +39,6 @@ jobs:
   test-rust:
     name: Test Rust Backend
     runs-on: ubuntu-latest
-    env:
-      PKG_CONFIG_PATH: /usr/lib/x86_64-linux-gnu/pkgconfig
 
     steps:
       - name: Checkout repository
@@ -49,30 +47,51 @@ jobs:
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
 
-      - name: Install FFmpeg dependencies
+      - name: Install System Dependencies
         run: |
           sudo apt-get update
           sudo apt-get install -y \
-            libavcodec-dev \
-            libavformat-dev \
-            libavutil-dev \
-            libavfilter-dev \
-            libavdevice-dev \
-            libswscale-dev \
-            libswresample-dev \
-            libasound2-dev \
-            libpostproc-dev \
-            libclang-dev \
-            pkg-config \
             libwebkit2gtk-4.1-dev \
-            build-essential \
-            curl \
-            wget \
-            file \
-            libxdo-dev \
-            libssl-dev \
             libayatana-appindicator3-dev \
-            librsvg2-dev
+            librsvg2-dev patchelf xdg-utils \
+            libva-dev \
+            build-essential pkg-config libssl-dev \
+            libclang-dev libxdo-dev cmake \
+            libasound2-dev \
+            curl wget file
+
+      - name: Cache Static FFmpeg (Linux)
+        id: cache-ffmpeg-linux
+        uses: actions/cache@v4
+        with:
+          path: ${{ runner.temp }}/ffmpeg-static
+          key: ffmpeg-8.0-linux-static-v2-x86_64-unknown-linux-gnu
+
+      - name: Build Static FFmpeg (Linux)
+        if: steps.cache-ffmpeg-linux.outputs.cache-hit != 'true'
+        run: |
+          mkdir -p /tmp/ffmpeg-src
+          curl -sL https://ffmpeg.org/releases/ffmpeg-8.0.tar.xz | tar -xJ --strip-components=1 -C /tmp/ffmpeg-src
+          cd /tmp/ffmpeg-src
+          ./configure \
+            --prefix="${{ runner.temp }}/ffmpeg-static" \
+            --enable-static \
+            --disable-shared \
+            --enable-pic \
+            --disable-programs \
+            --disable-doc \
+            --disable-network \
+            --disable-autodetect \
+            --disable-indevs \
+            --disable-outdevs \
+            --enable-vaapi
+          make -j$(nproc) install
+          rm -rf /tmp/ffmpeg-src
+
+      - name: Configure FFmpeg Environment (Linux)
+        run: |
+          echo "FFMPEG_DIR=${{ runner.temp }}/ffmpeg-static" >> $GITHUB_ENV
+          echo "PKG_CONFIG_PATH=${{ runner.temp }}/ffmpeg-static/lib/pkgconfig:/usr/lib/x86_64-linux-gnu/pkgconfig" >> $GITHUB_ENV
 
       - name: Rust cache
         uses: Swatinem/rust-cache@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,12 +40,44 @@ jobs:
             libayatana-appindicator3-dev \
             librsvg2-dev patchelf xdg-utils \
             libva-dev \
-            libavutil-dev libavcodec-dev libavformat-dev \
-            libswscale-dev libswresample-dev \
-            libavdevice-dev libavfilter-dev libpostproc-dev \
             build-essential pkg-config libssl-dev \
             libclang-dev libxdo-dev cmake \
             libasound2-dev
+
+      - name: Cache Static FFmpeg (Linux)
+        if: matrix.platform == 'ubuntu-24.04'
+        id: cache-ffmpeg-linux
+        uses: actions/cache@v4
+        with:
+          path: ${{ runner.temp }}/ffmpeg-static
+          key: ffmpeg-8.0-linux-static-v2-${{ matrix.target }}
+
+      - name: Build Static FFmpeg (Linux)
+        if: matrix.platform == 'ubuntu-24.04' && steps.cache-ffmpeg-linux.outputs.cache-hit != 'true'
+        run: |
+          mkdir -p /tmp/ffmpeg-src
+          curl -sL https://ffmpeg.org/releases/ffmpeg-8.0.tar.xz | tar -xJ --strip-components=1 -C /tmp/ffmpeg-src
+          cd /tmp/ffmpeg-src
+          ./configure \
+            --prefix="${{ runner.temp }}/ffmpeg-static" \
+            --enable-static \
+            --disable-shared \
+            --enable-pic \
+            --disable-programs \
+            --disable-doc \
+            --disable-network \
+            --disable-autodetect \
+            --disable-indevs \
+            --disable-outdevs \
+            --enable-vaapi
+          make -j$(nproc) install
+          rm -rf /tmp/ffmpeg-src
+
+      - name: Configure FFmpeg Environment (Linux)
+        if: matrix.platform == 'ubuntu-24.04'
+        run: |
+          echo "FFMPEG_DIR=${{ runner.temp }}/ffmpeg-static" >> $GITHUB_ENV
+          echo "PKG_CONFIG_PATH=${{ runner.temp }}/ffmpeg-static/lib/pkgconfig:${PKG_CONFIG_PATH:-}" >> $GITHUB_ENV
 
       # ── macOS ──────────────────────────────────────────────────────────────
       # whisper-rs-sys builds ggml via cmake. The only reliable way to set
@@ -54,14 +86,45 @@ jobs:
       # CMAKE_OSX_DEPLOYMENT_TARGET through CARGO_BUILD_TARGET_DIR cmake
       # passthrough. We use a .cargo/config.toml [env] block (committed) to
       # guarantee cmake sees the flag, and also set it here for safety.
-      - name: Install FFmpeg (macOS)
+      - name: Cache Static FFmpeg (macOS)
+        if: matrix.platform == 'macos-latest'
+        id: cache-ffmpeg-macos
+        uses: actions/cache@v4
+        with:
+          path: ${{ runner.temp }}/ffmpeg-static
+          key: ffmpeg-8.0-darwin-static-v2-${{ matrix.target }}
+
+      - name: Build Static FFmpeg (macOS)
+        if: matrix.platform == 'macos-latest' && steps.cache-ffmpeg-macos.outputs.cache-hit != 'true'
+        run: |
+          brew install cmake pkg-config
+          mkdir -p /tmp/ffmpeg-src
+          curl -sL https://ffmpeg.org/releases/ffmpeg-8.0.tar.xz | tar -xJ --strip-components=1 -C /tmp/ffmpeg-src
+          cd /tmp/ffmpeg-src
+          ./configure \
+            --prefix="${{ runner.temp }}/ffmpeg-static" \
+            --enable-static \
+            --disable-shared \
+            --enable-pic \
+            --disable-programs \
+            --disable-doc \
+            --disable-network \
+            --disable-autodetect \
+            --disable-indevs \
+            --disable-outdevs \
+            --enable-videotoolbox \
+            --enable-audiotoolbox \
+            --disable-xlib \
+            --disable-libxcb \
+            --disable-indev=xcbgrab
+          make -j$(sysctl -n hw.ncpu) install
+          rm -rf /tmp/ffmpeg-src
+
+      - name: Configure FFmpeg Environment (macOS)
         if: matrix.platform == 'macos-latest'
         run: |
-          brew install ffmpeg cmake pkg-config
-          BREW_PREFIX=$(brew --prefix)
-          FFMPEG_PREFIX=$(brew --prefix ffmpeg)
-          echo "FFMPEG_DIR=$FFMPEG_PREFIX" >> $GITHUB_ENV
-          echo "PKG_CONFIG_PATH=$FFMPEG_PREFIX/lib/pkgconfig:$BREW_PREFIX/lib/pkgconfig" >> $GITHUB_ENV
+          echo "FFMPEG_DIR=${{ runner.temp }}/ffmpeg-static" >> $GITHUB_ENV
+          echo "PKG_CONFIG_PATH=${{ runner.temp }}/ffmpeg-static/lib/pkgconfig" >> $GITHUB_ENV
           echo "SDKROOT=$(xcrun --sdk macosx --show-sdk-path)" >> $GITHUB_ENV
           echo "MACOSX_DEPLOYMENT_TARGET=11.0" >> $GITHUB_ENV
           echo "CMAKE_OSX_DEPLOYMENT_TARGET=11.0" >> $GITHUB_ENV

--- a/scripts/setup-ffmpeg.sh
+++ b/scripts/setup-ffmpeg.sh
@@ -44,10 +44,16 @@ if [ "$OS" = "Darwin" ]; then
     "--disable-xlib"
     "--disable-libxcb"
     "--disable-indev=xcbgrab"
+    "--disable-autodetect"
+    "--disable-indevs"
+    "--disable-outdevs"
   )
 elif [ "$OS" = "Linux" ]; then
   EXTRA_FLAGS=(
     "--enable-vaapi"
+    "--disable-autodetect"
+    "--disable-indevs"
+    "--disable-outdevs"
   )
 fi
 

--- a/src-tauri/.cargo/config.toml
+++ b/src-tauri/.cargo/config.toml
@@ -10,3 +10,5 @@ MACOSX_DEPLOYMENT_TARGET = "11.0"
 # Automatically configure FFMPEG_DIR for local builds using bundled static FFmpeg libraries.
 # Environment variables set in the shell will override this default if specified.
 FFMPEG_DIR = { value = "ffmpeg-static", relative = true }
+PKG_CONFIG_PATH = { value = "ffmpeg-static/lib/pkgconfig", relative = true }
+

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -645,7 +645,7 @@ dependencies = [
 
 [[package]]
 name = "clypra"
-version = "1.4.6"
+version = "1.4.7"
 dependencies = [
  "base64 0.22.1",
  "bytemuck",


### PR DESCRIPTION
## Summary
- Build static FFmpeg 8.0 on Linux and macOS with `--disable-autodetect`, `--disable-indevs`, and `--disable-outdevs` to eliminate missing hardware input/output device symbols (`-lraw1394`, `-ljack`, `-lopenal`, etc.).
- Replace dynamic Ubuntu `libav*-dev` in `ci.yml` with cached static FFmpeg 8.0 build matching release environment.
- Remove `brew install ffmpeg` from macOS release workflow to prevent dynamic Homebrew dylibs (`x264`, `x265`) from leaking into link flags.
- Automatically set `FFMPEG_DIR` and `PKG_CONFIG_PATH` in `.cargo/config.toml` and `src-tauri/.cargo/config.toml`.