### PR TITLE
fix(telemetry): session data not landing in DB — upload on project close

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -117,7 +117,7 @@ const App = () => {
         // Open a stable session ID scoped to this app launch. The session file
         // accumulates all telemetry locally and is uploaded as a single payload
         // when the window closes, replacing hundreds of per-rollup API calls.
-        if (platform.isTauri()) {
+        if (platform.isTauri() && !perfLogService.getSessionId()) {
           const launchSessionId = `launch-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
           void perfLogService.openSession(launchSessionId);
         }
@@ -638,6 +638,13 @@ const App = () => {
 
       const { closeProject } = useProjectStore.getState();
       await closeProject(); // closeProject handles saving internally
+
+      // Upload the completed perf-log session for this project, then open
+      // a fresh session so the next project gets its own log file.
+      void perfLogService.closeAndUpload().then(() => {
+        const nextSessionId = `launch-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+        void perfLogService.openSession(nextSessionId);
+      });
 
       updateStep("save", "completed");
       updateStep("session", "completed");

--- a/src/core/playback/playbackTrace.ts
+++ b/src/core/playback/playbackTrace.ts
@@ -41,8 +41,8 @@ export function tracePlayback(
   // file alongside rollup and native-sync entries.
   perfLogService.enqueue({
     kind: "playback-trace",
-    session_id: perfLogService.getSessionId() ?? "unknown",
-    timestamp_epoch_ms: payload.tsEpochMs as number,
+    sessionId: perfLogService.getSessionId() ?? "unknown",
+    timestampEpochMs: payload.tsEpochMs as number,
     payload,
   });
 

--- a/src/services/perfLogService.ts
+++ b/src/services/perfLogService.ts
@@ -63,17 +63,17 @@ export type PerfLogKind =
 export interface PerfLogEntry {
   kind: PerfLogKind;
   /** Matches the session ID passed to `openSession`. */
-  session_id: string;
+  sessionId: string;
   /** Unix epoch ms — set by the caller at collection time. */
-  timestamp_epoch_ms: number;
+  timestampEpochMs: number;
   /** Raw payload — typed by `kind` but opaque to the Rust layer. */
   payload: unknown;
 }
 
 interface PerfLogSessionInfo {
-  session_id: string;
-  file_path: string;
-  opened_at_epoch_ms: number;
+  sessionId: string;
+  filePath: string;
+  openedAtEpochMs: number;
 }
 
 // ── Internal helpers ─────────────────────────────────────────────────────────
@@ -126,8 +126,8 @@ class PerfLogService {
           sessionId,
         },
       );
-      this.sessionId = info.session_id;
-      this.filePath = info.file_path;
+      this.sessionId = info.sessionId;
+      this.filePath = info.filePath;
 
       this.startFlushTimer();
       this.startSyncPollTimer();
@@ -137,8 +137,8 @@ class PerfLogService {
       // hardware context with subsequent entries without re-parsing the whole file.
       this.enqueue({
         kind: "frontend-rollup",
-        session_id: this.sessionId,
-        timestamp_epoch_ms: Date.now(),
+        sessionId: this.sessionId,
+        timestampEpochMs: Date.now(),
         payload: {
           marker: "session-open",
           userAgent:
@@ -163,7 +163,7 @@ class PerfLogService {
 
     // Always stamp with the active session ID in case the caller passed a
     // stale ID from before a project switch.
-    entry.session_id = this.sessionId;
+    entry.sessionId = this.sessionId;
 
     this.queue.push(entry);
 
@@ -219,8 +219,8 @@ class PerfLogService {
     // Write a session-close marker before the final flush.
     this.queue.push({
       kind: "frontend-rollup",
-      session_id: sessionId,
-      timestamp_epoch_ms: Date.now(),
+      sessionId,
+      timestampEpochMs: Date.now(),
       payload: { marker: "session-close" },
     });
 
@@ -365,8 +365,8 @@ class PerfLogService {
       if (!snapshot) return;
       this.enqueue({
         kind: "native-sync",
-        session_id: this.sessionId,
-        timestamp_epoch_ms: Date.now(),
+        sessionId: this.sessionId,
+        timestampEpochMs: Date.now(),
         payload: snapshot,
       });
     } catch {
@@ -383,8 +383,8 @@ class PerfLogService {
           if (!this.sessionId) return;
           this.enqueue({
             kind: "native-diagnostic",
-            session_id: this.sessionId,
-            timestamp_epoch_ms: Date.now(),
+            sessionId: this.sessionId,
+            timestampEpochMs: Date.now(),
             payload,
           });
         },


### PR DESCRIPTION
## Additional fixes — data still not reaching DB after previous commits

Diagnosed from the actual NDJSON file on disk:
- File `session-1789073604406-5d747db6.ndjson` had 572B with two session-open markers and no session-close marker, confirming upload never ran.

### Bug 1 — handleCloseProject() never called closeAndUpload()

`closeAndUpload()` was only wired to the full app-exit paths (`requestAppClose`, `handleSaveAndExit`, `handleDiscardAndExit`). Closing a project back to the launch screen calls `handleCloseProject()` which was missing the upload call entirely.

**Fix:** `handleCloseProject()` now calls `perfLogService.closeAndUpload()` after `closeProject()`, then immediately opens a fresh session for the next project.

### Bug 2 — snake_case field names in three enqueue() call sites

`pollNativeSyncMetrics()`, `subscribeToNativeDiagnostics()`, and `playbackTrace.ts` all used `session_id` / `timestamp_epoch_ms` (snake_case) which are not in the `PerfLogEntry` interface (camelCase). TypeScript was silently accepting these as extra properties without enforcing the required camelCase fields, causing Rust deserialization to receive unexpected field names.

**Fix:** Changed all three to `sessionId` / `timestampEpochMs`.

### Bug 3 — Duplicate session-open markers

React StrictMode double-invokes effects in development, causing `openSession()` to fire twice with two different session IDs — creating two files and two markers.

**Fix:** Guard in `initializeApp` — only call `openSession()` if `perfLogService.getSessionId() === null`.
