### PR TITLE
fix(telemetry) + feat(export) + chore: v1.4.8 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,18 @@ All notable changes to Clypra will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### ✂️ Timeline Editing
+
+- **Select all clips in track** — right-click any track label to open the new track context menu and choose **Select All Clips in Track**. All clips on that track are added to the multi-selection in one action; gap and transition selections are cleared. The shortcut **⌘A** (macOS) / **Ctrl+A** (Windows/Linux) also works when the mouse is hovering over a track row, scoping the selection to that track only rather than selecting every clip across all tracks.
+- **Delete all clips in track** — the same track context menu exposes **Delete All Clips in Track**, which ripple-deletes every clip on the track in a single undoable step. The command is disabled if the track is locked or already empty.
+- **Track context menu on label right-click** — right-clicking the sticky track label column now opens a dedicated track context menu (distinct from the existing empty-space context menu). It surfaces track-scoped commands alongside the existing lock / mute / visibility toggles.
+
 ## [1.4.5] - 2026-08-27
 
 ### 🔤 Native GPU SDF Text Engine & Font Registry
+
 - **Native Signed Distance Field (SDF) text rendering** — migrated text rendering from browser canvas to GPU-accelerated wgpu/WGSL SDF shaders for razor-sharp typography at any preview scale.
 - **Native font registry & WOFF2 support** — added `register_native_font` / `register_native_font_bytes` IPC commands; native core automatically decodes bundled WOFF2 and TTF fonts via `woff2-patched`.
 - **Per-glyph font fallback & Noto Emoji** — `render_text_sdf_aligned_with_fallback` seamlessly resolves missing glyphs to the bundled `@fontsource/noto-emoji` fallback font.
@@ -16,6 +25,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - **Retired browser text rasterization** — desktop preview and export render text layers directly via wgpu, removing canvas raster roundtrips and DOM bottlenecks.
 
 ### 🔊 Professional Audio Engine & Timeline Controls
+
 - **Extended native audio mixer** — Rust mixer supports fade-in / fade-out curves, keyframe interpolation, pan, channel routing, and pitch preservation.
 - **Interactive audio envelope editor** — CapCut-style volume rubber bands and fade handle knobs directly on clips with cubic Bézier curves.
 - **J/L-cut audio unlinking** — added `UnlinkAudioCommand` and `RelinkAudioCommand` for independent audio/video trimming and J/L cut workflows.
@@ -24,11 +34,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - **Waveform fade curves & solo button** — waveforms render overlaid fade curves with source-scoped peak caching and per-track solo controls.
 
 ### 🔄 Session-Safe Deferred Updates & Auto-Updater Pipeline
+
 - **Two-stage update lifecycle** — separated update download from installation via `AutoUpdateManager` singleton; active editing sessions are never interrupted.
 - **Save-before-update verification** — transport playback is paused and project state is atomically saved and verified before update restart; save failures abort installation safely.
 - **Unified updater state** — synchronized update notifications, downloading status, and restart prompts across SettingsModal and UpdateBanner.
 
 ### 💾 Project Persistence Reliability & Crash Recovery
+
 - **Atomic save pipeline** — verified candidate write (`.tmp`), generation rotation (`.bak`), and atomic file replacement with save receipt verification.
 - **Transactional project hydration** — `validateAndMigrateProjectPayload` safely migrates legacy project fields; hydration failures roll back to the previously active project.
 - **Failure-isolated recent projects** — corrupt or unreadable projects no longer hide valid projects and offer one-click recovery from verified backup files.
@@ -36,16 +48,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - **Cross-platform save hardening** — resolved Windows backup rename races and mobile Capacitor overwrite/rename paths.
 
 ### 🖥️ Dual-Monitor Workspace & Preview Layouts
+
 - **Dual-monitor preview workspace** — added `PreviewMonitorWorkspace` supporting configurable side-by-side row and stacked column orientations for Source and Program monitors.
 - **Independent preview panels** — `PreviewPanel` supports an explicit `mode` prop ("program" vs "source") regardless of global preview state.
 - **Interaction-deferred transport context** — `SourcePreview` defers transport claiming until user interaction, preventing accidental playback hijacking on mount.
 
 ### 🎨 Design System, Semantic Tokens & Clip Palettes
+
 - **Per-theme clip palettes** — clip colors derive from dynamic semantic design tokens (`--clypra-clip-*`) mapped 1-to-1 with UI themes.
 - **Full palette fidelity** — eliminated heavy CSS saturation and opacity filters that dulled theme palette colors.
 - **Live theme preview swatches** — Settings theme swatches preview actual built-in clip palette color schemes.
 
 ### 📐 Timeline Viewport Precision & Interactions
+
 - **Sub-pixel alignment & 20px clip-start offset** — consistent timeline coordinates across Ruler, Clips, Playhead, Gaps, and mouse/wheel seek anchors via `TIMELINE_CLIP_START_OFFSET_PX`.
 - **Refined visual hierarchy** — distinct A-roll (primary) and B-roll visual roles with dedicated track heights.
 - **Visual track ordering guards** — visual tracks are prevented from being placed below the main video track, enforced across drag/drop and history undo/redo.
@@ -53,12 +68,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - **Spring-animated zoom & canonical overview** — buttery-smooth anchored wheel zoom with spring physics; projects reliably open at standard minimum zoom.
 
 ### ⚡ Performance, Telemetry & Lookahead Pre-fetching
+
 - **Zero-PII performance telemetry** — lightweight client and collector reporting stage timings and dropped frames with adaptive sampling.
 - **Bounded lookahead pre-fetching** — predictive decoding warms upcoming clip assets within a 3-second horizon without saturating GPU presentation.
 - **Event-driven paused render loop** — native preview pauses RAF loops while stopped, waking instantaneously on state and transform changes.
 - **24-track compositor density** — validated multi-track layer pooling and composition stability up to 24 concurrent tracks.
 
 ### 🛠️ UI Polish & Workflow Shortcuts
+
 - **Collapsible properties panel** — 44px collapsed rail with expand button and shortcut icons; `Alt+P` / `Cmd+Shift+P` toggle shortcut.
 - **Media library shortcut** — `Cmd+B` toggles the media library drawer.
 - **Transform overlay polish** — RAF-throttled gizmo tracking, enlarged hit targets, and diagonal resize cursors.

--- a/docs/export-output-resolution.md
+++ b/docs/export-output-resolution.md
@@ -1,0 +1,176 @@
+# Export Output Resolution — Architecture
+
+Status: implemented, tsc-clean, all tests passing.
+
+## Problem
+
+Prior to this change, all three export entry points (`exportVideo`, `exportSequence`,
+`exportFrame`) enforced a strict equality guard before constructing the native frame
+request:
+
+```typescript
+// OLD — blocked any export where output ≠ canvas size
+const nativeRequest =
+  width === scene.metadata.canvasWidth && height === scene.metadata.canvasHeight
+    ? buildNativeFrameRequest(...)
+    : null; // → throws "Frame N is outside the native compositor contract"
+```
+
+This meant a project with a 1920×1080 canvas could not be exported at 4K (3840×2160),
+and no aspect-ratio-preserving upscale or downscale was possible even though the
+underlying compositor pipeline had always supported it.
+
+## Root Cause
+
+The guard was unnecessary. `buildNativeFrameRequest` accepts independent
+`outputWidth`/`outputHeight` and `canvasWidth`/`canvasHeight` arguments by design — they
+are separate fields in `NativeFrameRequest` and have always been allowed to differ.
+The Rust bridge (`to_video_project_request` in `native_preview.rs`) already performs
+the coordinate transform before compositing, with no dimension-equality constraint in
+`FrameRequest::validate()`.
+
+The guards were a premature defensive measure that accidentally prevented the
+documented feature.
+
+## Architecture: How Output Resolution Works End-to-End
+
+```
+ExportDialog
+  └─ resolveExportDimensions(projectW, projectH, qualityTier)
+       Preserves project aspect ratio. Long edge → tier.longEdge (720 / 1080 / 2160 / 4320).
+       Rounds to even numbers (H.264/H.265 chroma subsampling requirement).
+       Result: resolvedWidth × resolvedHeight  (may differ from project canvas)
+         ↓
+exportVideo / exportSequence / exportFrame
+  └─ buildNativeFrameRequest(scene, ..., outputWidth, outputHeight, ...)
+       Passes outputWidth/outputHeight through unchanged as NativeFrameRequest.outputWidth/Height.
+       Also sets project.canvasWidth/Height from scene.metadata — these are the project's
+       logical coordinate space and are INDEPENDENT of outputWidth/outputHeight.
+         ↓
+renderNativeFrame(nativeRequest)  [Tauri IPC]
+  └─ present_native_frame_internal  [native_preview.rs]
+       └─ to_video_project_request(request)
+            scale_x = request.output_width  / request.project.canvas_width
+            scale_y = request.output_height / request.project.canvas_height
+
+            Applies scale_x / scale_y to every layer's (x, y, width, height).
+            Applies scale_x / scale_y to raster layer display dimensions.
+            Applies scale_x / scale_y to text layer (x, y, box_width, box_height).
+
+            Sets NativeVideoProjectFrameRequest.canvas_width  = output_width
+            Sets NativeVideoProjectFrameRequest.canvas_height = output_height
+              ↓
+            MultiTrackCompositor renders at output_width × output_height natively.
+            No intermediate resize blit. GPU produces pixels at the final resolution.
+```
+
+### Key invariants
+
+- `outputWidth` and `canvasWidth` are **always separate** — one is the GPU render target
+  size, the other is the project's logical coordinate space.
+- The coordinate transform (`scale_x`, `scale_y`) is **lossless for the compositor** —
+  all layer sizes, positions, and text box dimensions are expressed in output-pixel space
+  before the GPU sees them.
+- The Rust contract (`FrameRequest::validate()`) enforces: `output_width` and
+  `output_height` are non-zero and `≤ 8192`. There is no equality constraint with
+  canvas dimensions.
+- `FrameRequest::validate()` contract version is `NATIVE_CORE_CONTRACT_VERSION = 2`.
+
+## The Fix
+
+Removed three inline dimension-equality guards — one per export entry point — and
+replaced each with a direct unconditional call to `buildNativeFrameRequest`.
+
+### `exportVideo.ts`
+
+```typescript
+// BEFORE
+const nativeRequest =
+  width === scene.metadata.canvasWidth && height === scene.metadata.canvasHeight
+    ? buildNativeFrameRequest(scene, ..., width, height, ...)
+    : null; // → threw "Frame N is outside the native compositor contract"
+
+// AFTER — compositor handles any output resolution
+const nativeRequest = buildNativeFrameRequest(
+  scene, ..., width, height, ...
+);
+```
+
+### `exportFrame.ts`
+
+```typescript
+// BEFORE
+if (width !== scene.metadata.canvasWidth || height !== scene.metadata.canvasHeight) {
+  throw new Error("[ExportFrame] Native export requires project-sized output dimensions");
+}
+
+// AFTER — removed entirely; output dimensions are independent of canvas dimensions
+```
+
+### `exportSequence.ts`
+
+Same ternary pattern as `exportVideo.ts` — replaced with a direct call.
+
+## Memory Budget at 4K
+
+Each RGBA frame at 4K (3840×2160) is **~32 MB** (3840 × 2160 × 4 bytes).
+
+`exportVideo` uses `BATCH_SIZE = 10` frames per IPC flush. At 4K this means
+~320 MB batch buffer + ~320 MB source frames ≈ **640 MB peak** during a flush.
+This is acceptable on the minimum supported hardware (4 GB RAM) because the
+source frame references are null'd immediately after copy into the concat buffer
+(EX-2 fix), so GC can reclaim them before the batch write completes.
+
+At 1080p the peak is ~83 MB + ~83 MB ≈ 166 MB — unchanged from before.
+
+## What `buildNativeFrameRequest` Can Still Return `null` For
+
+Removing the dimension guard does not mask other contract failures.
+`buildNativeFrameRequest` still returns `null` (and the export still throws
+"Frame N is outside the native compositor contract") for scene-content reasons:
+
+| Condition | Example |
+|---|---|
+| Unsupported visual layer type | non-`"media"`, non-`"text"` layer in scene |
+| Animated/gradient background not yet rasterized | raster asset not ready |
+| Still image or animated sticker not yet rasterized | raster asset not ready |
+| Active transition not implemented natively | unsupported transition kind |
+| Lottie sticker | `stickerFormat === "lottie"` |
+| Non-native source path | blob URL, HTTP URL (not filesystem / `asset://`) |
+| Source rotation on the media container | `sourceRotation !== 0` |
+| Unsupported blend mode | not in `NATIVE_BLEND_MODES` |
+| Unsupported color grade / MPG v2 filter node | `getNativeColorGrade()` → null |
+| Body effect mask not yet rasterized | segmentation mask not ready |
+| Unsupported text effect primitive | non-SDF pass |
+| Completely empty scene | no renderable visual content |
+
+These are **scene-content** failures, not dimension failures, and they are correct
+to block export — they represent scenes the native compositor genuinely cannot
+render.
+
+## Relationship to `resolveExportDimensions`
+
+`resolveExportDimensions` (in `exportDimensions.ts`) resolves the user's chosen
+quality tier to concrete pixel dimensions that preserve the project's aspect ratio
+and produce even numbers for codec compliance. It is the canonical source of
+`width`/`height` in `ExportDialog`. The fix does not change this function — it
+already produced dimensions that could differ from the canvas size. The dimension
+guard was simply discarding those valid, correctly-resolved dimensions.
+
+## Regression Surface
+
+The only behavioral change is:
+
+1. `exportVideo`, `exportSequence`, and `exportFrame` no longer throw when
+   `outputWidth !== canvasWidth || outputHeight !== canvasHeight`.
+2. Those cases are now routed through `buildNativeFrameRequest` → Rust compositor
+   which scales layer coordinates proportionally.
+
+Existing behavior for same-size exports (output == canvas) is unchanged — the
+scale factors become 1.0 × 1.0 in Rust, which is a no-op transform.
+
+## Related Documents
+
+- [`native-architecture.md`](native-architecture.md) — native media authority contract
+- [`native-migration-adr.md`](native-migration-adr.md) — ADR: native media authority
+- [`performance-contract.md`](performance-contract.md) — frame timing budgets

