### PR TITLE
feat(v1.4.8): session-file perf logging, single-upload telemetry, and architecture docs

### DIFF
--- a/docs/clypra-runtime-performance-architecture.md
+++ b/docs/clypra-runtime-performance-architecture.md
@@ -67,9 +67,11 @@ Tauri command boundary
 
 All runtimes emit bounded numerical telemetry
         |
+        v  collected into NDJSON session file (perfLogService)
+        |  uploaded as single POST on window close
         v
-clypra-api -> Neon performance_telemetry_events
-        |
+clypra-api -> Neon session_perf_logs (one row per session)
+        |     JSONB expansion at query time feeds analytics engine
         v
 clypra-studio Admin performance pages
 ```
@@ -79,7 +81,7 @@ clypra-studio Admin performance pages
 - editor controls, selection, overlays, property panels, and visual state;
 - user intents such as play, pause, seek, edit, undo, and redo;
 - the WebView editing surface and its DOM hit-testing;
-- bounded client telemetry buffering and asynchronous API upload.
+- bounded client telemetry buffering and session-file accumulation via `perfLogService`.
 
 React does not choose the native playback frame on every display tick and does
 not issue a heavy Tauri command for every native frame.
@@ -99,14 +101,14 @@ core timing machine remains independently testable.
 
 ## 3. Program Preview output contract
 
-| State or operation | Authoritative output | Interaction behavior |
-| --- | --- | --- |
-| Continuous playback | Native child surface | Surface is pointer-transparent; DOM capture plane handles an edit intent |
-| Paused | WebView/DOM canvas | Selection, handles, focus, and accessibility are active |
-| Seeking/scrubbing | WebView/DOM canvas | Latest seek wins; stale responses cannot present |
-| Transform/edit gesture | WebView/DOM canvas plus DOM overlay | Optimistic local movement; one commit on release |
-| Native initialization failure | Existing bounded runtime fallback only | No persistent user mode; failure remains diagnosable |
-| Qualification | Explicit diagnostics workflow | Uses the same snapshot and settings for each path |
+| State or operation            | Authoritative output                   | Interaction behavior                                                     |
+| ----------------------------- | -------------------------------------- | ------------------------------------------------------------------------ |
+| Continuous playback           | Native child surface                   | Surface is pointer-transparent; DOM capture plane handles an edit intent |
+| Paused                        | WebView/DOM canvas                     | Selection, handles, focus, and accessibility are active                  |
+| Seeking/scrubbing             | WebView/DOM canvas                     | Latest seek wins; stale responses cannot present                         |
+| Transform/edit gesture        | WebView/DOM canvas plus DOM overlay    | Optimistic local movement; one commit on release                         |
+| Native initialization failure | Existing bounded runtime fallback only | No persistent user mode; failure remains diagnosable                     |
+| Qualification                 | Explicit diagnostics workflow          | Uses the same snapshot and settings for each path                        |
 
 The Native surface is a retained session resource, not a React component side
 effect. `nativeSurfaceLifecycle` owns configure, resize, presentation ordering,
@@ -354,9 +356,14 @@ continue producing duplicate windows or growing telemetry indefinitely.
 
 ## 8. Telemetry and analysis source of truth
 
-The existing `performance_telemetry_events` table in `clypra-api` remains the
-storage foundation. Events and rollups carry the identity needed to prevent
-cross-path contamination:
+`session_perf_logs` in `clypra-api` is the storage foundation.
+One row per editor session holds the complete NDJSON entry array in an
+`entries` JSONB column plus denormalised summary columns (`os_family`,
+`gpu_vendor`, `app_version`, `received_at`) for fast B-tree-indexed
+dashboard filtering.
+
+Events and rollups carry the identity needed to prevent cross-path
+contamination:
 
 - `sessionId`;
 - `qualificationRunId` when applicable;
@@ -364,8 +371,9 @@ cross-path contamination:
 - `measurementId` for idempotent insertion;
 - frame sequence/sample kind/drop reason/deadline where applicable.
 
-The API accepts batches asynchronously, reports `persisted` and
-`deduplicated`, and uses the unique measurement identity to ignore duplicate
+The API accepts a single session-file upload per session
+(`POST /performance/telemetry/ingest/session`), expands `entries` JSONB at
+query time, and uses the unique measurement identity to ignore duplicate
 logical measurements. Percentiles never mix unrelated measurement sources.
 
 The canonical inspection surfaces are:
@@ -381,14 +389,14 @@ surface.
 
 ### Confidence and SLA policy
 
-| Measurement | Target |
-| --- | ---: |
-| Continuous playback render P95 | <= 16.67 ms |
-| Session dropped-frame ratio | <= 1% |
-| Seek/paused interaction P95 | <= 100 ms |
-| Native present P95 | near zero |
-| Audio callback work P95 | below the device callback budget |
-| Text total render P95 | <= 16.67 ms for the qualified playback cohort |
+| Measurement                    |                                        Target |
+| ------------------------------ | --------------------------------------------: |
+| Continuous playback render P95 |                                   <= 16.67 ms |
+| Session dropped-frame ratio    |                                         <= 1% |
+| Seek/paused interaction P95    |                                     <= 100 ms |
+| Native present P95             |                                     near zero |
+| Audio callback work P95        |              below the device callback budget |
+| Text total render P95          | <= 16.67 ms for the qualified playback cohort |
 
 Confidence is based on measured frames, not API row count:
 
@@ -403,14 +411,14 @@ used as evidence that a qualification run has enough samples.
 
 The following findings are development evidence, not production guarantees:
 
-| Area | Observed evidence | Architectural conclusion |
-| --- | --- | --- |
-| Native preview | Approximately 7–9 ms render P95 in later runs; present cost near zero | Keep Native as the continuous playback path |
-| WebView preview | Transfer/readback observations around 189–242 ms P95; paused interaction also showed large decode tails | Do not unify WebView readback with Native playback |
-| Native audio | Approximately 2.25–2.75 ms callback P95 with zero underruns in observed runs | Audio callback is not the reported text freeze bottleneck in those runs |
-| Text interactive preview | Approximately 91 ms P95 in a small normal-text sample | Text edit/raster path needs coalescing and better warm-cache behavior |
-| Text session prewarm | Approximately 186 ms cold sample with most time in font wait/raster | Pay cold font work at bounded startup/prewarm, not during repeated edits |
-| Text cache behavior | Color, layout, and effect inputs participate in the raster identity | Paint/layout invalidation must remain explicit so visual changes are immediate without redoing unrelated work |
+| Area                     | Observed evidence                                                                                       | Architectural conclusion                                                                                      |
+| ------------------------ | ------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
+| Native preview           | Approximately 7–9 ms render P95 in later runs; present cost near zero                                   | Keep Native as the continuous playback path                                                                   |
+| WebView preview          | Transfer/readback observations around 189–242 ms P95; paused interaction also showed large decode tails | Do not unify WebView readback with Native playback                                                            |
+| Native audio             | Approximately 2.25–2.75 ms callback P95 with zero underruns in observed runs                            | Audio callback is not the reported text freeze bottleneck in those runs                                       |
+| Text interactive preview | Approximately 91 ms P95 in a small normal-text sample                                                   | Text edit/raster path needs coalescing and better warm-cache behavior                                         |
+| Text session prewarm     | Approximately 186 ms cold sample with most time in font wait/raster                                     | Pay cold font work at bounded startup/prewarm, not during repeated edits                                      |
+| Text cache behavior      | Color, layout, and effect inputs participate in the raster identity                                     | Paint/layout invalidation must remain explicit so visual changes are immediate without redoing unrelated work |
 
 Small samples must remain visibly marked as insufficient or preliminary. They
 are useful for finding a bottleneck, but not for declaring a path qualified.

--- a/docs/legacy-retirement-checklist.md
+++ b/docs/legacy-retirement-checklist.md
@@ -19,15 +19,15 @@ they must have an owner and a deletion gate.
 
 - [x] Tauri filmstrip requests use the versioned native frame service.
 - [ ] Duplicate decoder commands are removed after the native service covers
-  every thumbnail/source-still caller.
+      every thumbnail/source-still caller.
 - [ ] Web and Capacitor adapters remain frozen and are not used to judge the
-  desktop native migration.
+      desktop native migration.
 
 ## Playback and export
 
 - [ ] Native audio output and sample-clock session pass A/V tests.
 - [x] Native surface probe creates/configures the actual Tauri window surface
-  without repainting the editor.
+      without repainting the editor.
 - [ ] Native surface/shared-texture playback passes the platform matrix
       (macOS, Windows, Linux X11, and Wayland hardware validation pending).
 - [x] Export consumes the same versioned frame graph entry point as preview.
@@ -40,3 +40,50 @@ Before deletion, run searches for `<video`, `VideoFrame`, `WebCodecs`, `MSE`,
 `PreviewMediaPool`, `VideoTextureManager`, browser playback scheduler names,
 and legacy export frame pools. Review every match by program/source/export
 path; a global string match alone is not a sufficient audit.
+
+## Performance telemetry — batch-ingest retirement
+
+The old `POST /telemetry/ingest/batch` model has been replaced by the
+session-file ingest model. The following items must be cleaned up before
+the migration is considered complete.
+
+### API (`clypra-api`)
+
+- [ ] Delete `performanceStorage.persistToNeon()` and `persistToD1()` once
+      `performance_telemetry_events` is confirmed empty of new writes.
+- [ ] Drop the `performance_telemetry_events` table and remove it from
+      `setupSchema` in `db.ts` once historical data has aged out (suggested:
+      90 days after the `session-file` model goes live in production).
+- [ ] Delete the deprecated forwarding stubs `getAllEvents()`,
+      `getPreviewEvents()`, `getAudioEvents()`, `getTextEvents()` in
+      `performanceStorageService.ts` after confirming no remaining callers.
+- [ ] Remove unused `TelemetryBatchRequest` type from `types/performance.ts`
+      after confirming no test or route references it.
+
+### Desktop (`clypra`)
+
+- [ ] Delete `saveToOfflineStorage()`, `drainOfflineQueue()`,
+      `clearOfflineQueue()` from `telemetryCollector.ts` and remove the
+      `clypra:telemetry:offline_queue` localStorage key.
+- [ ] Delete `TelemetryTransportStatus.endpoint` field and
+      `getTransportStatus()` method (or repurpose for `perfLogService`
+      status) from `telemetryCollector.ts`.
+- [ ] Delete the commented-out `DEFAULT_API_INGEST_URL` and
+      `MAX_OFFLINE_BATCHES` constants from `telemetryCollector.ts`.
+- [ ] Remove the no-op `setAppVersion()` method from `telemetryCollector.ts`
+      after verifying no call sites remain.
+
+### Studio (`clypra-studio`)
+
+- [ ] Migrate all `recordStudioTextRender()` call sites in `clypra-studio`
+      to the studio equivalent of `perfLogService.enqueue()`.
+- [ ] Delete `clypra-studio/src/services/textPerformanceTelemetry.ts` after
+      migration is complete.
+
+### Deletion gate
+
+All items above require:
+
+1. `tsc --noEmit` passes on all three repos.
+2. No references to the deleted symbol survive in source (grep audit).
+3. `performance_telemetry_events` row count has not grown for ≥ 7 days.

--- a/docs/phone-transfer-architecture.md
+++ b/docs/phone-transfer-architecture.md
@@ -1,0 +1,233 @@
+# Phone Transfer Architecture
+
+> **Status:** Production  
+> **Protocol:** LocalSend v2 (LAN-only, no cloud, no account required)  
+> **Port:** 53317 (auto-fallback to 53318, 53319 on collision)
+
+---
+
+## 1. Overview
+
+Clypra's phone transfer system lets users move files between their phone and
+the desktop editor over a local Wi-Fi network without cables, cloud services,
+or accounts. It is a full implementation of the open
+[LocalSend v2 protocol](https://localsend.org), meaning it is interoperable
+with the LocalSend app on iOS and Android as well as any other LocalSend v2
+client on the network.
+
+The system is composed of:
+
+- A **Rust Axum HTTP server** embedded in the Tauri binary (`src-tauri/src/transfer/`)
+- A **React UI panel** (`src/components/ui/TransferPanel.tsx`)
+- A **theme sync bridge** (`src/store/themeRegistry.ts → update_transfer_theme`)
+
+---
+
+## 2. Protocol — LocalSend v2
+
+### Discovery
+
+Two mechanisms run simultaneously:
+
+**UDP Multicast (LocalSend v2 compatible)**
+
+```
+Multicast group: 224.0.0.167:53317
+Announce interval: every 4 seconds
+```
+
+The announcer broadcasts a JSON payload:
+
+```json
+{
+  "alias": "Clypra Desktop",
+  "version": "2.0",
+  "deviceModel": "Desktop",
+  "deviceType": "desktop",
+  "fingerprint": "<sha256 of device key>",
+  "port": 53317,
+  "protocol": "http",
+  "download": true,
+  "announce": true
+}
+```
+
+The listener reads multicast UDP packets, parses valid peer announcements
+(non-empty fingerprint, not self), and immediately sends a **direct unicast
+response** back to the sender IP. This ensures mutual visibility even when
+multicast is filtered by managed networks.
+
+**Active Subnet Scan**
+
+`scan_subnet` polls `GET /api/localsend/v2/info` on every host in the local
+`/24` subnet (`.1` through `.254`) using up to **40 concurrent HTTP requests**
+with a **1.2-second timeout** per host. The TransferPanel triggers a scan on
+every open and polls discovered devices every **4 seconds**.
+
+### HTTP Routes
+
+| Method | Path | Description |
+|---|---|---|
+| `GET` | `/api/localsend/v2/info` | Device identification (fingerprint, alias, OS, port) |
+| `POST` | `/api/localsend/v2/register` | Peer registration |
+| `POST` | `/api/localsend/v2/prepare-upload` | Initiate a receive session (triggers consent prompt) |
+| `POST` | `/api/localsend/v2/upload` | Stream file body (requires `sessionId`, `fileId`, `token` query params) |
+| `POST` | `/api/localsend/v2/cancel` | Cancel an in-progress session |
+| `GET` | `/` | Web Hub page (served to phone browser for staged-file download) |
+| `GET` | `/api/transfer/files` | List staged files |
+| `GET` | `/api/transfer/download/:id` | Download a staged file (`Content-Disposition: attachment`) |
+| `GET` | `/api/transfer/view/:id` | View a staged file inline (`Content-Disposition: inline`) |
+| `GET` | `/api/transfer/theme` | Live editor theme as JSON (consumed by Web Hub JS) |
+| `GET` | `/qr` | SVG QR code embedding the local HTTP URL |
+
+---
+
+## 3. State Machine — `TransferService`
+
+`TransferService` (`src-tauri/src/transfer/mod.rs`) is stored as Tauri managed
+state and owns:
+
+| Field | Type | Purpose |
+|---|---|---|
+| `sessions` | `DashMap<String, TransferSession>` | Active receive sessions |
+| `staged_files` | `DashMap<String, StagedFile>` | Files staged for phone download |
+| `discovered_devices` | `DashMap<String, DiscoveredDevice>` | UDP-discovered peers |
+| `consent_senders` | `DashMap<String, oneshot::Sender<bool>>` | Per-session oneshot channels that hold `prepare-upload` open until user accepts/rejects |
+| `file_tokens` | `DashMap<String, String>` | Per-file upload tokens (`sessionId:fileId` → UUID) |
+| `theme_colors` | `RwLock<HashMap<String, String>>` | Current editor theme for the Web Hub page |
+| `bound_port` | `Mutex<u16>` | Actual bound port (may differ from 53317) |
+
+### Session state transitions
+
+```
+                  prepare-upload received
+                        │
+                        ▼
+                    Pending (HTTP handler blocks on oneshot)
+                   /          \
+          accept              reject
+             │                   │
+             ▼                   ▼
+         Accepted             Rejected
+             │
+    files uploading
+             │
+             ▼
+         Complete
+             │ (or user cancels)
+             ▼
+         Cancelled
+```
+
+---
+
+## 4. File Transfer Flows
+
+### Desktop → Phone (Staged files)
+
+1. User picks files via `open_file_path` or the Tauri dialog. `stage_files_for_transfer` adds them to `staged_files`.
+2. Phone opens the Web Hub page (`GET /`) in its browser. The page lists staged files and renders a Download/View button per file.
+3. Server streams the file via `GET /api/transfer/download/:id` (attachment) or `GET /api/transfer/view/:id` (inline).
+4. Alternatively, `send_files_to_peer` sends directly to a discovered LocalSend peer using the prepare-upload / upload flow.
+
+### Phone → Desktop (Receive)
+
+```
+Phone POSTs /api/localsend/v2/prepare-upload
+  │  (HTTP handler blocks on oneshot for up to 60s)
+  │
+  └─► Tauri emits "clypra://transfer-incoming" with session ID + file briefs
+           │
+           ▼
+      TransferPanel shows consent dialog (auto-switches to Receive tab)
+           │
+      User clicks Accept ──► accept_transfer_session(sessionId)
+           │                   sends true to oneshot
+           │                   HTTP handler unblocks, responds:
+           │                   { sessionId, files: { fileId: token } }
+           │                   session state → Accepted
+           │
+      User clicks Reject ──► reject_transfer_session(sessionId)
+                               sends false to oneshot
+                               HTTP handler returns 403 Declined
+                               session state → Rejected
+           │
+           ▼ (after accept)
+Phone POSTs /api/localsend/v2/upload?sessionId=&fileId=&token=
+  for each file
+  │  (body streamed to disk, bytes_received updated per chunk)
+  │  (Tauri emits "clypra://transfer-progress" per chunk)
+  │
+  └─► All files received:
+      Tauri emits "clypra://transfer-complete" with absolute file paths
+```
+
+---
+
+## 5. QR Code
+
+`generate_qr_svg` uses the `qrcode` crate to produce an SVG QR code embedding
+the local HTTP URL (e.g. `http://192.168.1.5:53317`). TransferPanel fetches it
+via the `get_transfer_qr_code` Tauri command and renders it as a data-URL
+`<img>`. It is visible in both the Send and Receive tabs so the phone user can
+scan to open the Web Hub without manually typing the address.
+
+---
+
+## 6. Theme Sync
+
+The mobile Web Hub page mirrors the desktop editor's visual theme so the
+experience feels cohesive.
+
+`syncThemeToTransferService()` in `src/store/themeRegistry.ts` calls
+`invoke("update_transfer_theme", { theme })` with the current palette (CSS
+variable values). This fires:
+
+- When TransferPanel first opens
+- In a `useEffect` watching `uiTheme` and `fontFamily` changes
+- From `settingsStore` on every theme or font change
+
+On the Rust side, `update_transfer_theme` updates `theme_colors` in
+`TransferService`. The Web Hub page is rendered server-side by
+`render_upload_page()` which does string-template replacement of tokens
+(`{{BG}}`, `{{ACCENT}}`, `{{FONT_FAMILY}}`, etc.) with live theme values.
+`GET /api/transfer/theme` also returns the theme as JSON for client-side JS.
+
+---
+
+## 7. Tauri Commands
+
+| Command | Description |
+|---|---|
+| `get_transfer_service_status` | Health check and port |
+| `get_discovered_devices` | List UDP-discovered peers |
+| `start_transfer_service` | Start HTTP server + UDP discovery |
+| `stop_transfer_service` | Stop both |
+| `get_transfer_server_url` | Local HTTP URL for QR display |
+| `get_transfer_qr_code` | SVG QR code |
+| `accept_transfer_session` | Unblock the consent oneshot with `true` |
+| `reject_transfer_session` | Unblock with `false` |
+| `cancel_transfer_session` | Abort an in-progress receive |
+| `get_transfer_sessions` | All active sessions |
+| `stage_files_for_transfer` | Add files for phone download |
+| `unstage_file` | Remove a single staged file |
+| `clear_staged_files` | Clear all staged files |
+| `get_staged_files` | List staged files |
+| `scan_local_network` | Active subnet scan |
+| `send_files_to_peer` | Push files to a discovered LocalSend peer |
+| `get_transfer_save_directory` | Where received files are saved |
+| `set_transfer_save_directory` | Change save directory |
+| `open_transfer_save_directory` | Open in Finder/Explorer |
+| `update_transfer_theme` | Push editor theme to Web Hub page |
+| `get_network_interfaces` | Enumerate local network interfaces |
+
+---
+
+## 8. Security Model
+
+- All transfers are LAN-only. The server only binds to local interfaces; no port is exposed to the internet.
+- File uploads require a per-file UUID token issued by the server after user consent. Requests without a valid token are rejected.
+- The server validates that the uploaded file size matches the declared size from `prepare-upload`.
+- Filename collisions are resolved with `get_non_colliding_path` — files are never silently overwritten.
+- The consent oneshot times out after 60 seconds to prevent indefinitely blocked HTTP handlers.
+- `stage_files_for_transfer` uses `tauri-plugin-persisted-scope` to grant access to the specific files, not a directory tree.


