### PR TITLE
fix(windows): align windows-0.58.0 COM API signatures for CreateSharedHandle and OpenSharedHandle

### DIFF
--- a/src-tauri/src/wgpu_compositor/dxgi_import.rs
+++ b/src-tauri/src/wgpu_compositor/dxgi_import.rs
@@ -29,7 +29,7 @@
 
 use windows::Win32::Foundation::HANDLE;
 use windows::Win32::Graphics::Direct3D11::{
-    ID3D11Device, ID3D11Texture2D, D3D11_TEXTURE2D_DESC,
+    ID3D11Texture2D, D3D11_TEXTURE2D_DESC,
 };
 use windows::Win32::Graphics::Direct3D12::{
     ID3D12Device, ID3D12Resource, D3D12_RESOURCE_DESC, D3D12_RESOURCE_DIMENSION_TEXTURE2D,
@@ -101,13 +101,11 @@ pub unsafe fn extract_shared_handle(
     let resource: IDXGIResource1 = texture.cast().ok()?;
 
     // DXGI_SHARED_RESOURCE_READ = 0x80000000
-    let mut nt_handle = HANDLE::default();
-    resource
+    let nt_handle: HANDLE = resource
         .CreateSharedHandle(
             None,           // default security
             0x8000_0000u32, // DXGI_SHARED_RESOURCE_READ
             PCWSTR::null(), // no name
-            &mut nt_handle,
         )
         .ok()?;
 
@@ -168,9 +166,11 @@ pub fn import_into_wgpu(device: &wgpu::Device, shared: D3d11SharedFrame) -> Opti
             let d3d12_device: &ID3D12Device = hal_device.raw_device();
 
             // Open the D3D11 texture's DXGI handle as a D3D12 resource.
-            let d3d12_resource: ID3D12Resource = d3d12_device
-                .OpenSharedHandle(nt_handle)
+            let mut d3d12_resource: Option<ID3D12Resource> = None;
+            d3d12_device
+                .OpenSharedHandle(nt_handle, &mut d3d12_resource)
                 .ok()?;
+            let d3d12_resource: ID3D12Resource = d3d12_resource?;
 
             // Verify the format is NV12 as expected.
             let resource_desc: D3D12_RESOURCE_DESC = d3d12_resource.GetDesc();


### PR DESCRIPTION
## Root Cause

The `windows` crate on the Windows runner is **0.58.0**, which changed the signatures for two DXGI/D3D12 methods compared to what our code assumed:

### Errors Fixed

**E0061 — `IDXGIResource1::CreateSharedHandle` (3 args, not 4)**
- windows 0.58.0: returns `HANDLE` directly (no out-param)
- Fix: remove the `&mut nt_handle` arg and bind the return value

**E0061 + E0308 — `ID3D12Device::OpenSharedHandle` (2 args, not 1)**
- windows 0.58.0: takes an out-param `*mut Option<T>` as second argument
- Fix: use the out-param pattern: `let mut result: Option<ID3D12Resource> = None; device.OpenSharedHandle(handle, &mut result).ok()?; let resource = result?;`

**Unused import warning**
- Removed unused `ID3D11Device` import that would fail under `-D warnings`