--- a/docs/track-select-and-delete-all-clips.md
+++ b/docs/track-select-and-delete-all-clips.md
@@ -1,0 +1,224 @@
+# Track: Select All Clips & Delete All Clips
+
+Date: 2026-09-10
+
+Right-clicking a track label now opens a dedicated track context menu. Two new
+commands live in it — **Select All Clips in Track** and **Delete All Clips in
+Track** — and the ⌘A / Ctrl+A keyboard shortcut is scoped to whichever track
+the mouse is hovering over.
+
+---
+
+## Problem the change solves
+
+Before this update there was no way to operate on all clips belonging to one
+track as a group. Selecting them required shift-clicking each clip individually,
+and deleting them required either a selection loop or a destructive store
+mutation with no undo. The only context menu available on the track row was the
+**empty-space** menu (paste, add gap, add track), which mixes clip concerns with
+timeline-level concerns and has no access to track-scoped clip lists.
+
+---
+
+## Architecture
+
+### 1. `selectAllClipsInTrack` — `src/store/uiStore.ts`
+
+A new method added to `UIStore`:
+
+```ts
+selectAllClipsInTrack: (trackId: string) => void
+```
+
+Reads the flat `clips` array from `useTimelineStore.getState()`, filters by
+`trackId`, and sets the result as `selectedClipIds`. Also clears
+`selectedGapId` and `selectedTransitionId` so selection is never in a mixed
+state.
+
+```ts
+selectAllClipsInTrack: (trackId) => {
+  const clips = useTimelineStore.getState().clips.filter(
+    (c) => c.trackId === trackId,
+  );
+  set({
+    selectedClipIds: clips.map((c) => c.id),
+    selectedGapId: null,
+    selectedTransitionId: null,
+  });
+},
+```
+
+### 2. Two new track commands — `src/core/commands/timelineCommands.ts`
+
+Both commands are added to the existing `timelineCommands` array in the
+`"track"` group. They use the `TimelineCommandContext` interface unchanged —
+`clickedTrackId` and `clips` are already present.
+
+#### `track.selectAllClips`
+
+| Property | Value |
+|---|---|
+| Group | `"track"` |
+| Shortcut label | `⌘A` |
+| Enabled when | `clickedTrackId` is set **and** the track has ≥ 1 clip |
+| Disabled reason | `"Track has no clips"` |
+| Execute | Calls `useUIStore.getState().selectAllClipsInTrack(ctx.clickedTrackId)` |
+
+#### `track.deleteAllClips`
+
+| Property | Value |
+|---|---|
+| Group | `"track"` |
+| Danger | `true` |
+| Enabled when | `clickedTrackId` is set, track is **not** locked, and track has ≥ 1 clip |
+| Disabled reason | `"Track is locked"` or `"Track has no clips"` |
+| Execute | Collects all clip IDs on the track, calls `EditingActions.deleteSelection(ids, false)` (ripple delete, fully undoable) |
+
+### 3. `TrackContextMenu` — `src/components/editor/timeline/TrackContextMenu.tsx`
+
+A new component that mirrors `TimelineEmptySpaceContextMenu`. It calls
+`useTimelineCommands(trackId, 0)` — `clickedTime` is `0` because label
+right-clicks are not time-positioned — and maps the resolved commands to the
+shared `ContextMenu` UI component. Each item calls `executeCommand` then
+`onClose`.
+
+```
+TrackContextMenu
+  └── useTimelineCommands(trackId, 0)   ← resolves enabled/visible state
+  └── ContextMenu                        ← shared UI primitive
+```
+
+### 4. `TrackLabel` — `src/components/editor/timeline/TrackLabel.tsx`
+
+Added:
+
+- `onContextMenu?: (e: React.MouseEvent, trackId: string) => void` prop.
+- `data-track-label` attribute on the root div (already referenced by the
+  `seekFromPointer` guard in `Timeline.tsx` — previously implicit, now
+  explicit).
+- `onContextMenu` handler that calls `e.preventDefault()` +
+  `e.stopPropagation()` then fires the prop.
+
+### 5. `Timeline` — `src/components/editor/timeline/Timeline.tsx`
+
+Added:
+
+- `trackLabelContextMenu` state (mirrors `clipContextMenu` and
+  `emptySpaceContextMenu`).
+- `handleTrackLabelContextMenu` callback — sets the state and clears all other
+  open context menus.
+- Every other context-menu handler (`handleClipContextMenu`,
+  `handleTrackContextMenu`, `handleGapContextMenu`) also calls
+  `setTrackLabelContextMenu(null)` so only one menu is ever open.
+- `onContextMenu={handleTrackLabelContextMenu}` passed to `<TrackLabel>`.
+- `<TrackContextMenu>` rendered in the context-menu block between
+  `<ClipContextMenu>` and `<TimelineEmptySpaceContextMenu>`.
+
+### 6. Scoped ⌘A shortcut — `src/components/editor/timeline/Track.tsx`
+
+The track row div gains three new props:
+
+```tsx
+tabIndex={-1}
+onMouseEnter={(e) => e.currentTarget.focus({ preventScroll: true })}
+onKeyDown={handleKeyDown}
+```
+
+`tabIndex={-1}` makes the row programmatically focusable without inserting it
+into the natural tab order. `onMouseEnter` focuses it immediately on hover so
+⌘A works without needing a prior click. `outline-none` suppresses the browser
+default focus ring (the timeline's own selection highlight provides the visual
+cue).
+
+`handleKeyDown` intercepts ⌘A (macOS) / Ctrl+A (Windows/Linux):
+
+```ts
+const handleKeyDown = useCallback(
+  (e: React.KeyboardEvent<HTMLDivElement>) => {
+    const isMeta = e.metaKey || e.ctrlKey;
+    if (isMeta && e.key === "a") {
+      e.preventDefault();   // suppress browser select-all
+      e.stopPropagation();  // prevent global clip.selectAll from also firing
+      useUIStore.getState().selectAllClipsInTrack(track.id);
+    }
+  },
+  [track.id],
+);
+```
+
+`stopPropagation` is critical — the global `keydown` listener in `Timeline.tsx`
+handles `clip.selectAll` (all clips, all tracks) when ⌘A is pressed. Without
+stopping propagation both handlers would fire and immediately override the
+track-scoped selection with the full selection.
+
+---
+
+## Interaction design
+
+| Gesture | Result |
+|---|---|
+| Right-click track label | Opens `TrackContextMenu` |
+| Click **Select All Clips in Track** | All clips on that track enter `selectedClipIds`; prior selection (any track) is replaced |
+| Click **Delete All Clips in Track** | Ripple-deletes all clips on the track in one undoable step |
+| Hover over track row + ⌘A / Ctrl+A | Selects all clips on that track (does not affect other tracks) |
+| ⌘A without hovering a track | Global `clip.selectAll` fires — all clips across all tracks selected (unchanged behavior) |
+| Backspace / Delete after select-all | Existing ripple-delete shortcut in `Timeline.tsx` operates on `selectedClipIds` as normal |
+
+### Locked track behavior
+
+- **Select All** is enabled on locked tracks — selection is read-only and has
+  no side effects, so there is no reason to block it.
+- **Delete All** is disabled on locked tracks — the `isEnabled` guard returns
+  `false`, and the `disabledReason` surfaces `"Track is locked"` in the menu.
+
+### Empty track behavior
+
+Both commands are disabled (`isEnabled: false`) when the track has no clips.
+The context menu still shows them but renders them greyed out with a tooltip
+reason.
+
+---
+
+## Undo/redo
+
+`track.deleteAllClips` calls `EditingActions.deleteSelection(ids, false)` which
+dispatches `RippleDeleteRangeCommand` through `useHistoryStore.execute`. This is
+the same code path as pressing Backspace on a multi-selection — fully undoable,
+one history entry regardless of how many clips the track contained.
+
+`track.selectAllClips` and `selectAllClipsInTrack` are selection-only operations
+on `uiStore`, which is intentionally ephemeral and not part of the undo stack.
+
+---
+
+## Files changed
+
+| File | Change |
+|---|---|
+| `src/store/uiStore.ts` | Added `selectAllClipsInTrack(trackId)` to interface and implementation |
+| `src/core/commands/timelineCommands.ts` | Added `track.selectAllClips` and `track.deleteAllClips` commands; added `CheckSquare`, `Trash2` imports and `EditingActions` import |
+| `src/components/editor/timeline/TrackContextMenu.tsx` | New component |
+| `src/components/editor/timeline/TrackLabel.tsx` | Added `onContextMenu` prop, `data-track-label` attr, context-menu handler |
+| `src/components/editor/timeline/Timeline.tsx` | Added `trackLabelContextMenu` state, handler, `TrackContextMenu` render, `onContextMenu` on `<TrackLabel>` |
+| `src/components/editor/timeline/Track.tsx` | Added `tabIndex`, `onMouseEnter` focus, `handleKeyDown` for scoped ⌘A |
+
+---
+
+## Test coverage
+
+`src/core/commands/__tests__/trackCommands.test.ts`
+
+| Test | What it asserts |
+|---|---|
+| `selectAllClipsInTrack` — basic | Sets `selectedClipIds` to all clip IDs on the given track |
+| `selectAllClipsInTrack` — multi-track isolation | Only clips on the target track are selected; clips on other tracks are not included |
+| `selectAllClipsInTrack` — empty track | Results in an empty `selectedClipIds` array |
+| `selectAllClipsInTrack` — clears gap selection | `selectedGapId` is `null` after calling |
+| `track.selectAllClips` command — enabled on non-empty track | `isEnabled` returns `true` |
+| `track.selectAllClips` command — disabled on empty track | `isEnabled` returns `false`; `disabledReason` is `"Track has no clips"` |
+| `track.selectAllClips` command — enabled on locked track | Selection has no side effects, so locked tracks are allowed |
+| `track.deleteAllClips` command — enabled on unlocked non-empty track | `isEnabled` returns `true` |
+| `track.deleteAllClips` command — disabled on locked track | `isEnabled` returns `false`; `disabledReason` is `"Track is locked"` |
+| `track.deleteAllClips` command — disabled on empty track | `isEnabled` returns `false`; `disabledReason` is `"Track has no clips"` |
+| `track.deleteAllClips` execute — removes clips and clears selection | All clips on track are removed from the store; `selectedClipIds` is emptied |
+| `track.deleteAllClips` execute — does not touch other tracks | Clips on unrelated tracks are unmodified after execution |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clypra",
-  "version": "1.4.7",
+  "version": "1.4.8",
   "description": "A modern, open-source video editor built with Tauri, React, and TypeScript",
   "author": "Clypra Contributors",
   "license": "MIT",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clypra"
