### PR TITLE
fix(windows): bind cast temporary to named local to resolve E0716 on MSVC

### DIFF
--- a/src-tauri/src/wgpu_compositor/dxgi_import.rs
+++ b/src-tauri/src/wgpu_compositor/dxgi_import.rs
@@ -94,8 +94,11 @@ pub unsafe fn extract_shared_handle(
 
     // Borrow the COM pointer — do NOT call AddRef/Release; FFmpeg owns this.
     // We use windows-rs `from_raw_borrowed` which creates a non-owning borrow.
+    // Bind the cast to a named local first: MSVC's stricter NLL rules reject
+    // the inline temporary `&(texture_raw as *mut _)` with E0716.
+    let texture_ptr = texture_raw as *mut _;
     let texture: &ID3D11Texture2D =
-        windows::core::from_raw_borrowed(&(texture_raw as *mut _))?;
+        windows::core::from_raw_borrowed(&texture_ptr)?;
 
     // Get DXGI resource interface so we can create an NT shared handle.
     let resource: IDXGIResource1 = texture.cast().ok()?;


### PR DESCRIPTION
## Root Cause

In `src-tauri/src/wgpu_compositor/dxgi_import.rs:98`, the inline temporary `&(texture_raw as *mut _)` was dropped at the end of the statement while the borrowed `&ID3D11Texture2D` reference was used downstream by `texture.cast()`. The MSVC Rust compiler strictly enforces non-lexical lifetimes (NLL) and failed with:

```
error[E0716]: temporary value dropped while borrowed
   --> src\wgpu_compositor\dxgi_import.rs:98:43
    |
 98 |         windows::core::from_raw_borrowed(&(texture_raw as *mut _))?;
    |                                           ^^^^^^^^^^^^^^^^^^^^^^^  - temporary value is freed at the end of this statement
```

## Fix
Bind the cast pointer to a named variable `let texture_ptr = texture_raw as *mut _;` before passing `&texture_ptr` into `windows::core::from_raw_borrowed`. This guarantees its lifetime spans the scope of the borrow.