### PR DESCRIPTION
## Summary

Replaces the 500+ rows/session streaming telemetry model with a single-file session upload. All performance data for an editor session is accumulated locally in an NDJSON file and uploaded as one HTTP request when the window closes.

---

## Changes grouped by concern

### Rust — session-scoped NDJSON perf log writer
- `src-tauri/src/diagnostics/perf_log.rs` (new) — six Tauri commands: `open_perf_log_session`, `append_perf_log_entries`, `close_perf_log_session`, `upload_perf_log_session`, `list_perf_log_files`, `purge_perf_logs`
- Registered in `diagnostics.rs` and `lib.rs` invoke handler

### Frontend — service layer
- `src/services/perfLogService.ts` (new) — opens/flushes/uploads the session file; subscribes to `clypra://native-diagnostic`; polls `get_sync_metrics_snapshot`
- `src/lib/app/- `src/lib/a`- `src/lib/app/d - `src/lib/app/- `src/lib/a\-a- `src/lib/app/- `src/lib/a`- `src/lib/app/d - `src/lib/app/- `src/lib/a\-a- `src/lib/app/-�� r- `src/lib/app/ to `- `src/lib/app/- `src/lib/a`- `src/lib/app/d - `src/lib/app/- `src/lib/a\-a- `src/lib/app/- `src/lib/a`- `src/lib/app/d - `src/lib/app/- `src/lib/a\-a- `src/lib/app/-�� r- `src/lib/app/ to `- `src/lib/app/- `src/lission()` on init; `closeAndUpload()` in all three exit paths
- `src/main.tsx` — `p- `src/main.tsx` — `p- `src/main.tsx` — `p- `src/main.tsx` — `p- `src/main.tsx` — `p- `src/main.tsx` — `p- `src/main.tsx` — `p- `src/main.tsx` — `p- `src/main.tsx` — `p- `src/main.tsx` —ed- `src/main.tsx` — `p- `src/main.tsx` — `p- `src/mai previously untracked, now committ- `src/main.tsx` — `p- `src/main.tsx` — `p- `src/main.tsx` — `p- `src/main.tsx` — `p- `src/main.tsx` — `p- `src/main.tsx` — `p- `src/mailers
- `POST /benchmarks/evaluate` — no live callers

---

## Testing
- `tsc --noEmit` passes (pre-push hook confirmed)
- `cargo check` passes

---

## Follow-up items (tracked in docs/performance-telemetry.md §11)
- Delete tombstoned private methods from `telemetryCollector.ts`
- Migrate `clypra-studio/textPerformanceTelemetry.ts` then delete
- Drop `performance_telemetry_events` table once historical data ages out