### PR TITLE
fix(telemetry): session_id always unknown — align camelCase field names

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -944,7 +944,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "clypra"
-version = "1.4.7"
+version = "1.4.8"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/src/services/telemetryCollector.ts
+++ b/src/services/telemetryCollector.ts
@@ -1923,8 +1923,8 @@ class TelemetryCollector {
     // as a single request at session close instead of per-rollup API calls.
     perfLogService.enqueue({
       kind: resolvePerfLogKind(event),
-      session_id: event.sessionId ?? perfLogService.getSessionId() ?? "unknown",
-      timestamp_epoch_ms: event.timestampMs,
+      sessionId: event.sessionId ?? perfLogService.getSessionId() ?? "unknown",
+      timestampEpochMs: event.timestampMs,
       payload: event,
     });
 


### PR DESCRIPTION
## `session_id` was always "unknown" — root cause and fix

### Why

The Rust `PerfLogEntry` struct has `#[serde(rename_all = "camelCase")]`, so it serializes `session_id` → `sessionId` and `timestamp_epoch_ms` → `timestampEpochMs` in the NDJSON file.

The API `SessionPerfLogEntry` type and all downstream lookup sites used snake_case (`session_id`, `timestamp_epoch_ms`), so the field was never found and `sessionId` always fell back to `"unknown"`.

Additionally, `telemetryCollector.ts` was passing `session_id` / `timestamp_epoch_ms` (snake_case) to `perfLogService.enqueue()`, but `PerfLogEntry` expects camelCase — causing Rust to reject those entries as malformed.

### Fixes

**`clypra` (desktop)**
- `telemetryCollector.ts`: `enqueueEvent()` — `session_id` → `sessionId`, `timestamp_epoch_ms` → `timestampEpochMs`

**`clypra-api`** (already merged to main as `bfc9d7e`)
- `types/performance.ts`: `SessionPerfLogEntry.session_id` → `sessionId`, `timestamp_epoch_ms` → `timestampEpochMs`
- `performanceStorageService.ts`: all three read sites updated to camelCase
