### PR TITLE
fix(rust): resolve all Clippy warnings failing CI

### DIFF
--- a/src-tauri/src/commands/permissions.rs
+++ b/src-tauri/src/commands/permissions.rs
@@ -1,11 +1,11 @@
-/// permissions.rs — macOS media permission helpers.
-///
-/// These commands read (and optionally request) AVFoundation / AVAudioSession
-/// permissions without going through the browser's getUserMedia path, so they
-/// work even when the Tauri WKWebView camera path is not available.
-///
-/// All commands are `#[cfg(target_os = "macos")]`-guarded; on other platforms
-/// they return `"authorized"` immediately so the JS layer stays cross-platform.
+//! permissions.rs — macOS media permission helpers.
+//!
+//! These commands read (and optionally request) AVFoundation / AVAudioSession
+//! permissions without going through the browser's getUserMedia path, so they
+//! work even when the Tauri WKWebView camera path is not available.
+//!
+//! All commands are `#[cfg(target_os = "macos")]`-guarded; on other platforms
+//! they return `"authorized"` immediately so the JS layer stays cross-platform.
 
 use serde::Serialize;
 use tauri::command;

--- a/src-tauri/src/commands/transfer.rs
+++ b/src-tauri/src/commands/transfer.rs
@@ -171,7 +171,7 @@ pub async fn get_staged_files(app: AppHandle) -> Result<Vec<StagedFile>, String>
         .iter()
         .map(|e| e.value().clone())
         .collect();
-    files.sort_by(|a, b| b.created_at.cmp(&a.created_at));
+    files.sort_by_key(|f| std::cmp::Reverse(f.created_at));
     Ok(files)
 }
 

--- a/src-tauri/src/diagnostics/perf_log.rs
+++ b/src-tauri/src/diagnostics/perf_log.rs
@@ -239,7 +239,7 @@ pub async fn upload_perf_log_session(
         .filter(|line| !line.trim().is_empty())
         .map(|line| {
             serde_json::from_str::<serde_json::Value>(line)
-                .unwrap_or_else(|_| serde_json::Value::Null)
+                .unwrap_or(serde_json::Value::Null)
         })
         .filter(|v| !v.is_null())
         .collect();
@@ -382,10 +382,8 @@ pub fn purge_perf_logs(
             .and_then(|epoch_str| epoch_str.parse::<u64>().ok())
             .unwrap_or(0);
 
-        if now.saturating_sub(created_at) > max_age_ms {
-            if fs::remove_file(&path).is_ok() {
-                deleted += 1;
-            }
+        if now.saturating_sub(created_at) > max_age_ms && fs::remove_file(&path).is_ok() {
+            deleted += 1;
         }
     }
 

--- a/src-tauri/src/transfer/server.rs
+++ b/src-tauri/src/transfer/server.rs
@@ -691,7 +691,7 @@ async fn get_staged_files(State(state): State<AppState>) -> Json<Vec<StagedFile>
         .iter()
         .map(|e| e.value().clone())
         .collect();
-    files.sort_by(|a, b| b.created_at.cmp(&a.created_at));
+    files.sort_by_key(|f| std::cmp::Reverse(f.created_at));
     Json(files)
 }
 


### PR DESCRIPTION
## Problem

`cargo clippy -- -D warnings` was failing CI with 5 warnings promoted to errors.

## Fixes

| File | Line | Lint | Fix |
|---|---|---|---|
| `permissions.rs` | 1 | `empty_line_after_doc_comments` | Converted `///` outer doc to `//!` module-level doc comments |
| `transfer.rs` | 174 | `unnecessary_sort_by` | `sort_by(|a,b| b.x.cmp(&a.x))` → `sort_by_key(|f| Reverse(f.created_at))` |
| `server.rs` | 694 | `unnecessary_sort_by` | Same fix |
| `perf_log.rs` | 241 | `unnecessary_lazy_evaluations` | `unwrap_or_else(|_| Value::Null)` → `unwrap_or(Value::Null)` |
| `perf_log.rs` | 385 | `collapsible_if` | Collapsed nested if blocks into single conjunctive condition |

## Verification

- `cargo clippy -- -D warnings` — clean, zero warnings
- `tsc --noEmit` — clean