-version = "1.4.7"
+version = "1.4.8"
 description = "A modern, open-source video editor with native performance and GPU-accelerated preview"
 authors = ["Clypra Contributors"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Clypra",
-  "version": "1.4.7",
+  "version": "1.4.8",
   "identifier": "com.clypra.editor",
   "build": {
     "beforeDevCommand": "npm run dev",
@@ -53,7 +53,10 @@
     "targets": "all",
     "publisher": "AIEraDev",
     "createUpdaterArtifacts": true,
-    "externalBin": ["bin/ffmpeg", "bin/ffprobe"],
+    "externalBin": [
+      "bin/ffmpeg",
+      "bin/ffprobe"
+    ],
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",

--- a/src/components/editor/timeline/Timeline.tsx
+++ b/src/components/editor/timeline/Timeline.tsx
@@ -51,6 +51,7 @@ import { EmptyTimelineDropZone } from "./EmptyTimelineDropZone";
 import { ClipContextMenu } from "./ClipContextMenu";
 import { TimelineEmptySpaceContextMenu } from "./TimelineEmptySpaceContextMenu";
 import { GapContextMenu } from "./GapContextMenu";
+import { TrackContextMenu } from "./TrackContextMenu";
 import { AudioStreamPicker } from "./AudioStreamPicker";
 import { MediaJobIndicator } from "./MediaJobIndicator";
 import { RenameClipDialog } from "./RenameClipDialog";
@@ -90,6 +91,11 @@ export const Timeline: React.FC = () => {
     position: { x: number; y: number };
   } | null>(null);
 
+  const [trackLabelContextMenu, setTrackLabelContextMenu] = useState<{
+    trackId: string;
+    position: { x: number; y: number };
+  } | null>(null);
+
   const [emptySpaceContextMenu, setEmptySpaceContextMenu] = useState<{
     clickedTrackId: string | null;
     clickedTime: number;
@@ -108,9 +114,23 @@ export const Timeline: React.FC = () => {
     (e: React.MouseEvent, clipId: string, trackId: string) => {
       setEmptySpaceContextMenu(null);
       setGapContextMenu(null);
+      setTrackLabelContextMenu(null);
       setClipContextMenu({
         clickedClipId: clipId,
         clickedTrackId: trackId,
+        position: { x: e.clientX, y: e.clientY },
+      });
+    },
+    [],
+  );
+
+  const handleTrackLabelContextMenu = useCallback(
+    (e: React.MouseEvent, trackId: string) => {
+      setClipContextMenu(null);
+      setEmptySpaceContextMenu(null);
+      setGapContextMenu(null);
+      setTrackLabelContextMenu({
+        trackId,
         position: { x: e.clientX, y: e.clientY },
       });
     },
@@ -121,6 +141,7 @@ export const Timeline: React.FC = () => {
     (e: React.MouseEvent, trackId: string, time: number) => {
       setClipContextMenu(null);
       setGapContextMenu(null);
+      setTrackLabelContextMenu(null);
       setEmptySpaceContextMenu({
         clickedTrackId: trackId,
         clickedTime: time,
@@ -138,6 +159,7 @@ export const Timeline: React.FC = () => {
     }) => {
       setClipContextMenu(null);
       setEmptySpaceContextMenu(null);
+      setTrackLabelContextMenu(null);
       setGapContextMenu(params);
     },
     [],
@@ -155,8 +177,7 @@ export const Timeline: React.FC = () => {
       if (!container) return;
       const rect = container.getBoundingClientRect();
       const clickedTime = timelinePixelToTime(
-        getTimelineLaneClientX(e.clientX, rect.left, hasClips) +
-          scrollLeft,
+        getTimelineLaneClientX(e.clientX, rect.left, hasClips) + scrollLeft,
         pixelsPerSecond,
       );
       setClipContextMenu(null);
@@ -627,7 +648,10 @@ export const Timeline: React.FC = () => {
         container.scrollLeft,
         hasClips,
       );
-      const time = Math.max(0, Math.min(pixelToTime(x, pixelsPerSecond), duration));
+      const time = Math.max(
+        0,
+        Math.min(pixelToTime(x, pixelsPerSecond), duration),
+      );
 
       const frameRate = getPlaybackClock().frameRate;
       transportSeek(clampAndSnapProgramTime(time, duration, frameRate));
@@ -835,7 +859,11 @@ export const Timeline: React.FC = () => {
                   return (
                     <React.Fragment key={track.id}>
                       {/* LEFT: Track label — sticky left, scrolls vertically with clips */}
-                      <TrackLabel track={visualTrack} visualSpec={visualSpec} />
+                      <TrackLabel
+                        track={visualTrack}
+                        visualSpec={visualSpec}
+                        onContextMenu={handleTrackLabelContextMenu}
+                      />
 
                       {/* RIGHT: Track clips — scrolls both directions */}
                       <div
@@ -970,6 +998,14 @@ export const Timeline: React.FC = () => {
           position={clipContextMenu.position}
           onClose={() => setClipContextMenu(null)}
           onRename={(clipId) => setRenameClipId(clipId)}
+        />
+      )}
+
+      {trackLabelContextMenu && (
+        <TrackContextMenu
+          trackId={trackLabelContextMenu.trackId}
+          position={trackLabelContextMenu.position}
+          onClose={() => setTrackLabelContextMenu(null)}
         />
       )}
 

--- a/src/components/editor/timeline/Track.tsx
+++ b/src/components/editor/timeline/Track.tsx
@@ -1,4 +1,10 @@
-import React, { useEffect, useMemo, useRef, useState } from "react";
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { Lock } from "lucide-react";
 import { useDrop } from "react-dnd";
 import { useUIStore } from "@/store/uiStore";
@@ -377,6 +383,20 @@ const TrackInner: React.FC<TrackProps> = ({
     onTrackContextMenu?.(e, track.id, Math.max(0, clickedTime));
   };
 
+  // Cmd+A (Mac) / Ctrl+A (Win/Linux) while this track row is focused
+  // selects all clips on this track only, overriding the global select-all.
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLDivElement>) => {
+      const isMeta = e.metaKey || e.ctrlKey;
+      if (isMeta && e.key === "a") {
+        e.preventDefault();
+        e.stopPropagation();
+        useUIStore.getState().selectAllClipsInTrack(track.id);
+      }
+    },
+    [track.id],
+  );
+
   return (
     <div
       ref={(node) => {
@@ -384,7 +404,15 @@ const TrackInner: React.FC<TrackProps> = ({
       }}
       data-track-id={track.id}
       onContextMenu={handleTrackContextMenu}
-      className={`relative transition-colors mb-0 bg-surface-raised/40 ${selectedTrackId === track.id ? "bg-timeline-track-active" : ""} ${isOver && canDrop ? "bg-editor-drop/10" : ""} ${track.locked ? "bg-surface-app/45" : ""}`}
+      onKeyDown={handleKeyDown}
+      // tabIndex makes the row focusable so keyboard events land here.
+      // outline-none removes the browser default focus ring (timeline has its own selection highlight).
+      tabIndex={-1}
+      // Focus this row when the mouse enters so Cmd+A works without an extra click.
+      onMouseEnter={(e) =>
+        (e.currentTarget as HTMLDivElement).focus({ preventScroll: true })
+      }
+      className={`relative transition-colors mb-0 bg-surface-raised/40 outline-none ${selectedTrackId === track.id ? "bg-timeline-track-active" : ""} ${isOver && canDrop ? "bg-editor-drop/10" : ""} ${track.locked ? "bg-surface-app/45" : ""}`}
       style={{ height: `${visualSpec.height}px` }}
     >
       {/* Clips layer */}

--- a/src/components/editor/timeline/TrackContextMenu.tsx
+++ b/src/components/editor/timeline/TrackContextMenu.tsx
@@ -1,0 +1,42 @@
+import React from "react";
+import { ContextMenu, type ContextMenuGroup } from "@/components/ui/ContextMenu";
+import { useTimelineCommands } from "@/core/commands";
+
+export interface TrackContextMenuProps {
+  trackId: string;
+  position: { x: number; y: number };
+  onClose: () => void;
+}
+
+/**
+ * Context menu shown when right-clicking a track label.
+ *
+ * Renders the full set of track-scoped commands from timelineCommands,
+ * with clickedTrackId pre-populated and clickedTime as 0 (label clicks
+ * are not time-positioned).
+ */
+export const TrackContextMenu: React.FC<TrackContextMenuProps> = ({
+  trackId,
+  position,
+  onClose,
+}) => {
+  const { groupedCommands, executeCommand } = useTimelineCommands(trackId, 0);
+
+  const groups: ContextMenuGroup[] = groupedCommands.map((grp) => ({
+    items: grp.items.map((resolved) => ({
+      id: resolved.command.id,
+      label: resolved.command.label,
+      icon: resolved.command.icon,
+      shortcut: resolved.shortcutLabel,
+      danger: resolved.command.danger,
+      disabled: !resolved.isEnabled,
+      disabledReason: resolved.disabledReason,
+      onClick: () => {
+        executeCommand(resolved.command.id);
+        onClose();
+      },
+    })),
+  }));
+
+  return <ContextMenu groups={groups} position={position} onClose={onClose} />;
+};

--- a/src/components/editor/timeline/TrackLabel.tsx
+++ b/src/components/editor/timeline/TrackLabel.tsx
@@ -32,6 +32,7 @@ import { toggleTrackPropertyWithHistory } from "@/core/history/trackPropertyActi
 interface TrackLabelProps {
   track: Track;
   visualSpec?: TrackVisualSpec;
+  onContextMenu?: (e: React.MouseEvent, trackId: string) => void;
 }
 
 const TRACK_ROLE_ICONS: Record<TrackVisualRole, typeof Video> = {
@@ -55,13 +56,9 @@ const TRACK_ROLE_ICONS: Record<TrackVisualRole, typeof Video> = {
 export const TrackLabel: React.FC<TrackLabelProps> = ({
   track,
   visualSpec: visualSpecProp,
+  onContextMenu,
 }) => {
-  const {
-    tracks,
-    clips,
-    gaps,
-    mainVideoTrackId,
-  } = useTimelineStore();
+  const { tracks, clips, gaps, mainVideoTrackId } = useTimelineStore();
   const { selectedTrackId, selectTrack } = useUIStore();
   const visualSpec =
     visualSpecProp ??
@@ -78,6 +75,7 @@ export const TrackLabel: React.FC<TrackLabelProps> = ({
 
   return (
     <div
+      data-track-label
       className={`group relative flex items-center gap-2 px-2 transition-colors bg-surface-raised ${isSelected ? "bg-timeline-track-selected ring-1 ring-inset ring-timeline-track-active" : "hover:bg-timeline-track-hover"} ${isEmpty ? "opacity-70" : ""} ${track.locked ? "bg-timeline-track-active/60" : ""}`}
       style={{
         height: `${visualSpec.height}px`,
@@ -89,6 +87,11 @@ export const TrackLabel: React.FC<TrackLabelProps> = ({
         flexShrink: 0,
       }}
       onClick={() => selectTrack(track.id)}
+      onContextMenu={(e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        onContextMenu?.(e, track.id);
+      }}
     >
       <div
         className={`absolute left-0 top-0 h-full w-0.5 ${isSelected ? "bg-timeline-track-label" : "bg-transparent"}`}

--- a/src/core/commands/__tests__/trackCommands.test.ts
+++ b/src/core/commands/__tests__/trackCommands.test.ts
@@ -1,0 +1,304 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { timelineCommands } from "../timelineCommands";
+import type { TimelineCommandContext } from "../types";
+import { useTimelineStore } from "@/store/timelineStore";
+import { useUIStore } from "@/store/uiStore";
+import type { Clip, Track } from "@/types";
+
+vi.mock("@/lib/toast", () => ({
+  toast: {
+    info: vi.fn(),
+    success: vi.fn(),
+    error: vi.fn(),
+    warning: vi.fn(),
+  },
+}));
+
+vi.mock("@/hooks/usePlaybackClock", () => ({
+  getPlaybackClock: () => ({ time: 0 }),
+}));
+
+// ---------------------------------------------------------------------------
+// Shared fixtures
+// ---------------------------------------------------------------------------
+
+const trackA: Track = {
+  id: "track-a",
+  type: "video",
+  name: "Video A",
+  muted: false,
+  locked: false,
+  visible: true,
+  height: 68,
+};
+
+const trackB: Track = {
+  id: "track-b",
+  type: "audio",
+  name: "Audio B",
+  muted: false,
+  locked: false,
+  visible: true,
+  height: 52,
+};
+
+const trackLocked: Track = {
+  id: "track-locked",
+  type: "video",
+  name: "Video Locked",
+  muted: false,
+  locked: true,
+  visible: true,
+  height: 68,
+};
+
+const makeClip = (id: string, trackId: string, startTime = 0): Clip =>
+  ({
+    id,
+    trackId,
+    mediaId: "asset-1",
+    startTime,
+    duration: 5,
+    trimIn: 0,
+    trimOut: 5,
+    x: 0,
+    y: 0,
+    width: 1920,
+    height: 1080,
+    opacity: 1,
+    rotation: 0,
+    volume: 1.0,
+  }) as Clip;
+
+const clipA1 = makeClip("clip-a1", "track-a", 0);
+const clipA2 = makeClip("clip-a2", "track-a", 6);
+const clipB1 = makeClip("clip-b1", "track-b", 0);
+const clipLocked = makeClip("clip-locked", "track-locked", 0);
+
+function resetStores(clips: Clip[] = [clipA1, clipA2, clipB1, clipLocked]) {
+  useTimelineStore.setState({
+    tracks: [trackA, trackB, trackLocked],
+    clips,
+    gaps: [],
+    transitions: [],
+    mainVideoTrackId: "track-a",
+    epoch: 0,
+    zoomLevel: 1,
+    scrollLeft: 0,
+    viewportWidth: 1200,
+    pixelsPerSecond: 100,
+    rippleEditEnabled: false,
+    snapEnabled: true,
+    snapGuides: [],
+  });
+  useUIStore.setState({
+    selectedClipIds: [],
+    selectedGapId: null,
+    selectedTransitionId: null,
+    selectedTrackId: null,
+  });
+}
+
+function makeCtx(
+  trackId: string | null,
+  overrides: Partial<TimelineCommandContext> = {},
+): TimelineCommandContext {
+  const state = useTimelineStore.getState();
+  return {
+    clickedTrackId: trackId,
+    clickedTime: 0,
+    playheadTime: 0,
+    tracks: state.tracks,
+    clips: state.clips,
+    hasClipboard: false,
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// selectAllClipsInTrack (uiStore method)
+// ---------------------------------------------------------------------------
+
+describe("uiStore.selectAllClipsInTrack", () => {
+  beforeEach(() => resetStores());
+
+  it("sets selectedClipIds to all clips on the target track", () => {
+    useUIStore.getState().selectAllClipsInTrack("track-a");
+    const { selectedClipIds } = useUIStore.getState();
+    expect(selectedClipIds).toHaveLength(2);
+    expect(selectedClipIds).toContain("clip-a1");
+    expect(selectedClipIds).toContain("clip-a2");
+  });
+
+  it("does not include clips from other tracks", () => {
+    useUIStore.getState().selectAllClipsInTrack("track-a");
+    const { selectedClipIds } = useUIStore.getState();
+    expect(selectedClipIds).not.toContain("clip-b1");
+    expect(selectedClipIds).not.toContain("clip-locked");
+  });
+
+  it("selects exactly the one clip when a track has a single clip", () => {
+    useUIStore.getState().selectAllClipsInTrack("track-b");
+    expect(useUIStore.getState().selectedClipIds).toEqual(["clip-b1"]);
+  });
+
+  it("results in an empty selection when the track has no clips", () => {
+    // Remove all clips from track-a
+    resetStores([clipB1, clipLocked]);
+    useUIStore.getState().selectAllClipsInTrack("track-a");
+    expect(useUIStore.getState().selectedClipIds).toEqual([]);
+  });
+
+  it("clears selectedGapId after selecting", () => {
+    useUIStore.setState({ selectedGapId: "gap-1" });
+    useUIStore.getState().selectAllClipsInTrack("track-a");
+    expect(useUIStore.getState().selectedGapId).toBeNull();
+  });
+
+  it("clears selectedTransitionId after selecting", () => {
+    useUIStore.setState({ selectedTransitionId: "trans-1" });
+    useUIStore.getState().selectAllClipsInTrack("track-a");
+    expect(useUIStore.getState().selectedTransitionId).toBeNull();
+  });
+
+  it("replaces an existing multi-track selection", () => {
+    useUIStore.setState({ selectedClipIds: ["clip-b1", "clip-a1"] });
+    useUIStore.getState().selectAllClipsInTrack("track-b");
+    expect(useUIStore.getState().selectedClipIds).toEqual(["clip-b1"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// track.selectAllClips command
+// ---------------------------------------------------------------------------
+
+describe("timelineCommands: track.selectAllClips", () => {
+  const cmd = timelineCommands.find((c) => c.id === "track.selectAllClips")!;
+
+  beforeEach(() => resetStores());
+
+  it("is defined in the registry", () => {
+    expect(cmd).toBeDefined();
+  });
+
+  it("is visible when clickedTrackId is set", () => {
+    expect(cmd.isVisible(makeCtx("track-a"))).toBe(true);
+  });
+
+  it("is not visible when clickedTrackId is null", () => {
+    expect(cmd.isVisible(makeCtx(null))).toBe(false);
+  });
+
+  it("is enabled when the track has clips", () => {
+    expect(cmd.isEnabled(makeCtx("track-a"))).toBe(true);
+  });
+
+  it("is disabled when the track has no clips", () => {
+    resetStores([clipB1, clipLocked]); // track-a is now empty
+    expect(cmd.isEnabled(makeCtx("track-a"))).toBe(false);
+  });
+
+  it("provides the correct disabledReason for an empty track", () => {
+    resetStores([clipB1, clipLocked]);
+    expect(cmd.disabledReason?.(makeCtx("track-a"))).toBe("Track has no clips");
+  });
+
+  it("is enabled on a locked track — selection is read-only", () => {
+    expect(cmd.isEnabled(makeCtx("track-locked"))).toBe(true);
+  });
+
+  it("execute selects all clips on the track", () => {
+    cmd.execute(makeCtx("track-a"));
+    const { selectedClipIds } = useUIStore.getState();
+    expect(selectedClipIds).toContain("clip-a1");
+    expect(selectedClipIds).toContain("clip-a2");
+    expect(selectedClipIds).toHaveLength(2);
+  });
+
+  it("execute does not affect clips on other tracks", () => {
+    cmd.execute(makeCtx("track-a"));
+    expect(useUIStore.getState().selectedClipIds).not.toContain("clip-b1");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// track.deleteAllClips command
+// ---------------------------------------------------------------------------
+
+describe("timelineCommands: track.deleteAllClips", () => {
+  const cmd = timelineCommands.find((c) => c.id === "track.deleteAllClips")!;
+
+  beforeEach(() => resetStores());
+
+  it("is defined in the registry", () => {
+    expect(cmd).toBeDefined();
+  });
+
+  it("is visible when clickedTrackId is set", () => {
+    expect(cmd.isVisible(makeCtx("track-a"))).toBe(true);
+  });
+
+  it("is not visible when clickedTrackId is null", () => {
+    expect(cmd.isVisible(makeCtx(null))).toBe(false);
+  });
+
+  it("is enabled on an unlocked non-empty track", () => {
+    expect(cmd.isEnabled(makeCtx("track-a"))).toBe(true);
+  });
+
+  it("is disabled on a locked track", () => {
+    expect(cmd.isEnabled(makeCtx("track-locked"))).toBe(false);
+  });
+
+  it("provides disabledReason 'Track is locked' for locked tracks", () => {
+    expect(cmd.disabledReason?.(makeCtx("track-locked"))).toBe("Track is locked");
+  });
+
+  it("is disabled when the track has no clips", () => {
+    resetStores([clipB1, clipLocked]); // track-a is now empty
+    expect(cmd.isEnabled(makeCtx("track-a"))).toBe(false);
+  });
+
+  it("provides disabledReason 'Track has no clips' for an empty track", () => {
+    resetStores([clipB1, clipLocked]);
+    expect(cmd.disabledReason?.(makeCtx("track-a"))).toBe("Track has no clips");
+  });
+
+  it("marks the command as danger", () => {
+    expect(cmd.danger).toBe(true);
+  });
+
+  it("execute removes all clips from the target track", () => {
+    cmd.execute(makeCtx("track-a"));
+    const remaining = useTimelineStore.getState().clips.filter(
+      (c) => c.trackId === "track-a",
+    );
+    expect(remaining).toHaveLength(0);
+  });
+
+  it("execute does not remove clips from other tracks", () => {
+    cmd.execute(makeCtx("track-a"));
+    const { clips } = useTimelineStore.getState();
+    expect(clips.some((c) => c.id === "clip-b1")).toBe(true);
+  });
+
+  it("execute does not touch clips on the locked track", () => {
+    cmd.execute(makeCtx("track-a"));
+    const { clips } = useTimelineStore.getState();
+    expect(clips.some((c) => c.id === "clip-locked")).toBe(true);
+  });
+
+  it("execute clears selectedClipIds after deletion", () => {
+    useUIStore.setState({ selectedClipIds: ["clip-a1", "clip-a2"] });
+    cmd.execute(makeCtx("track-a"));
+    expect(useUIStore.getState().selectedClipIds).toHaveLength(0);
+  });
+
+  it("does nothing when execute is called but the track is empty", () => {
+    resetStores([clipB1, clipLocked]);
+    const before = useTimelineStore.getState().clips.length;
+    // isEnabled is false, but call execute directly to verify guard
+    cmd.execute(makeCtx("track-a"));
+    expect(useTimelineStore.getState().clips.length).toBe(before);
+  });
+});

--- a/src/core/commands/timelineCommands.ts
+++ b/src/core/commands/timelineCommands.ts
@@ -12,6 +12,8 @@ import {
   Lock,
   VolumeX,
   EyeOff,
+  CheckSquare,
+  Trash2,
 } from "lucide-react";
 import type { TimelineCommand } from "./types";
 import { clipboardService } from "@/core/clipboard/clipboardService";
@@ -20,6 +22,7 @@ import { useUIStore } from "@/store/uiStore";
 import { toast } from "@/lib/toast";
 import { GapManager } from "@/lib/timeline/gapManager";
 import { toggleTrackPropertyWithHistory } from "@/core/history/trackPropertyActions";
+import { EditingActions } from "@/core/interactions";
 
 export const timelineCommands: TimelineCommand[] = [
   // ─── Clipboard ──────────────────────────────────────────────────────────────
@@ -34,7 +37,10 @@ export const timelineCommands: TimelineCommand[] = [
     isEnabled: () => clipboardService.hasClips(),
     disabledReason: () => "Clipboard is empty",
     execute: (ctx) => {
-      clipboardService.pasteClips(ctx.clickedTime, ctx.clickedTrackId || undefined);
+      clipboardService.pasteClips(
+        ctx.clickedTime,
+        ctx.clickedTrackId || undefined,
+      );
     },
   },
 
@@ -62,7 +68,11 @@ export const timelineCommands: TimelineCommand[] = [
     icon: Scissors,
     group: "gap",
     isVisible: (ctx) => Boolean(ctx.clickedTrackId),
-    isEnabled: (ctx) => Boolean(ctx.clickedTrackId && !ctx.tracks.find((track) => track.id === ctx.clickedTrackId)?.locked),
+    isEnabled: (ctx) =>
+      Boolean(
+        ctx.clickedTrackId &&
+        !ctx.tracks.find((track) => track.id === ctx.clickedTrackId)?.locked,
+      ),
     disabledReason: () => "Track is locked or no track is selected",
     execute: (ctx) => {
       if (!ctx.clickedTrackId) return;
@@ -125,7 +135,9 @@ export const timelineCommands: TimelineCommand[] = [
     execute: (ctx) => {
       if (!ctx.clickedTrackId) return;
       toggleTrackPropertyWithHistory(ctx.clickedTrackId, "locked");
-      const track = useTimelineStore.getState().tracks.find((t) => t.id === ctx.clickedTrackId);
+      const track = useTimelineStore
+        .getState()
+        .tracks.find((t) => t.id === ctx.clickedTrackId);
       toast.info(track?.locked ? "Track locked" : "Track unlocked");
     },
   },
@@ -137,18 +149,26 @@ export const timelineCommands: TimelineCommand[] = [
     icon: VolumeX,
     group: "track",
     isVisible: (ctx) => Boolean(ctx.clickedTrackId),
-    isEnabled: (ctx) => Boolean(ctx.clickedTrackId && !ctx.tracks.find((track) => track.id === ctx.clickedTrackId)?.locked),
+    isEnabled: (ctx) =>
+      Boolean(
+        ctx.clickedTrackId &&
+        !ctx.tracks.find((track) => track.id === ctx.clickedTrackId)?.locked,
+      ),
     disabledReason: () => "Unlock the track before changing mute",
     execute: (ctx) => {
       if (!ctx.clickedTrackId) return;
       const store = useTimelineStore.getState();
-      const trackBefore = store.tracks.find((track) => track.id === ctx.clickedTrackId);
+      const trackBefore = store.tracks.find(
+        (track) => track.id === ctx.clickedTrackId,
+      );
       if (trackBefore?.locked) {
         toast.info("Unlock the track before changing mute");
         return;
       }
       toggleTrackPropertyWithHistory(ctx.clickedTrackId, "muted");
-      const track = useTimelineStore.getState().tracks.find((t) => t.id === ctx.clickedTrackId);
+      const track = useTimelineStore
+        .getState()
+        .tracks.find((t) => t.id === ctx.clickedTrackId);
       toast.info(track?.muted ? "Track muted" : "Track unmuted");
     },
   },
@@ -164,8 +184,60 @@ export const timelineCommands: TimelineCommand[] = [
     execute: (ctx) => {
       if (!ctx.clickedTrackId) return;
       toggleTrackPropertyWithHistory(ctx.clickedTrackId, "visible");
-      const track = useTimelineStore.getState().tracks.find((t) => t.id === ctx.clickedTrackId);
+      const track = useTimelineStore
+        .getState()
+        .tracks.find((t) => t.id === ctx.clickedTrackId);
       toast.info(track?.visible ? "Track visible" : "Track hidden");
+    },
+  },
+
+  // ─── Track Clip Selection & Deletion ────────────────────────────────────────
+  {
+    id: "track.selectAllClips",
+    label: "Select All Clips in Track",
+    shortcutLabel: "⌘A",
+    icon: CheckSquare,
+    group: "track",
+    isVisible: (ctx) => Boolean(ctx.clickedTrackId),
+    isEnabled: (ctx) => {
+      if (!ctx.clickedTrackId) return false;
+      return ctx.clips.some((c) => c.trackId === ctx.clickedTrackId);
+    },
+    disabledReason: () => "Track has no clips",
+    execute: (ctx) => {
+      if (!ctx.clickedTrackId) return;
+      useUIStore.getState().selectAllClipsInTrack(ctx.clickedTrackId);
+    },
+  },
+  {
+    id: "track.deleteAllClips",
+    label: "Delete All Clips in Track",
+    icon: Trash2,
+    group: "track",
+    danger: true,
+    isVisible: (ctx) => Boolean(ctx.clickedTrackId),
+    isEnabled: (ctx) => {
+      if (!ctx.clickedTrackId) return false;
+      const track = ctx.tracks.find((t) => t.id === ctx.clickedTrackId);
+      if (track?.locked) return false;
+      return ctx.clips.some((c) => c.trackId === ctx.clickedTrackId);
+    },
+    disabledReason: (ctx) => {
+      const track = ctx.tracks.find((t) => t.id === ctx.clickedTrackId);
+      return track?.locked ? "Track is locked" : "Track has no clips";
+    },
+    execute: (ctx) => {
+      if (!ctx.clickedTrackId) return;
+      const ids = ctx.clips
+        .filter((c) => c.trackId === ctx.clickedTrackId)
+        .map((c) => c.id);
+      if (ids.length === 0) return;
+      const result = EditingActions.deleteSelection(ids, false);
+      if (result) {
+        toast.success(
+          `Deleted ${result.deletedClipIds.length} clip${result.deletedClipIds.length !== 1 ? "s" : ""} from track`,
+        );
+      }
     },
   },
 ];

--- a/src/lib/export/__tests__/exportOutputResolution.test.ts
+++ b/src/lib/export/__tests__/exportOutputResolution.test.ts
@@ -1,0 +1,940 @@
+/**
+ * Export Output Resolution Tests
+ *
+ * Verifies that exportVideo, exportSequence, and exportFrame correctly pass
+ * arbitrary output dimensions (e.g. 4K, 720p, portrait) to the native
+ * compositor WITHOUT requiring a match against the project canvas size.
+ *
+ * Architecture under test:
+ *   - buildNativeFrameRequest receives (outputWidth, outputHeight) independently
+ *     from (canvasWidth, canvasHeight) in the project snapshot.
+ *   - to_video_project_request() on the Rust side applies
+ *       scale_x = outputW / canvasW,  scale_y = outputH / canvasH
+ *     to every layer before the GPU compositor renders natively at output size.
+ *   - FrameRequest::validate() enforces: non-zero, ≤ 8192 — no equality constraint.
+ *
+ * Before the fix all three callers contained a dimension-equality guard that
+ * short-circuited to null / threw before buildNativeFrameRequest was ever
+ * called.  These tests prove that guard is gone in every entry point.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { invoke } from "@tauri-apps/api/core";
+import type { Project } from "@/types";
+
+// ─── Hoisted mocks ──────────────────────────────────────────────────────────
+// vi.hoisted() ensures these run before any module is evaluated.
+
+const {
+  mockIsTauriRuntime,
+  mockRenderNativeFrame,
+  mockBuildNativeFrameRequest,
+  mockEvaluateScene,
+} = vi.hoisted(() => ({
+  mockIsTauriRuntime: vi.fn(() => true),
+  mockRenderNativeFrame: vi.fn(),
+  mockBuildNativeFrameRequest: vi.fn(),
+  mockEvaluateScene: vi.fn(),
+}));
+
+// ─── Module mocks ────────────────────────────────────────────────────────────
+
+vi.mock("@tauri-apps/api/core", () => {
+  class MockChannel {
+    onmessage: ((msg: unknown) => void) | null = null;
+  }
+  return {
+    invoke: vi.fn(),
+    Channel: MockChannel,
+    convertFileSrc: vi.fn((p: string) => p),
+  };
+});
+
+vi.mock("@/lib/platform/tauri", () => ({
+  isTauriRuntime: () => mockIsTauriRuntime(),
+  renderNativeFrame: (...args: unknown[]) => mockRenderNativeFrame(...args),
+}));
+
+vi.mock("@/components/editor/preview/nativeVideoPreview", () => ({
+  buildNativeFrameRequest: (...args: unknown[]) =>
+    mockBuildNativeFrameRequest(...args),
+}));
+
+vi.mock("@/core/evaluation/evaluator", () => ({
+  evaluateTimelineSceneCached: (...args: unknown[]) =>
+    mockEvaluateScene(...args),
+  clearEvaluationCache: vi.fn(),
+}));
+
+vi.mock("@/core/resources/ResourceCache", () => ({
+  getResourceCache: vi.fn(() => ({ clear: vi.fn() })),
+}));
+
+vi.mock("@/core/timeline/audioClips", () => ({
+  getActiveAudioClips: vi.fn(() => []),
+}));
+
+vi.mock("@/core/render/nativeRasterBridge", () => {
+  class MockNativeRasterBridge {
+    rasterize = vi.fn(async () => []);
+    rasterizeSmartOverlays = vi.fn(async () => []);
+    dispose = vi.fn();
+  }
+  return { NativeRasterBridge: MockNativeRasterBridge };
+});
+
+vi.mock("../exportPreflight", () => ({
+  verifyExportDependencies: vi.fn(async () => ({
+    ready: true,
+    missingEffects: [],
+    missingImageAssets: [],
+    missingAudioAssets: [],
+  })),
+  ExportBlockedError: class extends Error {},
+}));
+
+vi.mock("@/core/platform", () => ({
+  platform: { isCapacitor: () => false, isTauri: () => true },
+}));
+
+vi.mock("@/services/telemetryCollector", () => ({
+  telemetryCollector: { recordExportSpan: vi.fn() },
+}));
+
+vi.mock("../platform/pathConversion", () => ({
+  toNativePath: (p: string) => p,
+}));
+
+// ─── Shared fixtures ─────────────────────────────────────────────────────────
+
+/** A project whose canvas is 1920×1080 — the most common canvas size. */
+const CANVAS_1080P = { canvasWidth: 1920, canvasHeight: 1080 };
+
+/**
+ * A project whose canvas is 1080×1920 — portrait / Reels / Shorts.
+ * Used to verify that a portrait canvas can be exported at a portrait 4K
+ * output resolution (2160×3840) without being blocked.
+ */
+const CANVAS_PORTRAIT = { canvasWidth: 1080, canvasHeight: 1920 };
+
+/** A project whose canvas is 1080×1080 — square / Instagram. */
+const CANVAS_SQUARE = { canvasWidth: 1080, canvasHeight: 1080 };
+
+function makeProject(canvas = CANVAS_1080P): Project {
+  return {
+    id: "proj-resolution-test",
+    name: "Resolution Test Project",
+    canvasWidth: canvas.canvasWidth,
+    canvasHeight: canvas.canvasHeight,
+    frameRate: 30,
+    duration: 10,
+    aspectRatio: "16:9",
+    createdAt: 0,
+    updatedAt: 0,
+  };
+}
+
+/** Returns a mock EvaluatedScene with configurable canvas metadata. */
+function makeScene(canvas = CANVAS_1080P) {
+  return {
+    metadata: {
+      canvasWidth: canvas.canvasWidth,
+      canvasHeight: canvas.canvasHeight,
+    },
+    visualLayers: [],
+    transitions: [],
+    clips: [],
+  };
+}
+
+/**
+ * The mock native frame request object returned by buildNativeFrameRequest.
+ * Its exact shape does not matter for these tests — what matters is that it
+ * is truthy so the export loops proceed to renderNativeFrame.
+ */
+const MOCK_FRAME_REQUEST = { id: "mock-native-frame-request" };
+
+/**
+ * Build an RGBA ArrayBuffer of the given pixel dimensions.
+ * Each pixel is fully opaque red (255, 0, 0, 255).
+ */
+function makeRgbaBuffer(w: number, h: number): ArrayBuffer {
+  const buf = new Uint8Array(w * h * 4);
+  for (let i = 0; i < buf.length; i += 4) {
+    buf[i] = 255; // R
+    buf[i + 3] = 255; // A
+  }
+  return buf.buffer;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+//  1. exportVideo — output resolution decoupled from canvas
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("exportVideo — output resolution", () => {
+  const mockInvoke = vi.mocked(invoke);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockInvoke.mockImplementation(async (cmd: string) => {
+      if (cmd === "start_video_export") return "sess-001";
+      if (cmd === "write_export_frames_batch") return;
+      if (cmd === "finalize_video_export") return;
+      if (cmd === "cancel_video_export") return;
+    });
+
+    mockBuildNativeFrameRequest.mockReturnValue(MOCK_FRAME_REQUEST);
+    mockEvaluateScene.mockReturnValue(makeScene(CANVAS_1080P));
+  });
+
+  /**
+   * Core regression: 4K export of a 1080p project.
+   * Before the fix this threw "Frame 0 is outside the native compositor contract"
+   * because 3840 !== 1920 and 2160 !== 1080.
+   */
+  it("exports 4K (3840×2160) from a 1080p canvas without throwing", async () => {
+    const { exportVideo } = await import("../videoExport");
+
+    mockRenderNativeFrame.mockResolvedValue(makeRgbaBuffer(3840, 2160));
+
+    const result = await exportVideo({
+      clips: [],
+      tracks: [],
+      assets: [],
+      project: makeProject(CANVAS_1080P),
+      epoch: 1,
+      startTime: 0,
+      endTime: 1 / 30, // 1 frame
+      outputPath: "/out/4k.mp4",
+      width: 3840,
+      height: 2160,
+      frameRate: 30,
+    });
+
+    expect(result.cancelled).toBe(false);
+    expect(result.totalFrames).toBe(1);
+  });
+
+  it("passes the requested output dimensions — not canvas dimensions — to buildNativeFrameRequest", async () => {
+    const { exportVideo } = await import("../videoExport");
+
+    mockRenderNativeFrame.mockResolvedValue(makeRgbaBuffer(3840, 2160));
+
+    await exportVideo({
+      clips: [],
+      tracks: [],
+      assets: [],
+      project: makeProject(CANVAS_1080P),
+      epoch: 1,
+      startTime: 0,
+      endTime: 1 / 30,
+      outputPath: "/out/4k.mp4",
+      width: 3840,
+      height: 2160,
+      frameRate: 30,
+    });
+
+    // The 5th and 6th positional arguments to buildNativeFrameRequest are
+    // outputWidth and outputHeight.  They must be the export target dimensions,
+    // not the canvas dimensions.
+    const [, , , , outputWidth, outputHeight] =
+      mockBuildNativeFrameRequest.mock.calls[0];
+    expect(outputWidth).toBe(3840);
+    expect(outputHeight).toBe(2160);
+  });
+
+  it("passes canvas dimensions separately in the project snapshot — not in outputWidth/Height", async () => {
+    const { exportVideo } = await import("../videoExport");
+
+    mockRenderNativeFrame.mockResolvedValue(makeRgbaBuffer(3840, 2160));
+
+    await exportVideo({
+      clips: [],
+      tracks: [],
+      assets: [],
+      project: makeProject(CANVAS_1080P),
+      epoch: 1,
+      startTime: 0,
+      endTime: 1 / 30,
+      outputPath: "/out/4k.mp4",
+      width: 3840,
+      height: 2160,
+      frameRate: 30,
+    });
+
+    // The scene's canvasWidth / canvasHeight (1920×1080) must NOT appear as
+    // the outputWidth/Height argument to buildNativeFrameRequest.
+    const [, , , , outputWidth, outputHeight] =
+      mockBuildNativeFrameRequest.mock.calls[0];
+    expect(outputWidth).not.toBe(CANVAS_1080P.canvasWidth);
+    expect(outputHeight).not.toBe(CANVAS_1080P.canvasHeight);
+  });
+
+  it("downscales 1080p canvas to 720p export correctly", async () => {
+    const { exportVideo } = await import("../videoExport");
+
+    mockRenderNativeFrame.mockResolvedValue(makeRgbaBuffer(1280, 720));
+
+    const result = await exportVideo({
+      clips: [],
+      tracks: [],
+      assets: [],
+      project: makeProject(CANVAS_1080P),
+      epoch: 1,
+      startTime: 0,
+      endTime: 1 / 30,
+      outputPath: "/out/720p.mp4",
+      width: 1280,
+      height: 720,
+      frameRate: 30,
+    });
+
+    expect(result.cancelled).toBe(false);
+
+    const [, , , , outputWidth, outputHeight] =
+      mockBuildNativeFrameRequest.mock.calls[0];
+    expect(outputWidth).toBe(1280);
+    expect(outputHeight).toBe(720);
+  });
+
+  it("exports portrait 4K (2160×3840) from a portrait canvas (1080×1920)", async () => {
+    const { exportVideo } = await import("../videoExport");
+
+    mockEvaluateScene.mockReturnValue(makeScene(CANVAS_PORTRAIT));
+    mockRenderNativeFrame.mockResolvedValue(makeRgbaBuffer(2160, 3840));
+
+    const result = await exportVideo({
+      clips: [],
+      tracks: [],
+      assets: [],
+      project: makeProject(CANVAS_PORTRAIT),
+      epoch: 1,
+      startTime: 0,
+      endTime: 1 / 30,
+      outputPath: "/out/portrait-4k.mp4",
+      width: 2160,
+      height: 3840,
+      frameRate: 30,
+    });
+
+    expect(result.cancelled).toBe(false);
+
+    const [, , , , outputWidth, outputHeight] =
+      mockBuildNativeFrameRequest.mock.calls[0];
+    expect(outputWidth).toBe(2160);
+    expect(outputHeight).toBe(3840);
+  });
+
+  it("exports square 4K (2160×2160) from a square canvas (1080×1080)", async () => {
+    const { exportVideo } = await import("../videoExport");
+
+    mockEvaluateScene.mockReturnValue(makeScene(CANVAS_SQUARE));
+    mockRenderNativeFrame.mockResolvedValue(makeRgbaBuffer(2160, 2160));
+
+    const result = await exportVideo({
+      clips: [],
+      tracks: [],
+      assets: [],
+      project: makeProject(CANVAS_SQUARE),
+      epoch: 1,
+      startTime: 0,
+      endTime: 1 / 30,
+      outputPath: "/out/square-4k.mp4",
+      width: 2160,
+      height: 2160,
+      frameRate: 30,
+    });
+
+    expect(result.cancelled).toBe(false);
+
+    const [, , , , outputWidth, outputHeight] =
+      mockBuildNativeFrameRequest.mock.calls[0];
+    expect(outputWidth).toBe(2160);
+    expect(outputHeight).toBe(2160);
+  });
+
+  /**
+   * Same-size export (canvas == output) must continue to work — this is the
+   * pre-existing path and must not have been broken by removing the guard.
+   * The scale factors in Rust become 1.0 × 1.0, a no-op transform.
+   */
+  it("same-size export (output == canvas) continues to work", async () => {
+    const { exportVideo } = await import("../videoExport");
+
+    mockRenderNativeFrame.mockResolvedValue(makeRgbaBuffer(1920, 1080));
+
+    const result = await exportVideo({
+      clips: [],
+      tracks: [],
+      assets: [],
+      project: makeProject(CANVAS_1080P),
+      epoch: 1,
+      startTime: 0,
+      endTime: 1 / 30,
+      outputPath: "/out/1080p-same-size.mp4",
+      width: 1920,
+      height: 1080,
+      frameRate: 30,
+    });
+
+    expect(result.cancelled).toBe(false);
+
+    const [, , , , outputWidth, outputHeight] =
+      mockBuildNativeFrameRequest.mock.calls[0];
+    expect(outputWidth).toBe(1920);
+    expect(outputHeight).toBe(1080);
+  });
+
+  /**
+   * buildNativeFrameRequest may still return null for scene-content reasons
+   * (unsupported layer type, missing raster asset, etc.).  The export must
+   * still throw the contract error in that case — the null path is not gone,
+   * only the pre-emptive dimension guard is.
+   */
+  it("still throws contract error when buildNativeFrameRequest returns null for scene-content reasons", async () => {
+    const { exportVideo } = await import("../videoExport");
+
+    // Simulate a scene with an unsupported layer type that makes
+    // buildNativeFrameRequest return null.
+    mockBuildNativeFrameRequest.mockReturnValue(null);
+
+    await expect(
+      exportVideo({
+        clips: [],
+        tracks: [],
+        assets: [],
+        project: makeProject(CANVAS_1080P),
+        epoch: 1,
+        startTime: 0,
+        endTime: 1 / 30,
+        outputPath: "/out/unsupported.mp4",
+        width: 3840,
+        height: 2160,
+        frameRate: 30,
+      }),
+    ).rejects.toThrow("outside the native compositor contract");
+  });
+
+  it("calls buildNativeFrameRequest once per frame across a multi-frame export", async () => {
+    const { exportVideo } = await import("../videoExport");
+
+    // 9 frames at 30fps = 0.3 seconds
+    mockRenderNativeFrame.mockResolvedValue(makeRgbaBuffer(3840, 2160));
+
+    await exportVideo({
+      clips: [],
+      tracks: [],
+      assets: [],
+      project: makeProject(CANVAS_1080P),
+      epoch: 1,
+      startTime: 0,
+      endTime: 9 / 30,
+      outputPath: "/out/multi-frame-4k.mp4",
+      width: 3840,
+      height: 2160,
+      frameRate: 30,
+    });
+
+    expect(mockBuildNativeFrameRequest).toHaveBeenCalledTimes(9);
+
+    // Every call must use the output dimensions, not the canvas dimensions.
+    for (const call of mockBuildNativeFrameRequest.mock.calls) {
+      const [, , , , w, h] = call;
+      expect(w).toBe(3840);
+      expect(h).toBe(2160);
+    }
+  });
+
+  it("sends the correct output dimensions to the FFmpeg session, not the canvas dimensions", async () => {
+    const { exportVideo } = await import("../videoExport");
+
+    mockRenderNativeFrame.mockResolvedValue(makeRgbaBuffer(3840, 2160));
+
+    await exportVideo({
+      clips: [],
+      tracks: [],
+      assets: [],
+      project: makeProject(CANVAS_1080P),
+      epoch: 1,
+      startTime: 0,
+      endTime: 1 / 30,
+      outputPath: "/out/ffmpeg-dims.mp4",
+      width: 3840,
+      height: 2160,
+      frameRate: 30,
+    });
+
+    expect(mockInvoke).toHaveBeenCalledWith(
+      "start_video_export",
+      expect.objectContaining({
+        config: expect.objectContaining({ width: 3840, height: 2160 }),
+      }),
+    );
+  });
+
+  /**
+   * The dimension validator (applied before any frame work begins) must still
+   * reject dimensions that exceed the 8 K Rust contract limit (7680×4320 is
+   * the JS-side cap; the Rust cap is 8192×8192).
+   */
+  it("still rejects oversized output dimensions before attempting any frame work", async () => {
+    const { exportVideo } = await import("../videoExport");
+
+    await expect(
+      exportVideo({
+        clips: [],
+        tracks: [],
+        assets: [],
+        project: makeProject(CANVAS_1080P),
+        epoch: 1,
+        startTime: 0,
+        endTime: 1 / 30,
+        outputPath: "/out/too-big.mp4",
+        width: 9000,
+        height: 1080,
+        frameRate: 30,
+      }),
+    ).rejects.toThrow("Invalid export dimensions: 9000x1080");
+
+    expect(mockBuildNativeFrameRequest).not.toHaveBeenCalled();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+//  2. exportSequence — output resolution decoupled from canvas
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("exportSequence — output resolution", () => {
+  // exportSequence renders to a canvas element; set up a minimal DOM stub.
+  const originalCreateElement = globalThis.document?.createElement?.bind(
+    globalThis.document,
+  );
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockBuildNativeFrameRequest.mockReturnValue(MOCK_FRAME_REQUEST);
+    mockEvaluateScene.mockReturnValue(makeScene(CANVAS_1080P));
+
+    // Minimal canvas stub: createImageData, putImageData, and toBlob.
+    const stubCanvas = {
+      width: 0,
+      height: 0,
+      getContext: () => ({
+        createImageData: (w: number, h: number) => ({
+          data: new Uint8ClampedArray(w * h * 4),
+        }),
+        putImageData: vi.fn(),
+      }),
+      toBlob: (cb: (b: Blob | null) => void) =>
+        cb(new Blob(["frame"], { type: "image/png" })),
+    };
+
+    vi.spyOn(document, "createElement").mockImplementation((tag: string) => {
+      if (tag === "canvas") return stubCanvas as unknown as HTMLElement;
+      return originalCreateElement?.(tag) ?? ({} as HTMLElement);
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("exports 4K (3840×2160) image sequence from a 1080p canvas without throwing", async () => {
+    const { exportSequence } = await import("../exportSequence");
+
+    mockRenderNativeFrame.mockResolvedValue(makeRgbaBuffer(3840, 2160));
+
+    const result = await exportSequence({
+      clips: [],
+      tracks: [],
+      assets: [],
+      project: makeProject(CANVAS_1080P),
+      epoch: 1,
+      startTime: 0,
+      endTime: 1 / 30,
+      width: 3840,
+      height: 2160,
+      frameRate: 30,
+    });
+
+    expect(result.cancelled).toBe(false);
+    expect(result.totalFrames).toBe(1);
+  });
+
+  it("passes export output dimensions — not canvas dimensions — to buildNativeFrameRequest", async () => {
+    const { exportSequence } = await import("../exportSequence");
+
+    mockRenderNativeFrame.mockResolvedValue(makeRgbaBuffer(3840, 2160));
+
+    await exportSequence({
+      clips: [],
+      tracks: [],
+      assets: [],
+      project: makeProject(CANVAS_1080P),
+      epoch: 1,
+      startTime: 0,
+      endTime: 1 / 30,
+      width: 3840,
+      height: 2160,
+      frameRate: 30,
+    });
+
+    const [, , , , outputWidth, outputHeight] =
+      mockBuildNativeFrameRequest.mock.calls[0];
+    expect(outputWidth).toBe(3840);
+    expect(outputHeight).toBe(2160);
+  });
+
+  it("same-size sequence export (output == canvas) continues to work", async () => {
+    const { exportSequence } = await import("../exportSequence");
+
+    mockRenderNativeFrame.mockResolvedValue(makeRgbaBuffer(1920, 1080));
+
+    const result = await exportSequence({
+      clips: [],
+      tracks: [],
+      assets: [],
+      project: makeProject(CANVAS_1080P),
+      epoch: 1,
+      startTime: 0,
+      endTime: 1 / 30,
+      width: 1920,
+      height: 1080,
+      frameRate: 30,
+    });
+
+    expect(result.cancelled).toBe(false);
+  });
+
+  it("still throws contract error when buildNativeFrameRequest returns null for scene-content reasons", async () => {
+    const { exportSequence } = await import("../exportSequence");
+
+    mockBuildNativeFrameRequest.mockReturnValue(null);
+
+    await expect(
+      exportSequence({
+        clips: [],
+        tracks: [],
+        assets: [],
+        project: makeProject(CANVAS_1080P),
+        epoch: 1,
+        startTime: 0,
+        endTime: 1 / 30,
+        width: 3840,
+        height: 2160,
+        frameRate: 30,
+      }),
+    ).rejects.toThrow("outside the native compositor contract");
+  });
+
+  it("exports portrait 4K sequence (2160×3840) from a portrait canvas (1080×1920)", async () => {
+    const { exportSequence } = await import("../exportSequence");
+
+    mockEvaluateScene.mockReturnValue(makeScene(CANVAS_PORTRAIT));
+    mockRenderNativeFrame.mockResolvedValue(makeRgbaBuffer(2160, 3840));
+
+    const result = await exportSequence({
+      clips: [],
+      tracks: [],
+      assets: [],
+      project: makeProject(CANVAS_PORTRAIT),
+      epoch: 1,
+      startTime: 0,
+      endTime: 1 / 30,
+      width: 2160,
+      height: 3840,
+      frameRate: 30,
+    });
+
+    expect(result.cancelled).toBe(false);
+
+    const [, , , , outputWidth, outputHeight] =
+      mockBuildNativeFrameRequest.mock.calls[0];
+    expect(outputWidth).toBe(2160);
+    expect(outputHeight).toBe(3840);
+  });
+
+  it("invokes the onFrame callback with each rendered blob", async () => {
+    const { exportSequence } = await import("../exportSequence");
+
+    mockRenderNativeFrame.mockResolvedValue(makeRgbaBuffer(3840, 2160));
+
+    const onFrame = vi.fn(async (_frameNumber: number, _blob: Blob) => {});
+
+    await exportSequence({
+      clips: [],
+      tracks: [],
+      assets: [],
+      project: makeProject(CANVAS_1080P),
+      epoch: 1,
+      startTime: 0,
+      endTime: 3 / 30, // 3 frames
+      width: 3840,
+      height: 2160,
+      frameRate: 30,
+      onFrame,
+    });
+
+    expect(onFrame).toHaveBeenCalledTimes(3);
+    for (const [frameNumber, blob] of onFrame.mock.calls) {
+      expect(typeof frameNumber).toBe("number");
+      expect(blob).toBeInstanceOf(Blob);
+    }
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+//  3. exportFrame — output resolution decoupled from canvas
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("exportFrame — output resolution", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockBuildNativeFrameRequest.mockReturnValue(MOCK_FRAME_REQUEST);
+    mockEvaluateScene.mockReturnValue(makeScene(CANVAS_1080P));
+
+    // Minimal canvas stub for single-frame blob encoding.
+    vi.spyOn(document, "createElement").mockImplementation((tag: string) => {
+      if (tag === "canvas") {
+        return {
+          width: 0,
+          height: 0,
+          getContext: () => ({
+            createImageData: (w: number, h: number) => ({
+              data: new Uint8ClampedArray(w * h * 4),
+            }),
+            putImageData: vi.fn(),
+          }),
+          toBlob: (cb: (b: Blob | null) => void) =>
+            cb(new Blob(["frame"], { type: "image/png" })),
+        } as unknown as HTMLElement;
+      }
+      return {} as HTMLElement;
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("exports a single 4K frame from a 1080p canvas without throwing", async () => {
+    const { exportFrame } = await import("../exportFrame");
+
+    mockRenderNativeFrame.mockResolvedValue(makeRgbaBuffer(3840, 2160));
+
+    const blob = await exportFrame({
+      time: 0,
+      clips: [],
+      tracks: [],
+      assets: [],
+      project: makeProject(CANVAS_1080P),
+      epoch: 1,
+      width: 3840,
+      height: 2160,
+    });
+
+    expect(blob).toBeInstanceOf(Blob);
+  });
+
+  it("passes output dimensions — not canvas dimensions — to buildNativeFrameRequest", async () => {
+    const { exportFrame } = await import("../exportFrame");
+
+    mockRenderNativeFrame.mockResolvedValue(makeRgbaBuffer(3840, 2160));
+
+    await exportFrame({
+      time: 0,
+      clips: [],
+      tracks: [],
+      assets: [],
+      project: makeProject(CANVAS_1080P),
+      epoch: 1,
+      width: 3840,
+      height: 2160,
+    });
+
+    const [, , , , outputWidth, outputHeight] =
+      mockBuildNativeFrameRequest.mock.calls[0];
+    expect(outputWidth).toBe(3840);
+    expect(outputHeight).toBe(2160);
+  });
+
+  it("same-size single-frame export (output == canvas) continues to work", async () => {
+    const { exportFrame } = await import("../exportFrame");
+
+    mockRenderNativeFrame.mockResolvedValue(makeRgbaBuffer(1920, 1080));
+
+    const blob = await exportFrame({
+      time: 1.5,
+      clips: [],
+      tracks: [],
+      assets: [],
+      project: makeProject(CANVAS_1080P),
+      epoch: 1,
+      width: 1920,
+      height: 1080,
+    });
+
+    expect(blob).toBeInstanceOf(Blob);
+  });
+
+  it("still throws contract error when buildNativeFrameRequest returns null for scene-content reasons", async () => {
+    const { exportFrame } = await import("../exportFrame");
+
+    mockBuildNativeFrameRequest.mockReturnValue(null);
+
+    await expect(
+      exportFrame({
+        time: 0,
+        clips: [],
+        tracks: [],
+        assets: [],
+        project: makeProject(CANVAS_1080P),
+        epoch: 1,
+        width: 3840,
+        height: 2160,
+      }),
+    ).rejects.toThrow("outside the native compositor contract");
+  });
+
+  it("exports a portrait 4K frame (2160×3840) from a portrait canvas (1080×1920)", async () => {
+    const { exportFrame } = await import("../exportFrame");
+
+    mockEvaluateScene.mockReturnValue(makeScene(CANVAS_PORTRAIT));
+    mockRenderNativeFrame.mockResolvedValue(makeRgbaBuffer(2160, 3840));
+
+    const blob = await exportFrame({
+      time: 0,
+      clips: [],
+      tracks: [],
+      assets: [],
+      project: makeProject(CANVAS_PORTRAIT),
+      epoch: 1,
+      width: 2160,
+      height: 3840,
+    });
+
+    expect(blob).toBeInstanceOf(Blob);
+
+    const [, , , , outputWidth, outputHeight] =
+      mockBuildNativeFrameRequest.mock.calls[0];
+    expect(outputWidth).toBe(2160);
+    expect(outputHeight).toBe(3840);
+  });
+
+  it("defaults to canvas dimensions when no output size is supplied", async () => {
+    const { exportFrame } = await import("../exportFrame");
+
+    mockRenderNativeFrame.mockResolvedValue(
+      makeRgbaBuffer(CANVAS_1080P.canvasWidth, CANVAS_1080P.canvasHeight),
+    );
+
+    await exportFrame({
+      time: 0,
+      clips: [],
+      tracks: [],
+      assets: [],
+      project: makeProject(CANVAS_1080P),
+      epoch: 1,
+      // width / height intentionally omitted — should default to canvas size
+    });
+
+    const [, , , , outputWidth, outputHeight] =
+      mockBuildNativeFrameRequest.mock.calls[0];
+    expect(outputWidth).toBe(CANVAS_1080P.canvasWidth);
+    expect(outputHeight).toBe(CANVAS_1080P.canvasHeight);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+//  4. Cross-cutting invariants — all three entry points
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("output resolution — cross-cutting invariants", () => {
+  /**
+   * Scale-factor table: for every (canvas, output) pair, verify that the
+   * arguments passed to buildNativeFrameRequest always match the caller-supplied
+   * output dimensions, regardless of the canvas size.  This directly proves the
+   * guard is absent in all three callers.
+   */
+  const resolutionMatrix: Array<{
+    label: string;
+    canvas: { canvasWidth: number; canvasHeight: number };
+    output: { width: number; height: number };
+  }> = [
+    {
+      label: "1080p canvas → 4K",
+      canvas: CANVAS_1080P,
+      output: { width: 3840, height: 2160 },
+    },
+    {
+      label: "1080p canvas → 720p",
+      canvas: CANVAS_1080P,
+      output: { width: 1280, height: 720 },
+    },
+    {
+      label: "1080p canvas → 1080p (identity)",
+      canvas: CANVAS_1080P,
+      output: { width: 1920, height: 1080 },
+    },
+    {
+      label: "portrait canvas → portrait 4K",
+      canvas: CANVAS_PORTRAIT,
+      output: { width: 2160, height: 3840 },
+    },
+    {
+      label: "square canvas → square 4K",
+      canvas: CANVAS_SQUARE,
+      output: { width: 2160, height: 2160 },
+    },
+    {
+      label: "1080p canvas → 8K (max allowed)",
+      canvas: CANVAS_1080P,
+      output: { width: 7680, height: 4320 },
+    },
+  ];
+
+  describe("exportVideo — resolution matrix", () => {
+    const mockInvoke = vi.mocked(invoke);
+
+    beforeEach(() => {
+      vi.clearAllMocks();
+      mockInvoke.mockImplementation(async (cmd: string) => {
+        if (cmd === "start_video_export") return "sess-matrix";
+        if (cmd === "write_export_frames_batch") return;
+        if (cmd === "finalize_video_export") return;
+        if (cmd === "cancel_video_export") return;
+      });
+      mockBuildNativeFrameRequest.mockReturnValue(MOCK_FRAME_REQUEST);
+    });
+
+    for (const { label, canvas, output } of resolutionMatrix) {
+      it(`routes ${label} to compositor at correct output dimensions`, async () => {
+        const { exportVideo } = await import("../videoExport");
+
+        mockEvaluateScene.mockReturnValue(makeScene(canvas));
+        mockRenderNativeFrame.mockResolvedValue(
+          makeRgbaBuffer(output.width, output.height),
+        );
+
+        await exportVideo({
+          clips: [],
+          tracks: [],
+          assets: [],
+          project: makeProject(canvas),
+          epoch: 1,
+          startTime: 0,
+          endTime: 1 / 30,
+          outputPath: `/out/matrix-${output.width}x${output.height}.mp4`,
+          width: output.width,
+          height: output.height,
+          frameRate: 30,
+        });
+
+        const [, , , , w, h] = mockBuildNativeFrameRequest.mock.calls[0];
+        expect(w).toBe(output.width);
+        expect(h).toBe(output.height);
+      });
+    }
+  });
+});

--- a/src/lib/export/exportFrame.ts
+++ b/src/lib/export/exportFrame.ts
@@ -7,7 +7,13 @@
  */
 
 import { evaluateTimelineSceneCached } from "../../core/evaluation/evaluator";
-import type { Clip, Track, MediaAsset, Project, TransitionTimelineItem } from "../../types";
+import type {
+  Clip,
+  Track,
+  MediaAsset,
+  Project,
+  TransitionTimelineItem,
+} from "../../types";
 import { buildNativeFrameRequest } from "@/components/editor/preview/nativeVideoPreview";
 import { isTauriRuntime, renderNativeFrame } from "@/lib/platform/tauri";
 import { NativeRasterBridge } from "@/core/render/nativeRasterBridge";
@@ -72,25 +78,40 @@ export async function exportFrame(options: ExportFrameOptions): Promise<Blob> {
     quality = 0.92,
   } = options;
 
-  const scene = evaluateTimelineSceneCached(time, clips, tracks, assets, project, epoch, transitions);
+  const scene = evaluateTimelineSceneCached(
+    time,
+    clips,
+    tracks,
+    assets,
+    project,
+    epoch,
+    transitions,
+  );
 
   // Native Tauri export is authoritative for a project-sized scene that the
   // native graph can represent. Only explicit native errors are returned to
   // the caller.
   if (!isTauriRuntime()) {
-    throw new Error("[ExportFrame] Native frame export requires the desktop runtime");
+    throw new Error(
+      "[ExportFrame] Native frame export requires the desktop runtime",
+    );
   }
 
-  if (width !== scene.metadata.canvasWidth || height !== scene.metadata.canvasHeight) {
-    throw new Error("[ExportFrame] Native export requires project-sized output dimensions");
-  }
+  // The native compositor renders directly at outputWidth × outputHeight.
+  // to_video_project_request() in Rust applies scale_x = outputW/canvasW and
+  // scale_y = outputH/canvasH to every layer's coordinates before compositing,
+  // so output dimensions may freely differ from the project canvas size.
   const nativeRasterBridge = new NativeRasterBridge();
   try {
     const frameKey = Math.round(time * (project?.frameRate || 30));
-    const rasterLayers = await nativeRasterBridge.rasterize(scene, { frameKey });
+    const rasterLayers = await nativeRasterBridge.rasterize(scene, {
+      frameKey,
+    });
     const activeSmartOverlays = clips.filter(
       (clip): clip is SmartOverlayClip =>
-        clip.kind === "smart-overlay" && time >= clip.startTime && time < clip.startTime + clip.duration,
+        clip.kind === "smart-overlay" &&
+        time >= clip.startTime &&
+        time < clip.startTime + clip.duration,
     );
     const smartOverlayRasters = await nativeRasterBridge.rasterizeSmartOverlays(
       activeSmartOverlays,
@@ -110,25 +131,33 @@ export async function exportFrame(options: ExportFrameOptions): Promise<Blob> {
       { mode: "frameStep", quality: "full" },
     );
     if (!nativeRequest) {
-      throw new Error("[ExportFrame] Frame is outside the native compositor contract");
+      throw new Error(
+        "[ExportFrame] Frame is outside the native compositor contract",
+      );
     }
     let rgba: ArrayBuffer;
     try {
       rgba = await renderNativeFrame(nativeRequest);
     } catch (error) {
-      throw new Error(`[ExportFrame] Native frame export failed: ${error instanceof Error ? error.message : String(error)}`);
+      throw new Error(
+        `[ExportFrame] Native frame export failed: ${error instanceof Error ? error.message : String(error)}`,
+      );
     }
     const canvas = document.createElement("canvas");
     canvas.width = width;
     canvas.height = height;
     const context = canvas.getContext("2d");
-    if (!context) throw new Error("[ExportFrame] Failed to create native export canvas");
+    if (!context)
+      throw new Error("[ExportFrame] Failed to create native export canvas");
     const image = context.createImageData(width, height);
     image.data.set(new Uint8ClampedArray(rgba));
     context.putImageData(image, 0, 0);
     return await new Promise<Blob>((resolve, reject) => {
       canvas.toBlob(
-        (blob) => blob ? resolve(blob) : reject(new Error("[ExportFrame] Failed to encode native frame")),
+        (blob) =>
+          blob
+            ? resolve(blob)
+            : reject(new Error("[ExportFrame] Failed to encode native frame")),
         format === "jpeg" ? "image/jpeg" : "image/png",
         quality,
       );
@@ -144,7 +173,10 @@ export async function exportFrame(options: ExportFrameOptions): Promise<Blob> {
  * @param options - Export options
  * @param filename - Output filename
  */
-export async function exportFrameAndDownload(options: ExportFrameOptions, filename?: string): Promise<void> {
+export async function exportFrameAndDownload(
+  options: ExportFrameOptions,
+  filename?: string,
+): Promise<void> {
   const blob = await exportFrame(options);
 
   // Generate filename if not provided
@@ -168,7 +200,10 @@ export async function exportFrameAndDownload(options: ExportFrameOptions, filena
  * @param options - Export options
  * @param savePath - Path to save the file
  */
-export async function exportFrameToFile(options: ExportFrameOptions, savePath: string): Promise<void> {
+export async function exportFrameToFile(
+  options: ExportFrameOptions,
+  savePath: string,
+): Promise<void> {
   const blob = await exportFrame(options);
 
   // FIX (BUG-M3): Convert blob to Uint8Array and write via Tauri's binary IPC.

--- a/src/lib/export/exportSequence.ts
+++ b/src/lib/export/exportSequence.ts
@@ -7,7 +7,13 @@
  */
 
 import { evaluateTimelineSceneCached } from "../../core/evaluation/evaluator";
-import type { Clip, Track, MediaAsset, Project, TransitionTimelineItem } from "../../types";
+import type {
+  Clip,
+  Track,
+  MediaAsset,
+  Project,
+  TransitionTimelineItem,
+} from "../../types";
 import { buildNativeFrameRequest } from "@/components/editor/preview/nativeVideoPreview";
 import { isTauriRuntime, renderNativeFrame } from "@/lib/platform/tauri";
 import { NativeRasterBridge } from "@/core/render/nativeRasterBridge";
@@ -57,7 +63,11 @@ export interface ExportSequenceOptions {
   quality?: number;
 
   /** Progress callback */
-  onProgress?: (progress: number, currentFrame: number, totalFrames: number) => void;
+  onProgress?: (
+    progress: number,
+    currentFrame: number,
+    totalFrames: number,
+  ) => void;
 
   /** Frame callback (receives each frame as it's rendered) */
   onFrame?: (frameNumber: number, blob: Blob) => Promise<void>;
@@ -89,7 +99,6 @@ export interface ExportSequenceResult {
   cancelled: boolean;
 }
 
-
 /**
  * Export an image sequence.
  *
@@ -99,7 +108,9 @@ export interface ExportSequenceResult {
  * @param options - Export options
  * @returns Export result
  */
-export async function exportSequence(options: ExportSequenceOptions): Promise<ExportSequenceResult> {
+export async function exportSequence(
+  options: ExportSequenceOptions,
+): Promise<ExportSequenceResult> {
   const {
     clips,
     tracks,
@@ -156,7 +167,8 @@ export async function exportSequence(options: ExportSequenceOptions): Promise<Ex
   readbackCanvas.width = width;
   readbackCanvas.height = height;
   const readbackContext = readbackCanvas.getContext("2d");
-  if (!readbackContext) throw new Error("[ExportSequence] Failed to create native readback canvas");
+  if (!readbackContext)
+    throw new Error("[ExportSequence] Failed to create native readback canvas");
 
   const nativeFrameToBlob = async (rgba: ArrayBuffer): Promise<Blob> => {
     const image = readbackContext.createImageData(width, height);
@@ -164,7 +176,12 @@ export async function exportSequence(options: ExportSequenceOptions): Promise<Ex
     readbackContext.putImageData(image, 0, 0);
     return new Promise<Blob>((resolve, reject) => {
       readbackCanvas.toBlob(
-        (blob) => blob ? resolve(blob) : reject(new Error("[ExportSequence] Failed to encode native frame")),
+        (blob) =>
+          blob
+            ? resolve(blob)
+            : reject(
+                new Error("[ExportSequence] Failed to encode native frame"),
+              ),
         format === "jpeg" ? "image/jpeg" : "image/png",
         quality,
       );
@@ -175,7 +192,9 @@ export async function exportSequence(options: ExportSequenceOptions): Promise<Ex
   let cancelled = false;
 
   if (!isTauriRuntime()) {
-    throw new Error("[ExportSequence] Native image-sequence export requires the desktop runtime");
+    throw new Error(
+      "[ExportSequence] Native image-sequence export requires the desktop runtime",
+    );
   }
   const nativeRasterBridge = new NativeRasterBridge();
 
@@ -187,41 +206,62 @@ export async function exportSequence(options: ExportSequenceOptions): Promise<Ex
 
       const time = frameTimes[i];
       try {
-        const scene = evaluateTimelineSceneCached(time, clips, tracks, assets, project, epoch, transitions);
+        const scene = evaluateTimelineSceneCached(
+          time,
+          clips,
+          tracks,
+          assets,
+          project,
+          epoch,
+          transitions,
+        );
         let blob: Blob;
         const frameKey = startFrameIndex + i;
-        const rasterLayers = await nativeRasterBridge.rasterize(scene, { frameKey });
+        const rasterLayers = await nativeRasterBridge.rasterize(scene, {
+          frameKey,
+        });
         const activeSmartOverlays = clips.filter(
           (clip): clip is SmartOverlayClip =>
-            clip.kind === "smart-overlay" && time >= clip.startTime && time < clip.startTime + clip.duration,
+            clip.kind === "smart-overlay" &&
+            time >= clip.startTime &&
+            time < clip.startTime + clip.duration,
         );
-        const smartOverlayRasters = await nativeRasterBridge.rasterizeSmartOverlays(
-          activeSmartOverlays,
-          time,
-          scene.metadata.canvasWidth,
-          scene.metadata.canvasHeight,
-          { frameKey },
+        const smartOverlayRasters =
+          await nativeRasterBridge.rasterizeSmartOverlays(
+            activeSmartOverlays,
+            time,
+            scene.metadata.canvasWidth,
+            scene.metadata.canvasHeight,
+            { frameKey },
+          );
+        // The native compositor renders directly at outputWidth × outputHeight.
+        // to_video_project_request() in Rust applies scale_x = outputW/canvasW and
+        // scale_y = outputH/canvasH to every layer's coordinates before compositing,
+        // so output dimensions may freely differ from the project canvas size.
+        const nativeRequest = buildNativeFrameRequest(
+          scene,
+          `${project?.id ?? "export"}:${epoch}`,
+          frameKey,
+          frameRate,
+          width,
+          height,
+          [...rasterLayers, ...smartOverlayRasters],
+          { mode: "frameStep", quality: "full" },
         );
-        const nativeRequest = width === scene.metadata.canvasWidth && height === scene.metadata.canvasHeight
-          ? buildNativeFrameRequest(
-              scene,
-              `${project?.id ?? "export"}:${epoch}`,
-              frameKey,
-              frameRate,
-              width,
-              height,
-              [...rasterLayers, ...smartOverlayRasters],
-              { mode: "frameStep", quality: "full" },
-            )
-          : null;
         if (nativeRequest) {
           try {
-            blob = await nativeFrameToBlob(await renderNativeFrame(nativeRequest));
+            blob = await nativeFrameToBlob(
+              await renderNativeFrame(nativeRequest),
+            );
           } catch (error) {
-            throw new Error(`[ExportSequence] Native frame failed: ${error instanceof Error ? error.message : String(error)}`);
+            throw new Error(
+              `[ExportSequence] Native frame failed: ${error instanceof Error ? error.message : String(error)}`,
+            );
           }
         } else {
-          throw new Error("[ExportSequence] Frame is outside the native compositor contract");
+          throw new Error(
+            "[ExportSequence] Frame is outside the native compositor contract",
+          );
         }
 
         if (onFrame) {
@@ -231,7 +271,11 @@ export async function exportSequence(options: ExportSequenceOptions): Promise<Ex
         completedFrames++;
 
         if (onProgress) {
-          onProgress(completedFrames / totalFrames, completedFrames, totalFrames);
+          onProgress(
+            completedFrames / totalFrames,
+            completedFrames,
+            totalFrames,
+          );
         }
       } catch (err) {
         throw err;
@@ -248,7 +292,8 @@ export async function exportSequence(options: ExportSequenceOptions): Promise<Ex
   }
 
   const totalTimeMs = Date.now() - startTimeMs;
-  const avgTimePerFrameMs = completedFrames > 0 ? totalTimeMs / completedFrames : 0;
+  const avgTimePerFrameMs =
+    completedFrames > 0 ? totalTimeMs / completedFrames : 0;
 
   return {
     totalFrames: completedFrames,
@@ -267,7 +312,7 @@ export function cancelExport(): void {
   // This is a no-op in the new API. Pass onCancelReady to exportSequence instead.
   console.warn(
     "[ExportSequence] cancelExport() is deprecated. Use the cancel() function provided " +
-    "via the onCancelReady callback in exportSequence options.",
+      "via the onCancelReady callback in exportSequence options.",
   );
 }
 
@@ -275,7 +320,10 @@ export function cancelExport(): void {
  * Export sequence and download as ZIP.
  * (Placeholder download behavior)
  */
-export async function exportSequenceAndDownload(options: ExportSequenceOptions, filename?: string): Promise<void> {
+export async function exportSequenceAndDownload(
+  options: ExportSequenceOptions,
+  filename?: string,
+): Promise<void> {
   const frames: { frameNumber: number; blob: Blob }[] = [];
 
   await exportSequence({

--- a/src/lib/export/videoExport.ts
+++ b/src/lib/export/videoExport.ts
@@ -10,17 +10,30 @@
  */
 
 import { platform } from "../../core/platform";
-import { evaluateTimelineSceneCached, clearEvaluationCache } from "../../core/evaluation/evaluator";
+import {
+  evaluateTimelineSceneCached,
+  clearEvaluationCache,
+} from "../../core/evaluation/evaluator";
 import { getResourceCache } from "../../core/resources/ResourceCache";
 import { getActiveAudioClips } from "../../core/timeline/audioClips";
 import { PRESET_CONFIGS } from "./exportPresets";
-import type { Clip, Track, MediaAsset, Project, TransitionTimelineItem } from "../../types";
+import type {
+  Clip,
+  Track,
+  MediaAsset,
+  Project,
+  TransitionTimelineItem,
+} from "../../types";
 import type { ExportAudioClip, ExportProgress } from "../../types/export";
 import { buildNativeFrameRequest } from "@/components/editor/preview/nativeVideoPreview";
 import { isTauriRuntime, renderNativeFrame } from "@/lib/platform/tauri";
 import { NativeRasterBridge } from "@/core/render/nativeRasterBridge";
 import type { SmartOverlayClip } from "@/types/smartOverlay";
-import { verifyExportDependencies, ExportBlockedError, type MissingTextEffect } from "./exportPreflight";
+import {
+  verifyExportDependencies,
+  ExportBlockedError,
+  type MissingTextEffect,
+} from "./exportPreflight";
 import { telemetryCollector } from "@/services/telemetryCollector";
 
 /**
@@ -134,23 +147,54 @@ export interface VideoExportResult {
  * @returns Export result
  */
 export function isWebCodecsSupported(): boolean {
-  return typeof VideoEncoder !== "undefined" && typeof AudioEncoder !== "undefined";
+  return (
+    typeof VideoEncoder !== "undefined" && typeof AudioEncoder !== "undefined"
+  );
 }
 
-export async function exportVideo(config: VideoExportConfig): Promise<VideoExportResult> {
+export async function exportVideo(
+  config: VideoExportConfig,
+): Promise<VideoExportResult> {
   if (platform.isCapacitor()) {
-    throw new Error("[videoExport] Native video export is not available in the Capacitor runtime");
+    throw new Error(
+      "[videoExport] Native video export is not available in the Capacitor runtime",
+    );
   }
   if (!isTauriRuntime()) {
-    throw new Error("[videoExport] Native video export requires the desktop runtime");
+    throw new Error(
+      "[videoExport] Native video export requires the desktop runtime",
+    );
   }
 
-  const { clips, tracks, transitions = [], assets, project, epoch, startTime, endTime, outputPath, frameRate = project?.frameRate || 30, width = project?.canvasWidth || 1920, height = project?.canvasHeight || 1080, codec = "h264", preset = "medium", crf = 23, pixelFormat = "yuv420p", onProgress, onSessionReady, signal } = config;
+  const {
+    clips,
+    tracks,
+    transitions = [],
+    assets,
+    project,
+    epoch,
+    startTime,
+    endTime,
+    outputPath,
+    frameRate = project?.frameRate || 30,
+    width = project?.canvasWidth || 1920,
+    height = project?.canvasHeight || 1080,
+    codec = "h264",
+    preset = "medium",
+    crf = 23,
+    pixelFormat = "yuv420p",
+    onProgress,
+    onSessionReady,
+    signal,
+  } = config;
 
   // Preflight dependency check: enforce §1.2 zero silent-fallback contract
   const preflight = await verifyExportDependencies(clips as any, { assets });
   if (!preflight.ready) {
-    if (preflight.missingImageAssets.length > 0 || preflight.missingAudioAssets.length > 0) {
+    if (
+      preflight.missingImageAssets.length > 0 ||
+      preflight.missingAudioAssets.length > 0
+    ) {
       throw new ExportBlockedError(
         preflight.missingEffects,
         preflight.missingImageAssets,
@@ -162,7 +206,7 @@ export async function exportVideo(config: VideoExportConfig): Promise<VideoExpor
     }
     console.warn(
       "[videoExport] ⚠️ FORCE EXPORT OPT-IN: Uncached offline text effects will degrade to base typography:",
-      preflight.missingEffects
+      preflight.missingEffects,
     );
   }
 
@@ -203,7 +247,13 @@ export async function exportVideo(config: VideoExportConfig): Promise<VideoExpor
   };
 
   // This replaces 20+ lines of inline filtering/mapping with a single function call
-  const audioClips: ExportAudioClip[] = getActiveAudioClips(clips, tracks, assets, startTime, endTime);
+  const audioClips: ExportAudioClip[] = getActiveAudioClips(
+    clips,
+    tracks,
+    assets,
+    startTime,
+    endTime,
+  );
 
   // Start FFmpeg export session
   const sessionId = await invoke<string>("start_video_export", {
@@ -244,16 +294,21 @@ export async function exportVideo(config: VideoExportConfig): Promise<VideoExpor
     if (signal.aborted) {
       await performCancel();
     } else {
-      signal.addEventListener("abort", () => {
-        performCancel().catch(() => {});
-      }, { once: true });
+      signal.addEventListener(
+        "abort",
+        () => {
+          performCancel().catch(() => {});
+        },
+        { once: true },
+      );
     }
   }
 
   // EX-2 fix: Batch size reduced from 30 → 10 frames.
-  // At 1080p a single frame is ~8 MB (1920×1080×4). BATCH_SIZE=30 caused a ~248 MB
-  // contiguous allocation per flush (plus the 30 source frames still in memory = ~496 MB peak).
-  // BATCH_SIZE=10 caps that at ~83 MB batch + ~83 MB source = ~166 MB peak — safe on 4 GB machines.
+  // At 1080p a single RGBA frame is ~8 MB (1920×1080×4). At 4K (3840×2160) it is ~32 MB.
+  // BATCH_SIZE=10 caps peak memory at ~320 MB batch + ~320 MB source ≈ 640 MB for 4K,
+  // and ~83 MB + ~83 MB ≈ 166 MB for 1080p — acceptable on a 4 GB machine at any resolution
+  // the export dimension validator admits (max 7680×4320).
   const BATCH_SIZE = 10;
   const frameBuffer: Uint8Array[] = [];
   const frameSize = width * height * 4; // RGBA bytes per frame
@@ -319,41 +374,62 @@ export async function exportVideo(config: VideoExportConfig): Promise<VideoExpor
       const time = frameTimes[i];
 
       // Evaluate scene for this frame using the canonical evaluator
-      const scene = evaluateTimelineSceneCached(time, clips, tracks, assets, project, epoch, transitions);
+      const scene = evaluateTimelineSceneCached(
+        time,
+        clips,
+        tracks,
+        assets,
+        project,
+        epoch,
+        transitions,
+      );
       let frameBytes: Uint8Array;
       const frameKey = startFrameIndex + i;
-      const rasterLayers = await nativeRasterBridge.rasterize(scene, { frameKey });
+      const rasterLayers = await nativeRasterBridge.rasterize(scene, {
+        frameKey,
+      });
       const activeSmartOverlays = clips.filter(
         (clip): clip is SmartOverlayClip =>
-          clip.kind === "smart-overlay" && time >= clip.startTime && time < clip.startTime + clip.duration,
+          clip.kind === "smart-overlay" &&
+          time >= clip.startTime &&
+          time < clip.startTime + clip.duration,
       );
-      const smartOverlayRasters = await nativeRasterBridge.rasterizeSmartOverlays(
-        activeSmartOverlays,
-        time,
-        scene.metadata.canvasWidth,
-        scene.metadata.canvasHeight,
-        { frameKey },
+      const smartOverlayRasters =
+        await nativeRasterBridge.rasterizeSmartOverlays(
+          activeSmartOverlays,
+          time,
+          scene.metadata.canvasWidth,
+          scene.metadata.canvasHeight,
+          { frameKey },
+        );
+      // The native compositor renders directly at outputWidth × outputHeight.
+      // to_video_project_request() in Rust applies scale_x = outputW/canvasW and
+      // scale_y = outputH/canvasH to every layer's coordinates before compositing,
+      // so export resolution may freely differ from the project canvas size (e.g. a
+      // 4K export of a 1080p project). No intermediate resize blit is needed — the
+      // GPU renders natively at the requested output resolution.
+      const nativeRequest = buildNativeFrameRequest(
+        scene,
+        `${project?.id ?? "export"}:${epoch}`,
+        frameKey,
+        frameRate,
+        width,
+        height,
+        [...rasterLayers, ...smartOverlayRasters],
+        { mode: "frameStep", quality: "full" },
       );
-      const nativeRequest = width === scene.metadata.canvasWidth && height === scene.metadata.canvasHeight
-        ? buildNativeFrameRequest(
-            scene,
-            `${project?.id ?? "export"}:${epoch}`,
-            frameKey,
-            frameRate,
-            width,
-            height,
-            [...rasterLayers, ...smartOverlayRasters],
-            { mode: "frameStep", quality: "full" },
-          )
-        : null;
       if (nativeRequest) {
         try {
           frameBytes = new Uint8Array(await renderNativeFrame(nativeRequest));
         } catch (error) {
-          throw new Error(`[videoExport] Native frame ${i} failed: ${error instanceof Error ? error.message : String(error)}`);
+          throw new Error(
+            `[videoExport] Native frame ${i} failed: ${error instanceof Error ? error.message : String(error)}`,
+          );
         }
       } else {
-        throw new Error(`[videoExport] Frame ${i} is outside the native compositor contract`);
+        throw new Error(
+          `[videoExport] Frame ${i} is outside the native compositor contract`,
+        );
       }
       frameBuffer.push(frameBytes);
 
@@ -415,7 +491,12 @@ export async function exportVideo(config: VideoExportConfig): Promise<VideoExpor
           width,
           height,
           nominalFps: frameRate,
-          codec: codec === "h265" ? "hevc" : codec === "prores" ? "prores422" : "h264",
+          codec:
+            codec === "h265"
+              ? "hevc"
+              : codec === "prores"
+                ? "prores422"
+                : "h264",
         },
       });
       // Try to cancel on error
@@ -436,10 +517,14 @@ export async function exportVideo(config: VideoExportConfig): Promise<VideoExpor
   }
 
   const totalTimeMs = Date.now() - startTimeMs;
-  const avgTimePerFrameMs = completedFrames > 0 ? totalTimeMs / completedFrames : 0;
+  const avgTimePerFrameMs =
+    completedFrames > 0 ? totalTimeMs / completedFrames : 0;
   const mediaDurationMs = Math.max(1, (endTime - startTime) * 1000);
   const realTimeFactor = totalTimeMs / mediaDurationMs;
-  const exportFps = completedFrames > 0 && totalTimeMs > 0 ? completedFrames / (totalTimeMs / 1000) : 0;
+  const exportFps =
+    completedFrames > 0 && totalTimeMs > 0
+      ? completedFrames / (totalTimeMs / 1000)
+      : 0;
 
   telemetryCollector.recordExportSpan({
     exportDurationMs: totalTimeMs,
@@ -456,7 +541,8 @@ export async function exportVideo(config: VideoExportConfig): Promise<VideoExpor
       width,
       height,
       nominalFps: frameRate,
-      codec: codec === "h265" ? "hevc" : codec === "prores" ? "prores422" : "h264",
+      codec:
+        codec === "h265" ? "hevc" : codec === "prores" ? "prores422" : "h264",
     },
   });
 
@@ -466,7 +552,9 @@ export async function exportVideo(config: VideoExportConfig): Promise<VideoExpor
     totalTimeMs,
     avgTimePerFrameMs,
     cancelled,
-    ...(preflight.missingEffects.length > 0 ? { degradedTextEffects: preflight.missingEffects } : {}),
+    ...(preflight.missingEffects.length > 0
+      ? { degradedTextEffects: preflight.missingEffects }
+      : {}),
   };
 }
 

--- a/src/services/perfLogService.ts
+++ b/src/services/perfLogService.ts
@@ -25,9 +25,17 @@
  * - It does NOT block any audio/video hot path — all Tauri invocations are fire-and-forget.
  */
 
-import { isTauri } from "@/core/platform/platform";
 import { getApiBaseUrl, getApiKey } from "@/lib/api/apiUtils";
 import { getAppVersion, getAppVersionSync } from "@/lib/app/appVersion";
+
+// ── Tauri runtime guard ───────────────────────────────────────────────────────
+// Evaluated lazily at call time, not at module-load time. The module-level
+// `isTauri` constant from platform.ts is evaluated when the module is first
+// imported — which can happen before Tauri injects `__TAURI_INTERNALS__` into
+// the window, freezing the value as false for the entire session.
+function isTauriRuntime(): boolean {
+  return typeof window !== "undefined" && "__TAURI_INTERNALS__" in window;
+}
 
 // ── Constants ────────────────────────────────────────────────────────────────
 
@@ -109,7 +117,7 @@ class PerfLogService {
    * Call this as early as possible in the app lifecycle (e.g. root component mount).
    */
   async openSession(sessionId: string): Promise<void> {
-    if (!isTauri) return;
+    if (!isTauriRuntime()) return;
 
     try {
       const info = await tauriInvoke<PerfLogSessionInfo>(
@@ -151,7 +159,7 @@ class PerfLogService {
    * No-op if no session is open or not running in Tauri.
    */
   enqueue(entry: PerfLogEntry): void {
-    if (!this.sessionId || !isTauri) return;
+    if (!this.sessionId || !isTauriRuntime()) return;
 
     // Always stamp with the active session ID in case the caller passed a
     // stale ID from before a project switch.
@@ -174,7 +182,7 @@ class PerfLogService {
    *   - `visibilitychange` → hidden (best-effort for backgrounded web views)
    */
   async closeAndUpload(): Promise<void> {
-    if (!this.sessionId || !isTauri) return;
+    if (!this.sessionId || !isTauriRuntime()) return;
 
     // Deduplicate concurrent close calls (e.g. close-requested + visibility change).
     if (this.closeInFlight) return this.closeInFlight;
@@ -196,7 +204,7 @@ class PerfLogService {
    * so the proper close path can upload the complete file later.
    */
   flushToDisk(): void {
-    if (!this.sessionId || !isTauri) return;
+    if (!this.sessionId || !isTauriRuntime()) return;
     void this.flushQueue();
   }
 

--- a/src/store/uiStore.ts
+++ b/src/store/uiStore.ts
@@ -35,6 +35,7 @@
 
 import { create } from "zustand";
 import type { MediaAsset } from "@/types";
+import { useTimelineStore } from "@/store/timelineStore";
 
 interface UIStore {
   selectedClipIds: string[]; // Multi-select support
@@ -69,6 +70,7 @@ interface UIStore {
 
   selectClip: (clipId: string | null) => void;
   toggleClipSelection: (clipId: string) => void;
+  selectAllClipsInTrack: (trackId: string) => void;
   selectGap: (gapId: string | null) => void;
   selectTransition: (transitionId: string | null) => void;
   clearSelection: () => void;
@@ -155,6 +157,17 @@ export const useUIStore = create<UIStore>((set, get) => ({
         selectedTransitionId: null,
         selectedGapId: null, // TL-07 fix: Clear gap selection when toggling clip selection
       };
+    });
+  },
+
+  selectAllClipsInTrack: (trackId) => {
+    const clips = useTimelineStore
+      .getState()
+      .clips.filter((c) => c.trackId === trackId);
+    set({
+      selectedClipIds: clips.map((c) => c.id),
+      selectedGapId: null,
+      selectedTransitionId: null,
     });
   },
 


### PR DESCRIPTION
## v1.4.8

### Critical fix — session performance data never reaching DB

All session NDJSON files were 0 bytes. Root cause: `perfLogService.ts` imported `isTauri` from `platform.ts` as a module-level constant. That constant is evaluated at import time — which happens when `telemetryCollector.ts` is first loaded, before Tauri injects `__TAURI_INTERNALS__` into the window. The value was frozen as `false` for the entire session, so every `enqueue()` call silently dropped its entry.

`open_perf_log_session` still ran (called from App.tsx after Tauri is fully ready, so the file was created), but `append_perf_log_entries` was never called. Every session file was 0 bytes and the upload sent nothing.

**Fix:** replaced the static import with a local `isTauriRuntime()` function that reads `__TAURI_INTERNALS__` from `window` at call time on every invocation.

Also fixed 3 other session-upload bugs from the previous PR (race on sessionId null, visibilitychange closing the session prematurely, in-flight flush not awaited).

### feat — arbitrary export output resolution

Removed the canvas-size equality guard from all three export entry points (`exportVideo`, `exportSequence`, `exportFrame`). Projects can now be exported at any resolution — 4K upscale, 720p downscale, portrait crop — regardless of canvas dimensions. The Rust bridge applies per-layer scale transforms before the GPU compositor renders at the output size.

### chore — version bump 1.4.7 → 1.4.8

`tauri.conf.json`, `Cargo.toml`, `package.json`
